### PR TITLE
fix: ファイルビュー詳細の位置情報表示で測位失敗を第3状態で区別

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 修正
 - 位置情報のある写真を選択したとき `MapStatusOverlay`（暗いオーバーレイ）が消えずにマップ全体にマスクがかかったままになるリグレッションを修正。`_statusVisibility` 初期値を `Collapsed` に変更し、`Map` プロパティ変更時にも `UpdateMapStatusFromViewModel()` を呼ぶよう修正。
 - 上記リグレッションの再発防止として、`MapPaneViewModelTests.InitialStateIsCorrect` に `StatusVisibility == Collapsed` の検証を追加し、E2E で `sample.jpg` 選択後に `MapStatusPanel` が非表示になることをアサートするよう修正。
+- ファイルビュー(詳細)の位置情報表示に「測位失敗の可能性」状態を追加し、`0,0` など地図で無効扱いの座標は専用アイコンとツールチップで区別表示するよう改善。
 
 ## [1.7.1] - 2026-03-04
 

--- a/PhotoGeoExplorer.Core/Models/PhotoMetadata.cs
+++ b/PhotoGeoExplorer.Core/Models/PhotoMetadata.cs
@@ -5,13 +5,22 @@ namespace PhotoGeoExplorer.Models;
 
 internal sealed class PhotoMetadata
 {
-    public PhotoMetadata(DateTimeOffset? takenAt, string? cameraMake, string? cameraModel, double? latitude, double? longitude)
+    private const double ZeroCoordinateThreshold = 0.000001;
+
+    public PhotoMetadata(
+        DateTimeOffset? takenAt,
+        string? cameraMake,
+        string? cameraModel,
+        double? latitude,
+        double? longitude,
+        bool hasGpsData = false)
     {
         TakenAt = takenAt;
         CameraMake = cameraMake;
         CameraModel = cameraModel;
         Latitude = latitude;
         Longitude = longitude;
+        HasGpsData = hasGpsData;
     }
 
     public DateTimeOffset? TakenAt { get; }
@@ -19,8 +28,14 @@ internal sealed class PhotoMetadata
     public string? CameraModel { get; }
     public double? Latitude { get; }
     public double? Longitude { get; }
+    public bool HasGpsData { get; }
 
     public bool HasLocation => Latitude.HasValue && Longitude.HasValue;
+    public bool HasValidLocation => HasLocation
+        && Latitude is double lat
+        && Longitude is double lon
+        && (Math.Abs(lat) >= ZeroCoordinateThreshold || Math.Abs(lon) >= ZeroCoordinateThreshold);
+    public bool IsLikelyLocationFixFailed => HasGpsData && !HasValidLocation;
 
     public string? CameraSummary
     {

--- a/PhotoGeoExplorer.Core/Services/ExifService.cs
+++ b/PhotoGeoExplorer.Core/Services/ExifService.cs
@@ -111,7 +111,13 @@ internal static class ExifService
             takenAt = new DateTimeOffset(localTime);
         }
 
-        return new PhotoMetadata(takenAt, cameraMake, cameraModel, latitude, longitude);
+        return new PhotoMetadata(
+            takenAt,
+            cameraMake,
+            cameraModel,
+            latitude,
+            longitude,
+            hasGpsData: gpsDirectory is not null);
     }
 
     private static bool WriteMetadata(

--- a/PhotoGeoExplorer.Tests/FileBrowserPaneServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserPaneServiceTests.cs
@@ -79,7 +79,7 @@ public class FileBrowserPaneServiceTests
 
             var item = Assert.Single(items);
             Assert.True(string.IsNullOrWhiteSpace(item.TakenAtText));
-            Assert.Null(item.LocationStatusGlyph);
+            Assert.Equal(Microsoft.UI.Xaml.Visibility.Collapsed, item.LocationStatusVisibility);
         }
         finally
         {
@@ -106,7 +106,7 @@ public class FileBrowserPaneServiceTests
 
             var item = Assert.Single(items);
             Assert.True(string.IsNullOrWhiteSpace(item.TakenAtText));
-            Assert.Null(item.LocationStatusGlyph);
+            Assert.Equal(Microsoft.UI.Xaml.Visibility.Collapsed, item.LocationStatusVisibility);
         }
         finally
         {

--- a/PhotoGeoExplorer.Tests/PhotoListItemTests.cs
+++ b/PhotoGeoExplorer.Tests/PhotoListItemTests.cs
@@ -1,6 +1,8 @@
 using System;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using PhotoGeoExplorer.Models;
+using PhotoGeoExplorer.Services;
 using PhotoGeoExplorer.ViewModels;
 
 namespace PhotoGeoExplorer.Tests;
@@ -201,7 +203,24 @@ public sealed class PhotoListItemTests
         Assert.Equal(takenAt, listItem.TakenAt);
         Assert.Equal("2024-01-02 03:04", listItem.TakenAtText);
         Assert.True(listItem.HasLocation);
-        Assert.Equal("\uE707", listItem.LocationStatusGlyph);
+        Assert.Equal(Symbol.Map, listItem.LocationStatusSymbol);
+        Assert.Equal(LocalizationService.GetString("StatusBar.GpsAvailable"), listItem.LocationStatusTooltip);
+        Assert.Equal(Visibility.Visible, listItem.LocationStatusVisibility);
+    }
+
+    [Fact]
+    public void UpdateMetadataSetsFixFailedIconAndTooltip()
+    {
+        var photoItem = new PhotoItem("C:\\test\\file.jpg", 1024, DateTimeOffset.UtcNow, isFolder: false);
+        var listItem = new PhotoListItem(photoItem, thumbnail: null);
+        var takenAt = new DateTimeOffset(2024, 1, 2, 3, 4, 0, TimeSpan.Zero);
+
+        var result = listItem.UpdateMetadata(takenAt, hasLocation: false, isLocationFixFailed: true);
+
+        Assert.True(result);
+        Assert.False(listItem.HasLocation);
+        Assert.Equal(Symbol.Important, listItem.LocationStatusSymbol);
+        Assert.Equal(LocalizationService.GetString("StatusBar.GpsFixFailed"), listItem.LocationStatusTooltip);
         Assert.Equal(Visibility.Visible, listItem.LocationStatusVisibility);
     }
 

