### PR TITLE
fix(ci): Codecov 失敗時に CI が止まらないよう fail_ci_if_error を false へ変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           files: TestResults/**/coverage.cobertura.xml
           flags: unittests
           disable_search: true
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
       - name: Upload test results
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 変更
 - CI/CD ワークフロー（ci.yml, security-check.yml, e2e.yml, release.yml）の `dotnet-version` 直書きを廃止し、`global-json-file: global.json` を使用して SDK バージョンを `global.json` で一元管理するよう変更。
+- `ci.yml`: Codecov アップロード失敗時の `fail_ci_if_error` を `true` から `false` へ変更し、Codecov 側の問題（"Repository not found"）が CI を止めないようにした（`CODECOV_TOKEN` 再設定後に `true` へ戻す）。
 
 ## [1.7.2] - 2026-03-06
 


### PR DESCRIPTION
## 概要

Codecov の API が `{"message":"Repository not found"}` を返して CI が失敗するため、`fail_ci_if_error` を `false` に変更して CI をアンブロックします。

## 原因

- `CODECOV_TOKEN` シークレットが無効化・期限切れ、もしくは Codecov 側でリポジトリが未登録状態になっている
- `fail_ci_if_error: true` 設定のため、この Codecov 側の問題が CI 全体を止めていた

## 変更内容

- `.github/workflows/ci.yml`: `fail_ci_if_error: true` → `false`

## 根本対応（別途手動作業が必要）

`CODECOV_TOKEN` シークレットを再設定してください：

1. [Codecov ダッシュボード](https://app.codecov.io/gh/scottlz0310/PhotoGeoExplorer) でトークンを確認・再生成
2. GitHub リポジトリの Settings → Secrets and variables → Actions → `CODECOV_TOKEN` を更新
3. 動作確認後、`fail_ci_if_error` を `true` に戻す

## 検証

再実行後もエラーが発生するため、再実行では解決しないことを確認済み。