### PR TITLE
chore(deps-csharp): SixLabors.ImageSharp を 3.1.12 → 4.0.0 に更新し CI ライセンス対応を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         configuration: [Release]
         platform: [x64]
     env:
-      SIXLABORS_LICENSE_KEY: ${{ secrets.SIXLABORS_LICENSE_KEY }}
+      SIXLABORS_LICENSE_KEY: ${{ vars.SIXLABORS_LICENSE_KEY }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       matrix:
         configuration: [Release]
         platform: [x64]
+    env:
+      SIXLABORS_LICENSE_KEY: ${{ secrets.SIXLABORS_LICENSE_KEY }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         configuration: [Release]
         platform: [x64]
     env:
-      SIXLABORS_LICENSE_KEY: ${{ vars.SIXLABORS_LICENSE_KEY }}
+      SIXLABORS_LICENSE_KEY: ${{ secrets.SIXLABORS_LICENSE_KEY }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
   e2e:
     runs-on: windows-latest
     env:
-      SIXLABORS_LICENSE_KEY: ${{ vars.SIXLABORS_LICENSE_KEY }}
+      SIXLABORS_LICENSE_KEY: ${{ secrets.SIXLABORS_LICENSE_KEY }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   e2e:
     runs-on: windows-latest
+    env:
+      SIXLABORS_LICENSE_KEY: ${{ secrets.SIXLABORS_LICENSE_KEY }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
   e2e:
     runs-on: windows-latest
     env:
-      SIXLABORS_LICENSE_KEY: ${{ secrets.SIXLABORS_LICENSE_KEY }}
+      SIXLABORS_LICENSE_KEY: ${{ vars.SIXLABORS_LICENSE_KEY }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     runs-on: windows-latest
     env:
-      SIXLABORS_LICENSE_KEY: ${{ vars.SIXLABORS_LICENSE_KEY }}
+      SIXLABORS_LICENSE_KEY: ${{ secrets.SIXLABORS_LICENSE_KEY }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     runs-on: windows-latest
     env:
-      SIXLABORS_LICENSE_KEY: ${{ secrets.SIXLABORS_LICENSE_KEY }}
+      SIXLABORS_LICENSE_KEY: ${{ vars.SIXLABORS_LICENSE_KEY }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   release:
     runs-on: windows-latest
+    env:
+      SIXLABORS_LICENSE_KEY: ${{ secrets.SIXLABORS_LICENSE_KEY }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -84,6 +84,8 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    env:
+      SIXLABORS_LICENSE_KEY: ${{ vars.SIXLABORS_LICENSE_KEY }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -85,7 +85,7 @@ jobs:
       contents: read
       security-events: write
     env:
-      SIXLABORS_LICENSE_KEY: ${{ vars.SIXLABORS_LICENSE_KEY }}
+      SIXLABORS_LICENSE_KEY: ${{ secrets.SIXLABORS_LICENSE_KEY }}
 
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+### 変更
+- `SixLabors.ImageSharp` を 3.1.12 → 4.0.0 に更新。v4 はビルド時ライセンス検証（`ValidateLicenseTask`）が必須のため、`Directory.Build.props` に環境変数 `SIXLABORS_LICENSE_KEY` から `$(SixLaborsLicenseKey)` への転写を追加し、CI ワークフロー（ci.yml / e2e.yml / release.yml）に GitHub シークレット `SIXLABORS_LICENSE_KEY` の受け渡しを追加。**このプロジェクトは MIT ライセンスのオープンソースプロジェクトであり SixLabors コミュニティライセンス（無償）の取得対象です。** ライセンスキーは https://licensing.sixlabors.com/ で取得し、GitHub リポジトリの Secrets に `SIXLABORS_LICENSE_KEY` として設定してください。
+
 ### ドキュメント
 - `docs/refactor_plan_v1.8/phase1_ideal_architecture.md` と `docs/refactor_plan_v1.8/phase2_repository_audit.md` を追加し、v1.8 リファクタリング計画の Phase 1 / Phase 2 文書を整備。
 - 上記リファクタリング計画書をブラッシュアップし、例外禁止ポリシー、アンチパターン定義、禁止判断、テスト起点監査、優先順位付けルール、Issue 分解ヒントを追加。

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,8 @@
   </PropertyGroup>
 
   <!-- SixLabors.ImageSharp v4 以降はビルド時ライセンス検証が必須。
-       SIXLABORS_LICENSE_KEY 環境変数（GitHub シークレット）から SixLaborsLicenseKey に転写する。
+       SIXLABORS_LICENSE_KEY 環境変数（GitHub リポジトリ変数 vars.SIXLABORS_LICENSE_KEY）から SixLaborsLicenseKey に転写する。
+       リポジトリ変数は fork PR でも参照可能なため secrets ではなく vars を使用する。
        https://sixlabors.com/posts/licence-enforcement-changes/ -->
   <PropertyGroup Condition="'$(SixLaborsLicenseKey)' == '' AND '$(SIXLABORS_LICENSE_KEY)' != ''">
     <SixLaborsLicenseKey>$(SIXLABORS_LICENSE_KEY)</SixLaborsLicenseKey>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,8 +9,7 @@
   </PropertyGroup>
 
   <!-- SixLabors.ImageSharp v4 以降はビルド時ライセンス検証が必須。
-       SIXLABORS_LICENSE_KEY 環境変数（GitHub リポジトリ変数 vars.SIXLABORS_LICENSE_KEY）から SixLaborsLicenseKey に転写する。
-       リポジトリ変数は fork PR でも参照可能なため secrets ではなく vars を使用する。
+       SIXLABORS_LICENSE_KEY 環境変数（GitHub シークレット）から SixLaborsLicenseKey に転写する。
        https://sixlabors.com/posts/licence-enforcement-changes/ -->
   <PropertyGroup Condition="'$(SixLaborsLicenseKey)' == '' AND '$(SIXLABORS_LICENSE_KEY)' != ''">
     <SixLaborsLicenseKey>$(SIXLABORS_LICENSE_KEY)</SixLaborsLicenseKey>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,4 +7,11 @@
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
+
+  <!-- SixLabors.ImageSharp v4 以降はビルド時ライセンス検証が必須。
+       SIXLABORS_LICENSE_KEY 環境変数（GitHub シークレット）から SixLaborsLicenseKey に転写する。
+       https://sixlabors.com/posts/licence-enforcement-changes/ -->
+  <PropertyGroup Condition="'$(SixLaborsLicenseKey)' == '' AND '$(SIXLABORS_LICENSE_KEY)' != ''">
+    <SixLaborsLicenseKey>$(SIXLABORS_LICENSE_KEY)</SixLaborsLicenseKey>
+  </PropertyGroup>
 </Project>

--- a/PhotoGeoExplorer.Core/PhotoGeoExplorer.Core.csproj
+++ b/PhotoGeoExplorer.Core/PhotoGeoExplorer.Core.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="MetadataExtractor" Version="2.9.3" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/PhotoGeoExplorer.E2E/PhotoGeoExplorer.E2E.csproj
+++ b/PhotoGeoExplorer.E2E/PhotoGeoExplorer.E2E.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="FlaUI.Core" Version="5.0.0" />
     <PackageReference Include="FlaUI.UIA3" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="4.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>


### PR DESCRIPTION
ImageSharp v4 はビルド時ライセンス検証（ValidateLicenseTask）が必須となったため、
ライセンスキーなしではビルドが失敗する。

このプロジェクトは MIT ライセンスのオープンソースプロジェクトであり、
SixLabors Split License のコミュニティ条件（オープンソースソフトウェア向け無償）を満たす。
https://licensing.sixlabors.com/ でコミュニティライセンスを取得し、
GitHub Secrets に SIXLABORS_LICENSE_KEY として設定することで CI が通過する。

変更内容:
- PhotoGeoExplorer.Core: SixLabors.ImageSharp 3.1.12 → 4.0.0
- PhotoGeoExplorer.E2E: SixLabors.ImageSharp 3.1.12 → 4.0.0
- Directory.Build.props: SIXLABORS_LICENSE_KEY 環境変数を SixLaborsLicenseKey MSBuild プロパティに転写する設定を追加
- ci.yml / e2e.yml / release.yml: SIXLABORS_LICENSE_KEY シークレットをジョブ環境変数として渡す設定を追加

https://claude.ai/code/session_015Syxa5CpqkuKJ9RUvsMzc8