--- a/PhotoGeoExplorer.Tests/PhotoMetadataTests.cs
+++ b/PhotoGeoExplorer.Tests/PhotoMetadataTests.cs
@@ -46,4 +46,24 @@ public sealed class PhotoMetadataTests
 
         Assert.Equal("2024-01-02 03:04", metadata.TakenAtText);
     }
+
+    [Fact]
+    public void HasValidLocationReturnsFalseForZeroCoordinates()
+    {
+        var metadata = new PhotoMetadata(null, null, null, 0, 0, hasGpsData: true);
+
+        Assert.True(metadata.HasLocation);
+        Assert.False(metadata.HasValidLocation);
+        Assert.True(metadata.IsLikelyLocationFixFailed);
+    }
+
+    [Fact]
+    public void HasValidLocationReturnsTrueForNonZeroCoordinates()
+    {
+        var metadata = new PhotoMetadata(null, null, null, 35.681236, 139.767125, hasGpsData: true);
+
+        Assert.True(metadata.HasLocation);
+        Assert.True(metadata.HasValidLocation);
+        Assert.False(metadata.IsLikelyLocationFixFailed);
+    }
 }

--- a/PhotoGeoExplorer/MainWindow.xaml
+++ b/PhotoGeoExplorer/MainWindow.xaml
@@ -188,10 +188,8 @@
                 Background="{ThemeResource SystemControlBackgroundBaseLowBrush}"
                 CornerRadius="4">
                 <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                    <FontIcon
