### PR TITLE
docs(web): docsページの配色をテーマ追随に対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 変更
 - Renovate の `customManagers`（regex）を追加し、`PhotoGeoExplorer.csproj` / `PhotoGeoExplorer.Tests.csproj` と `docs/archive/PhotoGeoExplorer_plan.md` の `netX.Y-windows10.0.19041.0` 表記で `netX.Y` 部分を追従更新できるように変更。
+- `docs/help/index*.html` / `docs/privacy-policy*.html` / `docs/index.html` の配色を `prefers-color-scheme`（light/dark）追随に更新し、テーマ切替時の視認性を改善。
 
 ### 修正
 - Store 版などでタイルキャッシュディレクトリ初期化に失敗した場合でも、永続キャッシュなしで地図レイヤーを継続生成するフォールバックを追加し、地図表示不能によるマスク残留を回避。

--- a/docs/help/index.en.html
+++ b/docs/help/index.en.html
@@ -6,13 +6,27 @@
   <title>PhotoGeoExplorer Detailed Help</title>
   <style>
     :root {
-      color-scheme: light;
+      color-scheme: light dark;
       --bg: #f4f6f8;
       --card: #ffffff;
       --text: #1f2328;
       --muted: #59636e;
       --accent: #1f6feb;
       --border: #d8dee4;
+      --tag-bg: #e7f0ff;
+      --tag-text: #0b4db3;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d1117;
+        --card: #161b22;
+        --text: #e6edf3;
+        --muted: #9da7b3;
+        --accent: #58a6ff;
+        --border: #30363d;
+        --tag-bg: #1f2a3d;
+        --tag-text: #9cc2ff;
+      }
     }
     * {
       box-sizing: border-box;
@@ -97,8 +111,8 @@
       padding: 2px 8px;
       border-radius: 999px;
       font-size: 12px;
-      background: #e7f0ff;
-      color: #0b4db3;
+      background: var(--tag-bg);
+      color: var(--tag-text);
       margin-right: 6px;
     }
   </style>

--- a/docs/help/index.html
+++ b/docs/help/index.html
@@ -6,13 +6,27 @@
   <title>PhotoGeoExplorer 詳細ヘルプ</title>
   <style>
     :root {
-      color-scheme: light;
+      color-scheme: light dark;
       --bg: #f4f6f8;
       --card: #ffffff;
       --text: #1f2328;
       --muted: #59636e;
       --accent: #1f6feb;
       --border: #d8dee4;
+      --tag-bg: #e7f0ff;
+      --tag-text: #0b4db3;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d1117;
+        --card: #161b22;
+        --text: #e6edf3;
+        --muted: #9da7b3;
+        --accent: #58a6ff;
+        --border: #30363d;
+        --tag-bg: #1f2a3d;
+        --tag-text: #9cc2ff;
+      }
     }
     * {
       box-sizing: border-box;
@@ -97,8 +111,8 @@
       padding: 2px 8px;
       border-radius: 999px;
       font-size: 12px;
-      background: #e7f0ff;
-      color: #0b4db3;
+      background: var(--tag-bg);
+      color: var(--tag-text);
       margin-right: 6px;
     }
   </style>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,34 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="refresh" content="0; url=privacy-policy.html" />
     <title>PhotoGeoExplorer</title>
+    <style>
+        :root {
+            color-scheme: light dark;
+            --bg: #f5f5f5;
+            --text: #333333;
+            --accent: #1e90ff;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg: #0d1117;
+                --text: #e6edf3;
+                --accent: #58a6ff;
+            }
+        }
+
+        body {
+            margin: 0;
+            padding: 24px;
+            background-color: var(--bg);
+            color: var(--text);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+        }
+
+        a {
+            color: var(--accent);
+        }
+    </style>
 </head>
 
 <body>

--- a/docs/privacy-policy.html
+++ b/docs/privacy-policy.html
@@ -6,36 +6,61 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>プライバシーポリシー - PhotoGeoExplorer</title>
     <style>
+        :root {
+            color-scheme: light dark;
+            --bg: #f5f5f5;
+            --card: #ffffff;
+            --text: #333333;
+            --muted: #666666;
+            --accent: #1e90ff;
+            --border: #dddddd;
+            --highlight-bg: #e8f4fd;
+            --shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg: #0d1117;
+                --card: #161b22;
+                --text: #e6edf3;
+                --muted: #9da7b3;
+                --accent: #58a6ff;
+                --border: #30363d;
+                --highlight-bg: #1f2a3d;
+                --shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+            }
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
             line-height: 1.6;
-            color: #333;
+            color: var(--text);
             max-width: 800px;
             margin: 0 auto;
             padding: 20px;