-                        Glyph="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.StatusBarLocationGlyph}"
-                        FontFamily="Segoe MDL2 Assets"
-                        FontSize="16"
+                    <SymbolIcon
+                        Symbol="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.StatusBarLocationSymbol}"
                         Visibility="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.StatusBarLocationVisibility}"
                         Width="16"
                         Height="16"

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml
@@ -152,9 +152,8 @@
                     Margin="12,0,0,0"
                     VerticalAlignment="Center"
                     Visibility="{Binding DataContext.DetailsLocationColumnVisibility, ElementName=RootGrid}">
-                    <FontIcon
-                        Glyph="{Binding LocationStatusGlyph}"
-                        FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                    <SymbolIcon
+                        Symbol="{Binding LocationStatusSymbol}"
                         Opacity="0.7"
                         VerticalAlignment="Center"
                         Visibility="{Binding LocationStatusVisibility}"

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -35,7 +35,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     private readonly SemaphoreSlim _thumbnailGenerationSemaphore = new(ThumbnailGenerationConcurrency, ThumbnailGenerationConcurrency);
     private readonly HashSet<string> _thumbnailsInProgress = new();
     private readonly object _thumbnailsInProgressLock = new();
-    private readonly List<(PhotoListItem Item, string? ThumbnailPath, string? Key, int Generation, int? Width, int? Height, DateTimeOffset? TakenAt, bool? HasLocation)> _pendingThumbnailUpdates = new();
+    private readonly List<(PhotoListItem Item, string? ThumbnailPath, string? Key, int Generation, int? Width, int? Height, DateTimeOffset? TakenAt, bool? HasLocation, bool IsLocationFixFailed)> _pendingThumbnailUpdates = new();
     private readonly object _pendingThumbnailUpdatesLock = new();
 
     private string? _currentFolderPath;
@@ -69,7 +69,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     private Visibility _statusPrimaryActionVisibility = Visibility.Collapsed;
     private Visibility _statusSecondaryActionVisibility = Visibility.Collapsed;
     private string? _statusBarText;
-    private string? _statusBarLocationGlyph;
+    private Symbol _statusBarLocationSymbol = Symbol.Map;
     private Visibility _statusBarLocationVisibility = Visibility.Collapsed;
     private string? _statusBarLocationTooltip;
     private int _thumbnailGenerationTotal;
@@ -480,10 +480,10 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         private set => SetProperty(ref _statusBarText, value);
     }
 
-    public string? StatusBarLocationGlyph
+    public Symbol StatusBarLocationSymbol
     {
-        get => _statusBarLocationGlyph;
-        private set => SetProperty(ref _statusBarLocationGlyph, value);
+        get => _statusBarLocationSymbol;
+        private set => SetProperty(ref _statusBarLocationSymbol, value);
     }
 
     public Visibility StatusBarLocationVisibility
@@ -1133,27 +1133,33 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         if (SelectedItem is null || SelectedItem.IsFolder)
         {
             StatusBarLocationVisibility = Visibility.Collapsed;
-            StatusBarLocationGlyph = null;
+            StatusBarLocationSymbol = Symbol.Map;
             StatusBarLocationTooltip = null;
             return;
         }
 
-        if (_selectedMetadata?.HasLocation == true)
+        if (_selectedMetadata?.HasValidLocation == true)
         {
             StatusBarLocationVisibility = Visibility.Visible;
-            StatusBarLocationGlyph = "\uE707";
+            StatusBarLocationSymbol = Symbol.Map;
             StatusBarLocationTooltip = LocalizationService.GetString("StatusBar.GpsAvailable");
         }
         else if (_selectedMetadata is null)
         {
             StatusBarLocationVisibility = Visibility.Collapsed;
-            StatusBarLocationGlyph = null;
+            StatusBarLocationSymbol = Symbol.Map;
             StatusBarLocationTooltip = null;
+        }
+        else if (_selectedMetadata.IsLikelyLocationFixFailed)
+        {
+            StatusBarLocationVisibility = Visibility.Visible;
+            StatusBarLocationSymbol = Symbol.Important;
+            StatusBarLocationTooltip = LocalizationService.GetString("StatusBar.GpsFixFailed");
         }
         else
         {
             StatusBarLocationVisibility = Visibility.Visible;
-            StatusBarLocationGlyph = "\uE711";
+            StatusBarLocationSymbol = Symbol.Cancel;
             StatusBarLocationTooltip = LocalizationService.GetString("StatusBar.GpsMissing");
         }
     }
@@ -1343,20 +1349,22 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 
                 DateTimeOffset? takenAt = null;
                 bool? hasLocation = null;
+                var isLocationFixFailed = false;
                 if (IsJpegFile(listItem))
                 {
                     var metadata = await ExifService.GetMetadataAsync(listItem.FilePath, cancellationToken).ConfigureAwait(false);
                     if (metadata is not null)
                     {
                         takenAt = metadata.TakenAt;
-                        hasLocation = metadata.HasLocation;
+                        hasLocation = metadata.HasValidLocation;
+                        isLocationFixFailed = metadata.IsLikelyLocationFixFailed;
                     }
                 }
 
                 // UIスレッドで BitmapImage を作成して更新をキューに追加
                 lock (_pendingThumbnailUpdatesLock)
                 {
-                    _pendingThumbnailUpdates.Add((listItem, result.ThumbnailPath, key, listItem.Generation, result.Width, result.Height, takenAt, hasLocation));
+                    _pendingThumbnailUpdates.Add((listItem, result.ThumbnailPath, key, listItem.Generation, result.Width, result.Height, takenAt, hasLocation, isLocationFixFailed));
                 }
             }
             finally
@@ -1402,7 +1410,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         // まず、生成完了チェックを実行（キューの有無に関わらず）
         var shouldStopTimer = Volatile.Read(ref _thumbnailGenerationCompleted) >= _thumbnailGenerationTotal;
 
-        List<(PhotoListItem Item, string? ThumbnailPath, string? Key, int Generation, int? Width, int? Height, DateTimeOffset? TakenAt, bool? HasLocation)> updates;
+        List<(PhotoListItem Item, string? ThumbnailPath, string? Key, int Generation, int? Width, int? Height, DateTimeOffset? TakenAt, bool? HasLocation, bool IsLocationFixFailed)> updates;
 
         lock (_pendingThumbnailUpdatesLock)
         {
@@ -1417,13 +1425,13 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
                 return;
             }
 
-            updates = new List<(PhotoListItem, string?, string?, int, int?, int?, DateTimeOffset?, bool?)>(_pendingThumbnailUpdates);
+            updates = new List<(PhotoListItem, string?, string?, int, int?, int?, DateTimeOffset?, bool?, bool)>(_pendingThumbnailUpdates);
             _pendingThumbnailUpdates.Clear();
         }
 
         var successCount = 0;
         var metadataUpdatedCount = 0;
-        foreach (var (item, thumbnailPath, key, generation, width, height, takenAt, hasLocation) in updates)
+        foreach (var (item, thumbnailPath, key, generation, width, height, takenAt, hasLocation, isLocationFixFailed) in updates)
         {
             // UIスレッドでBitmapImageを作成
             var thumbnail = CreateThumbnailImage(thumbnailPath);
@@ -1432,7 +1440,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
                 successCount++;
             }
 
-            if (item.UpdateMetadata(takenAt, hasLocation))
+            if (item.UpdateMetadata(takenAt, hasLocation, isLocationFixFailed))
             {
                 metadataUpdatedCount++;
             }