-            background-color: #f5f5f5;
+            background-color: var(--bg);
         }
 
         .container {
-            background-color: white;
+            background-color: var(--card);
             padding: 40px;
             border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            box-shadow: var(--shadow);
         }
 
         h1 {
-            color: #1E90FF;
-            border-bottom: 3px solid #1E90FF;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
             padding-bottom: 10px;
         }
 
         h2 {
-            color: #333;
+            color: var(--text);
             margin-top: 30px;
         }
 
         .last-updated {
-            color: #666;
+            color: var(--muted);
             font-size: 0.9em;
             font-style: italic;
         }
@@ -45,20 +70,20 @@
         }
 
         .highlight {
-            background-color: #e8f4fd;
+            background-color: var(--highlight-bg);
             padding: 15px;
-            border-left: 4px solid #1E90FF;
+            border-left: 4px solid var(--accent);
             margin: 20px 0;
         }
 
         .divider {
             border: none;
-            border-top: 1px solid #ddd;
+            border-top: 1px solid var(--border);
             margin: 40px 0;
         }
 
         a {
-            color: #1E90FF;
+            color: var(--accent);
             text-decoration: none;
         }
 
@@ -69,9 +94,9 @@
         footer {
             margin-top: 40px;
             padding-top: 20px;
-            border-top: 1px solid #ddd;
+            border-top: 1px solid var(--border);
             text-align: center;
-            color: #666;
+            color: var(--muted);
             font-size: 0.9em;
         }
     </style>

--- a/docs/privacy-policy/index.html
+++ b/docs/privacy-policy/index.html
@@ -6,36 +6,61 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>プライバシーポリシー - PhotoGeoExplorer</title>
     <style>
+        :root {
+            color-scheme: light dark;
+            --bg: #f5f5f5;
+            --card: #ffffff;
+            --text: #333333;
+            --muted: #666666;
+            --accent: #1e90ff;
+            --border: #dddddd;
+            --highlight-bg: #e8f4fd;
+            --shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg: #0d1117;
+                --card: #161b22;
+                --text: #e6edf3;
+                --muted: #9da7b3;
+                --accent: #58a6ff;
+                --border: #30363d;
+                --highlight-bg: #1f2a3d;
+                --shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+            }
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
             line-height: 1.6;
-            color: #333;
+            color: var(--text);
             max-width: 800px;
             margin: 0 auto;
             padding: 20px;
-            background-color: #f5f5f5;
+            background-color: var(--bg);
         }
 
         .container {
-            background-color: white;
+            background-color: var(--card);
             padding: 40px;
             border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            box-shadow: var(--shadow);
         }
 
         h1 {
-            color: #1E90FF;
-            border-bottom: 3px solid #1E90FF;
+            color: var(--accent);
+            border-bottom: 3px solid var(--accent);
             padding-bottom: 10px;
         }
 
         h2 {
-            color: #333;
+            color: var(--text);
             margin-top: 30px;
         }
 
         .last-updated {
-            color: #666;
+            color: var(--muted);
             font-size: 0.9em;
             font-style: italic;
         }
@@ -45,20 +70,20 @@
         }
 
         .highlight {
-            background-color: #e8f4fd;
+            background-color: var(--highlight-bg);
             padding: 15px;
-            border-left: 4px solid #1E90FF;
+            border-left: 4px solid var(--accent);
             margin: 20px 0;
         }
 
         .divider {
             border: none;
-            border-top: 1px solid #ddd;
+            border-top: 1px solid var(--border);
             margin: 40px 0;
         }
 
         a {
-            color: #1E90FF;
+            color: var(--accent);
             text-decoration: none;
         }
 
@@ -69,9 +94,9 @@
         footer {
             margin-top: 40px;
             padding-top: 20px;
-            border-top: 1px solid #ddd;
+            border-top: 1px solid var(--border);
             text-align: center;
-            color: #666;
+            color: var(--muted);
             font-size: 0.9em;
         }
     </style>


### PR DESCRIPTION
## 概要
Cloudflare Pages で配信しているドキュメントHTMLの配色を、システムテーマ（light/dark）に追随するよう更新しました。

## 変更内容
- `docs/help/index.html` / `docs/help/index.en.html`
  - `color-scheme: light dark` と `@media (prefers-color-scheme: dark)` を追加
  - `.tag` の固定色をCSS変数化
- `docs/privacy-policy/index.html` / `docs/privacy-policy.html`
  - 固定色をCSS変数化し、dark用配色を追加
- `docs/index.html`
  - リダイレクト中継ページに最小テーマ追随スタイルを追加
- `CHANGELOG.md`
  - Unreleased に今回の変更を追記

## 背景
個人→組織移行後のPages確認で公開ページは正常でしたが、ページ配色がテーマ追随していない課題があったため改善しました。

## 検証
- 変更差分の目視確認（HTML/CSSのみの変更）
- 公開URL構成に合わせた対象ページの更新