--- a/PhotoGeoExplorer/Panes/Map/MapPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/Map/MapPaneViewModel.cs
@@ -556,14 +556,9 @@ internal sealed class MapPaneViewModel : PaneViewModelBase
     {
         latitude = 0;
         longitude = 0;
-        if (!metadata.HasLocation
+        if (!metadata.HasValidLocation
             || metadata.Latitude is not double lat
             || metadata.Longitude is not double lon)
-        {
-            return false;
-        }
-
-        if (Math.Abs(lat) < 0.000001 && Math.Abs(lon) < 0.000001)
         {
             return false;
         }

--- a/PhotoGeoExplorer/Strings/en-US/Resources.resw
+++ b/PhotoGeoExplorer/Strings/en-US/Resources.resw
@@ -531,6 +531,9 @@
   <data name="StatusBar.GpsMissing" xml:space="preserve">
     <value>GPS location missing</value>
   </data>
+  <data name="StatusBar.GpsFixFailed" xml:space="preserve">
+    <value>GPS fix may have failed</value>
+  </data>
   <data name="MapStatus.ControlMissingTitle" xml:space="preserve">
     <value>Map control unavailable</value>
   </data>

--- a/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
+++ b/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
@@ -531,6 +531,9 @@
   <data name="StatusBar.GpsMissing" xml:space="preserve">
     <value>GPS 情報なし</value>
   </data>
+  <data name="StatusBar.GpsFixFailed" xml:space="preserve">
+    <value>GPS 測位失敗の可能性</value>
+  </data>
   <data name="MapStatus.ControlMissingTitle" xml:space="preserve">
     <value>地図コントロールが利用できません</value>
   </data>

--- a/PhotoGeoExplorer/ViewModels/MainViewModel.cs
+++ b/PhotoGeoExplorer/ViewModels/MainViewModel.cs
@@ -1423,7 +1423,7 @@ internal sealed class MainViewModel : BindableBase, IDisposable
             return;
         }
 
-        if (SelectedMetadata?.HasLocation == true)
+        if (SelectedMetadata?.HasValidLocation == true)
         {
             StatusBarLocationVisibility = Visibility.Visible;
             StatusBarLocationGlyph = "\uE707";
@@ -1434,6 +1434,12 @@ internal sealed class MainViewModel : BindableBase, IDisposable
             StatusBarLocationVisibility = Visibility.Collapsed;
             StatusBarLocationGlyph = null;
             StatusBarLocationTooltip = null;
+        }
+        else if (SelectedMetadata.IsLikelyLocationFixFailed)
+        {
+            StatusBarLocationVisibility = Visibility.Visible;
+            StatusBarLocationGlyph = "\uE711";
+            StatusBarLocationTooltip = LocalizationService.GetString("StatusBar.GpsFixFailed");
         }
         else
         {

--- a/PhotoGeoExplorer/ViewModels/MainViewModel.cs
+++ b/PhotoGeoExplorer/ViewModels/MainViewModel.cs
@@ -1438,7 +1438,7 @@ internal sealed class MainViewModel : BindableBase, IDisposable
         else if (SelectedMetadata.IsLikelyLocationFixFailed)
         {
             StatusBarLocationVisibility = Visibility.Visible;
-            StatusBarLocationGlyph = "\uE711";
+            StatusBarLocationGlyph = "\uE8C9";
             StatusBarLocationTooltip = LocalizationService.GetString("StatusBar.GpsFixFailed");
         }
         else

--- a/PhotoGeoExplorer/ViewModels/PhotoListItem.cs
+++ b/PhotoGeoExplorer/ViewModels/PhotoListItem.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
 using PhotoGeoExplorer.Models;
 using PhotoGeoExplorer.Services;
@@ -15,6 +16,7 @@ internal sealed class PhotoListItem : BindableBase
     private int? _pixelHeight;
     private DateTimeOffset? _takenAt;
     private bool? _hasLocation;
+    private bool _isLocationFixFailed;
     private string? _toolTipText;
     private readonly bool _isGeneratedToolTip;
 
@@ -30,6 +32,7 @@ internal sealed class PhotoListItem : BindableBase
         _pixelHeight = item.PixelHeight;
         _takenAt = item.TakenAt;
         _hasLocation = item.HasLocation;
+        _isLocationFixFailed = false;
     }
 
     public PhotoItem Item { get; }
@@ -40,15 +43,17 @@ internal sealed class PhotoListItem : BindableBase
     public DateTimeOffset? TakenAt => _takenAt;
     public bool? HasLocation => _hasLocation;
     public string TakenAtText => _takenAt?.ToString("yyyy-MM-dd HH:mm", System.Globalization.CultureInfo.CurrentCulture) ?? string.Empty;
-    public string? LocationStatusGlyph => _hasLocation switch
+    public Symbol LocationStatusSymbol => _hasLocation switch
     {
-        true => "\uE707",
-        false => "\uE711",
-        _ => null
+        true => Symbol.Map,
+        false when _isLocationFixFailed => Symbol.Important,
+        false => Symbol.Cancel,
+        _ => Symbol.Map
     };
     public string? LocationStatusTooltip => _hasLocation switch
     {
         true => LocalizationService.GetString("StatusBar.GpsAvailable"),
+        false when _isLocationFixFailed => LocalizationService.GetString("StatusBar.GpsFixFailed"),
         false => LocalizationService.GetString("StatusBar.GpsMissing"),
         _ => null
     };
@@ -147,19 +152,23 @@ internal sealed class PhotoListItem : BindableBase
         _generation++;
     }
 
-    public bool UpdateMetadata(DateTimeOffset? takenAt, bool? hasLocation)
+    public bool UpdateMetadata(DateTimeOffset? takenAt, bool? hasLocation, bool isLocationFixFailed = false)
     {
-        if (_takenAt == takenAt && _hasLocation == hasLocation)
+        var normalizedFixFailed = hasLocation == false && isLocationFixFailed;
+        if (_takenAt == takenAt
+            && _hasLocation == hasLocation
+            && _isLocationFixFailed == normalizedFixFailed)
         {
             return false;
         }
 
         _takenAt = takenAt;
         _hasLocation = hasLocation;
+        _isLocationFixFailed = normalizedFixFailed;
         OnPropertyChanged(nameof(TakenAt));
         OnPropertyChanged(nameof(HasLocation));
         OnPropertyChanged(nameof(TakenAtText));
-        OnPropertyChanged(nameof(LocationStatusGlyph));
+        OnPropertyChanged(nameof(LocationStatusSymbol));
         OnPropertyChanged(nameof(LocationStatusTooltip));
         OnPropertyChanged(nameof(LocationStatusVisibility));
         return true;


### PR DESCRIPTION
## 概要
ファイルビュー(詳細)の位置情報列で、GPSタグはあるが有効座標がない写真（例: 0,0）を「位置情報あり」と誤認しやすい表示になっていたため、測位失敗の可能性を第3状態として区別表示するよう修正しました。

## 変更内容
- `PhotoMetadata` に以下を追加
  - `HasGpsData`
  - `HasValidLocation`（0,0 を無効扱い）
  - `IsLikelyLocationFixFailed`（GPSタグあり + 有効座標なし）
- EXIF読み取りで GPS ディレクトリ有無を `HasGpsData` に反映
- ファイルビュー詳細の位置情報アイコンを3状態化
  - 位置情報あり: `Map`
  - 位置情報なし: `Cancel`
  - 測位失敗の可能性: `Important`
- ステータスバーの位置情報表示ロジックも同基準に統一
- マップ側の有効座標判定を `HasValidLocation` に統一
- 文字列リソース追加
  - `StatusBar.GpsFixFailed`（ja/en）
- テスト更新/追加
  - `PhotoMetadataTests`
  - `PhotoListItemTests`
  - `FileBrowserPaneServiceTests`

## 検証
- `dotnet build PhotoGeoExplorer.sln -c Release -p:Platform=x64`
- `dotnet test PhotoGeoExplorer.Tests\PhotoGeoExplorer.Tests.csproj -c Release -p:Platform=x64 --filter "FullyQualifiedName~PhotoListItemTests|FullyQualifiedName~PhotoMetadataTests|FullyQualifiedName~FileBrowserPaneServiceTests"`
  - 47 passed, 0 failed, 0 skipped