### PR TITLE
refactor(vm): FileBrowserPane / Map / Preview ViewModel の System.IO 依存をサービス経由へ移管 (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 ## [Unreleased]
 
 ### リファクタリング
+- MVVM 境界違反修正（#92 PR-A）: `FileBrowserPaneViewModel` から `System.IO` 直接依存を除去。
+  - `Directory.GetParent` → `IFileOperationService.GetParentPath` に置き換え（`CanNavigateUp`, `CanMoveToParentSelection`, `NavigateUpAsync`）。
+  - `Directory.Exists` → `IFileOperationService.FolderExistsAtPath` に置き換え（`LoadFolderAsync`, `OpenHomeAsync`）。
+  - `Path.GetExtension` による JPEG 判定 → `IFileOperationService.IsJpegFile` に移管（`IsJpegFile` プライベートメソッド）。
+  - `IFileOperationService` に `FolderExistsAtPath` / `IsJpegFile` を追加し `FileOperationService` に実装。
+  - `using System.IO;` を `FileBrowserPaneViewModel.cs` から削除。
+  - `FileOperationServiceTests` に `FolderExistsAtPath` / `IsJpegFile` のテストを追加。
 - MVVM 境界違反修正（#91）: `FileBrowserPaneView.xaml.cs` から `System.IO` 依存・ファイル操作 `foreach` ループ・パス検証関数（`IsSamePath`/`IsDescendantPath`/`ContainsInvalidFileNameChars`/`NormalizeRename`）を完全撤去。
   - `IFileOperationService` / `FileOperationService` を `Services/` に新設し、フォルダ作成・リネーム・移動・削除の実処理とパス検証ロジックを集約。
   - `FileBrowserPaneViewModel` に `Execute*` メソッド群を追加（`ExecuteCreateFolderAsync`, `ExecuteRenameAsync`, `ExecuteMoveItemsToFolderAsync`, `ExecuteMoveToParentAsync`, `ExecuteDeleteItemsAsync`, `HandleExternalFileDropAsync`）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ## [Unreleased]
 
 ### リファクタリング
+- MVVM 境界違反修正（#92 PR-B）: `MapPaneViewModel` / `PreviewPaneViewModel` の IO 依存・直接サービス呼び出しを移管。
+  - `MapPaneViewModel.GetPinPath`（`Path.Combine` によるピン画像パス生成）→ `IMapPaneService.GetPinImagePath` へ移管。
+  - `MapPaneViewModel.TryCreatePinStyle` の `File.Exists` → `IMapPaneService.FileExistsAtPath` へ移管。
+  - `GetPinPath` private static メソッドを削除し `using System.IO;` を `MapPaneViewModel` から除去。
+  - `PreviewPaneViewModel` の `ExifService.GetMetadataAsync` 直呼び出し → `IPreviewPaneService.GetMetadataAsync` 経由へ統一。
+  - `PreviewPaneService` に `GetMetadataAsync` を追加し `ExifService` へ委譲。
 - MVVM 境界違反修正（#92 PR-A）: `FileBrowserPaneViewModel` から `System.IO` 直接依存を除去。
   - `Directory.GetParent` → `IFileOperationService.GetParentPath` に置き換え（`CanNavigateUp`, `CanMoveToParentSelection`, `NavigateUpAsync`）。
   - `Directory.Exists` → `IFileOperationService.FolderExistsAtPath` に置き換え（`LoadFolderAsync`, `OpenHomeAsync`）。

--- a/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
@@ -1073,6 +1073,13 @@ public class FileBrowserPaneViewModelTests
         public bool IsSamePath(string left, string right) => string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
         public string? GetParentPath(string path) => ParentPath;
         public bool ItemExistsAtPath(string path) => false;
+        public bool FolderExistsAtPath(string path) => Directory.Exists(path);
+        public bool IsJpegFile(string filePath)
+        {
+            var ext = Path.GetExtension(filePath);
+            return string.Equals(ext, ".jpg", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(ext, ".jpeg", StringComparison.OrdinalIgnoreCase);
+        }
         public FileOperationResult CreateFolder(string parentFolder, string folderName) => CreateFolderResult;
 
         public FileOperationResult RenameItem(PhotoListItem item, string normalizedName)

--- a/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
@@ -166,6 +166,57 @@ public sealed class FileOperationServiceTests
     }
 
     // =========================================================
+    // FolderExistsAtPath
+    // =========================================================
+
+    [Fact]
+    public void FolderExistsAtPath_ExistingDirectory_ReturnsTrue()
+    {
+        Assert.True(_service.FolderExistsAtPath(Path.GetTempPath()));
+    }
+
+    [Fact]
+    public void FolderExistsAtPath_ExistingFile_ReturnsFalse()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            Assert.False(_service.FolderExistsAtPath(tempFile));
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void FolderExistsAtPath_NonExistentPath_ReturnsFalse()
+    {
+        Assert.False(_service.FolderExistsAtPath(Path.Combine(Path.GetTempPath(), $"nonexistent-{Guid.NewGuid()}")));
+    }
+
+    // =========================================================
+    // IsJpegFile
+    // =========================================================
+
+    [Theory]
+    [InlineData("photo.jpg")]
+    [InlineData("photo.JPG")]
+    [InlineData("photo.jpeg")]
+    [InlineData("photo.JPEG")]
+    public void IsJpegFile_JpegExtension_ReturnsTrue(string fileName)
+        => Assert.True(_service.IsJpegFile(Path.Combine(@"C:\photos", fileName)));
+
+    [Theory]
+    [InlineData("photo.png")]
+    [InlineData("photo.heic")]
+    [InlineData("photo.tiff")]
+    [InlineData("noextension")]
+    [InlineData("")]
+    public void IsJpegFile_NonJpegExtension_ReturnsFalse(string fileName)
+        => Assert.False(_service.IsJpegFile(fileName));
+
+    // =========================================================
     // CreateFolder
     // =========================================================
 

--- a/PhotoGeoExplorer.Tests/MapPaneServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/MapPaneServiceTests.cs
@@ -176,6 +176,54 @@ public class MapPaneServiceTests
         Assert.Empty(result);
     }
 
+    // =========================================================
+    // GetPinImagePath
+    // =========================================================
+
+    [Fact]
+    public void GetPinImagePath_TakenAt10DaysAgo_ReturnsGreenPin()
+    {
+        var service = new MapPaneService();
+        var metadata = new PhotoMetadata(DateTimeOffset.Now.AddDays(-10), null, null, 35.0, 135.0);
+
+        var path = service.GetPinImagePath(metadata);
+
+        Assert.EndsWith("green_pin.png", path, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetPinImagePath_TakenAt100DaysAgo_ReturnsBluePin()
+    {
+        var service = new MapPaneService();
+        var metadata = new PhotoMetadata(DateTimeOffset.Now.AddDays(-100), null, null, 35.0, 135.0);
+
+        var path = service.GetPinImagePath(metadata);
+
+        Assert.EndsWith("blue_pin.png", path, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetPinImagePath_TakenAt400DaysAgo_ReturnsRedPin()
+    {
+        var service = new MapPaneService();
+        var metadata = new PhotoMetadata(DateTimeOffset.Now.AddDays(-400), null, null, 35.0, 135.0);
+
+        var path = service.GetPinImagePath(metadata);
+
+        Assert.EndsWith("red_pin.png", path, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetPinImagePath_TakenAtNull_ReturnsRedPin()
+    {
+        var service = new MapPaneService();
+        var metadata = new PhotoMetadata(null, null, null, 35.0, 135.0);
+
+        var path = service.GetPinImagePath(metadata);
+
+        Assert.EndsWith("red_pin.png", path, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static string CreateTempCacheRoot()
     {
         var path = Path.Combine(Path.GetTempPath(), "PhotoGeoExplorer.Tests", Guid.NewGuid().ToString("N"));

--- a/PhotoGeoExplorer.Tests/MapPaneViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/MapPaneViewModelTests.cs
@@ -288,5 +288,11 @@ public class MapPaneViewModelTests
         {
             return Path.GetTempPath();
         }
+
+        public string GetPinImagePath(PhotoMetadata metadata)
+            => Path.Combine(Path.GetTempPath(), "red_pin.png");
+
+        public bool FileExistsAtPath(string path)
+            => false;
     }
 }

--- a/PhotoGeoExplorer.Tests/PreviewPaneViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/PreviewPaneViewModelTests.cs
@@ -51,6 +51,11 @@ public class PreviewPaneViewModelTests
             var correctedZoom = (float)(currentZoom * oldScale / newScale);
             return Math.Clamp(correctedZoom, minZoom, maxZoom);
         }
+
+        public System.Threading.Tasks.Task<PhotoGeoExplorer.Models.PhotoMetadata?> GetMetadataAsync(
+            string filePath,
+            System.Threading.CancellationToken cancellationToken)
+            => System.Threading.Tasks.Task.FromResult<PhotoGeoExplorer.Models.PhotoMetadata?>(null);
     }
 
     [Fact]

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -520,14 +519,14 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 
     public bool CanNavigateBack => _service.CanNavigateBack;
     public bool CanNavigateForward => _service.CanNavigateForward;
-    public bool CanNavigateUp => !string.IsNullOrWhiteSpace(CurrentFolderPath) && Directory.GetParent(CurrentFolderPath) is not null;
+    public bool CanNavigateUp => !string.IsNullOrWhiteSpace(CurrentFolderPath) && _fileOperationService.GetParentPath(CurrentFolderPath) is not null;
     public bool CanCreateFolder => !string.IsNullOrWhiteSpace(CurrentFolderPath);
     public bool CanModifySelection => SelectedCount > 0;
     public bool CanRenameSelection => SelectedCount == 1;
     public bool CanMoveToParentSelection
         => SelectedCount > 0
            && !string.IsNullOrWhiteSpace(CurrentFolderPath)
-           && Directory.GetParent(CurrentFolderPath) is not null;
+           && _fileOperationService.GetParentPath(CurrentFolderPath) is not null;
     public bool CanEditExif => SelectedCount == 1 && IsJpegFile(SelectedItem);
 
     public string NameSortIndicator => GetSortIndicator(FileSortColumn.Name);
@@ -690,7 +689,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
             return;
         }
 
-        if (!Directory.Exists(folderPath))
+        if (!_fileOperationService.FolderExistsAtPath(folderPath))
         {
             await RunOnUIThreadAsync(() =>
             {
@@ -792,7 +791,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     public async Task OpenHomeAsync()
     {
         var homePath = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
-        if (string.IsNullOrWhiteSpace(homePath) || !Directory.Exists(homePath))
+        if (string.IsNullOrWhiteSpace(homePath) || !_fileOperationService.FolderExistsAtPath(homePath))
         {
             await RunOnUIThreadAsync(() =>
             {
@@ -841,10 +840,10 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
             return;
         }
 
-        var parent = Directory.GetParent(CurrentFolderPath);
-        if (parent is not null)
+        var parentPath = _fileOperationService.GetParentPath(CurrentFolderPath);
+        if (parentPath is not null)
         {
-            await LoadFolderAsync(parent.FullName).ConfigureAwait(false);
+            await LoadFolderAsync(parentPath).ConfigureAwait(false);
         }
     }
 
@@ -1329,17 +1328,8 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         }
     }
 
-    private static bool IsJpegFile(PhotoListItem? item)
-    {
-        if (item is null || item.IsFolder)
-        {
-            return false;
-        }
-
-        var extension = Path.GetExtension(item.FilePath);
-        return string.Equals(extension, ".jpg", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(extension, ".jpeg", StringComparison.OrdinalIgnoreCase);
-    }
+    private bool IsJpegFile(PhotoListItem? item)
+        => item is { IsFolder: false } && _fileOperationService.IsJpegFile(item.FilePath);
 
     private void CancelFolderLoad()
     {

--- a/PhotoGeoExplorer/Panes/Map/IMapPaneService.cs
+++ b/PhotoGeoExplorer/Panes/Map/IMapPaneService.cs
@@ -47,4 +47,18 @@ internal interface IMapPaneService
     /// タイルキャッシュのルートディレクトリを取得する
     /// </summary>
     string GetTileCacheRootDirectory();
+
+    /// <summary>
+    /// メタデータに基づいてピン画像のパスを返す
+    /// </summary>
+    /// <param name="metadata">写真メタデータ</param>
+    /// <returns>ピン画像のフルパス</returns>
+    string GetPinImagePath(PhotoMetadata metadata);
+
+    /// <summary>
+    /// 指定パスにファイルが存在するか確認する
+    /// </summary>
+    /// <param name="path">確認するファイルパス</param>
+    /// <returns>ファイルが存在する場合 true</returns>
+    bool FileExistsAtPath(string path);
 }

--- a/PhotoGeoExplorer/Panes/Map/MapPaneService.cs
+++ b/PhotoGeoExplorer/Panes/Map/MapPaneService.cs
@@ -108,6 +108,29 @@ internal sealed class MapPaneService : IMapPaneService
         return _tileCacheRootDirectory;
     }
 
+    public string GetPinImagePath(PhotoMetadata metadata)
+    {
+        var assetsRoot = Path.Combine(AppContext.BaseDirectory, "Assets", "MapPins");
+        if (metadata.TakenAt is DateTimeOffset takenAt)
+        {
+            var age = DateTimeOffset.Now - takenAt;
+            if (age <= TimeSpan.FromDays(30))
+            {
+                return Path.Combine(assetsRoot, "green_pin.png");
+            }
+
+            if (age <= TimeSpan.FromDays(365))
+            {
+                return Path.Combine(assetsRoot, "blue_pin.png");
+            }
+        }
+
+        return Path.Combine(assetsRoot, "red_pin.png");
+    }
+
+    public bool FileExistsAtPath(string path)
+        => File.Exists(path);
+
     private FileCache? CreatePersistentCache(MapTileSourceType sourceType)
     {
         var cacheDirectory = GetTileCacheRootDirectory();

--- a/PhotoGeoExplorer/Panes/Map/MapPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/Map/MapPaneViewModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -488,9 +487,9 @@ internal sealed class MapPaneViewModel : PaneViewModelBase
         _map.Navigator.ZoomToBox(bounds, MBoxFit.Fit, 0, Mapsui.Animations.Easing.CubicOut);
     }
 
-    private static IStyle[] CreatePinStyles(PhotoMetadata metadata)
+    private IStyle[] CreatePinStyles(PhotoMetadata metadata)
     {
-        var pinPath = GetPinPath(metadata);
+        var pinPath = _service.GetPinImagePath(metadata);
         if (TryCreatePinStyle(pinPath, out var pinStyle))
         {
             return new IStyle[] { pinStyle };
@@ -499,10 +498,10 @@ internal sealed class MapPaneViewModel : PaneViewModelBase
         return new IStyle[] { CreateFallbackMarkerStyle() };
     }
 
-    private static bool TryCreatePinStyle(string imagePath, out ImageStyle pinStyle)
+    private bool TryCreatePinStyle(string imagePath, out ImageStyle pinStyle)
     {
         pinStyle = null!;
-        if (string.IsNullOrWhiteSpace(imagePath) || !File.Exists(imagePath))
+        if (string.IsNullOrWhiteSpace(imagePath) || !_service.FileExistsAtPath(imagePath))
         {
             if (!string.IsNullOrWhiteSpace(imagePath))
             {
@@ -530,26 +529,6 @@ internal sealed class MapPaneViewModel : PaneViewModelBase
             Fill = new Brush(Color.FromArgb(255, 32, 128, 255)),
             Outline = new Pen(Color.White, 2)
         };
-    }
-
-    private static string GetPinPath(PhotoMetadata metadata)
-    {
-        var assetsRoot = Path.Combine(AppContext.BaseDirectory, "Assets", "MapPins");
-        if (metadata.TakenAt is DateTimeOffset takenAt)
-        {
-            var age = DateTimeOffset.Now - takenAt;
-            if (age <= TimeSpan.FromDays(30))
-            {
-                return Path.Combine(assetsRoot, "green_pin.png");
-            }
-
-            if (age <= TimeSpan.FromDays(365))
-            {
-                return Path.Combine(assetsRoot, "blue_pin.png");
-            }
-        }
-
-        return Path.Combine(assetsRoot, "red_pin.png");
     }
 
     private static bool TryGetValidLocation(PhotoMetadata metadata, out double latitude, out double longitude)

--- a/PhotoGeoExplorer/Panes/Preview/IPreviewPaneService.cs
+++ b/PhotoGeoExplorer/Panes/Preview/IPreviewPaneService.cs
@@ -1,5 +1,7 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Media.Imaging;
+using PhotoGeoExplorer.Models;
 
 namespace PhotoGeoExplorer.Panes.Preview;
 
@@ -15,6 +17,14 @@ internal interface IPreviewPaneService
     /// <param name="filePath">画像ファイルパス</param>
     /// <returns>BitmapImage オブジェクト</returns>
     Task<BitmapImage?> LoadImageAsync(string filePath);
+
+    /// <summary>
+    /// 指定ファイルの EXIF メタデータを非同期で読み込む
+    /// </summary>
+    /// <param name="filePath">画像ファイルパス</param>
+    /// <param name="cancellationToken">キャンセルトークン</param>
+    /// <returns>PhotoMetadata オブジェクト</returns>
+    Task<PhotoMetadata?> GetMetadataAsync(string filePath, CancellationToken cancellationToken);
 
     /// <summary>
     /// ビューポートに画像をフィットさせるズームファクターを計算

--- a/PhotoGeoExplorer/Panes/Preview/PreviewPaneService.cs
+++ b/PhotoGeoExplorer/Panes/Preview/PreviewPaneService.cs
@@ -1,7 +1,10 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml.Media.Imaging;
+using PhotoGeoExplorer.Models;
+using PhotoGeoExplorer.Services;
 
 namespace PhotoGeoExplorer.Panes.Preview;
 
@@ -41,6 +44,12 @@ internal sealed class PreviewPaneService : IPreviewPaneService
             return null;
         }
     }
+
+    /// <summary>
+    /// 指定ファイルの EXIF メタデータを非同期で読み込む
+    /// </summary>
+    public Task<PhotoMetadata?> GetMetadataAsync(string filePath, CancellationToken cancellationToken)
+        => ExifService.GetMetadataAsync(filePath, cancellationToken);
 
     /// <summary>
     /// ビューポートに画像をフィットさせるズームファクターを計算

--- a/PhotoGeoExplorer/Panes/Preview/PreviewPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/Preview/PreviewPaneViewModel.cs
@@ -355,7 +355,7 @@ internal sealed class PreviewPaneViewModel : PaneViewModelBase
         _currentFilePath = filePath;
 
         var image = await _service.LoadImageAsync(filePath).ConfigureAwait(false);
-        var metadata = await ExifService.GetMetadataAsync(filePath, CancellationToken.None).ConfigureAwait(false);
+        var metadata = await _service.GetMetadataAsync(filePath, CancellationToken.None).ConfigureAwait(false);
 
         // UI スレッドで更新
         var dispatcherQueue = TryGetDispatcherQueue();

--- a/PhotoGeoExplorer/Services/FileOperationService.cs
+++ b/PhotoGeoExplorer/Services/FileOperationService.cs
@@ -61,6 +61,16 @@ internal sealed class FileOperationService : IFileOperationService
     public bool ItemExistsAtPath(string path)
         => Directory.Exists(path) || File.Exists(path);
 
+    public bool FolderExistsAtPath(string path)
+        => Directory.Exists(path);
+
+    public bool IsJpegFile(string filePath)
+    {
+        var ext = Path.GetExtension(filePath);
+        return string.Equals(ext, ".jpg", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(ext, ".jpeg", StringComparison.OrdinalIgnoreCase);
+    }
+
     public FileOperationResult CreateFolder(string parentFolder, string folderName)
     {
         var targetPath = Path.Combine(parentFolder, folderName);

--- a/PhotoGeoExplorer/Services/IFileOperationService.cs
+++ b/PhotoGeoExplorer/Services/IFileOperationService.cs
@@ -13,6 +13,8 @@ internal interface IFileOperationService
     bool IsSamePath(string left, string right);
     string? GetParentPath(string path);
     bool ItemExistsAtPath(string path);
+    bool FolderExistsAtPath(string path);
+    bool IsJpegFile(string filePath);
 
     // ファイル操作（単発）
     FileOperationResult CreateFolder(string parentFolder, string folderName);


### PR DESCRIPTION
## 概要

Issue #92 の PR-A（FileBrowserPaneViewModel）と PR-B（MapPaneViewModel / PreviewPaneViewModel）をまとめた実装です。
MainViewModel の旧ファイルブラウザ責務整理（PR-C）は Issue #96 で独立させます。

## 変更内容

### PR-A: FileBrowserPaneViewModel の System.IO 除去

- `Directory.GetParent` → `IFileOperationService.GetParentPath`（`CanNavigateUp`, `CanMoveToParentSelection`, `NavigateUpAsync`）
- `Directory.Exists` → `IFileOperationService.FolderExistsAtPath`（`LoadFolderAsync`, `OpenHomeAsync`）
- `Path.GetExtension` による JPEG 判定 → `IFileOperationService.IsJpegFile`（`IsJpegFile` プライベートメソッド）
- `IFileOperationService` / `FileOperationService` に `FolderExistsAtPath` / `IsJpegFile` を追加
- `using System.IO;` を `FileBrowserPaneViewModel.cs` から削除

### PR-B: MapPaneViewModel / PreviewPaneViewModel の IO 依存移管

- `MapPaneViewModel.GetPinPath`（`Path.Combine` 系）→ `IMapPaneService.GetPinImagePath` へ移管
- `MapPaneViewModel.TryCreatePinStyle` の `File.Exists` → `IMapPaneService.FileExistsAtPath` へ移管
- `GetPinPath` private static メソッドを削除、`using System.IO;` を `MapPaneViewModel.cs` から除去
- `PreviewPaneViewModel` の `ExifService.GetMetadataAsync` 直呼び出し → `_service.GetMetadataAsync` へ統一
- `IPreviewPaneService` / `PreviewPaneService` に `GetMetadataAsync` を追加

## テスト

- `FileOperationServiceTests` に `FolderExistsAtPath` / `IsJpegFile` のパラメータ化テストを追加
- `MapPaneServiceTests` に `GetPinImagePath` のテストを追加（green/blue/red/TakenAtなし の4ケース）
- `FileBrowserPaneViewModelTests.StubFileOperationService` に新メソッドを実装
- `MapPaneViewModelTests.WorkspaceSelectionMapPaneService` に `GetPinImagePath` / `FileExistsAtPath` を追加
- `PreviewPaneViewModelTests.MockPreviewPaneService` に `GetMetadataAsync` を追加
- 全 450 件パス

## 検証

```
dotnet test PhotoGeoExplorer.Tests/PhotoGeoExplorer.Tests.csproj -c Release -p:Platform=x64
成功!  - 合格: 450, 失敗: 0
```

## 関連 Issue

- Part of #92（PR-A + PR-B 分。MainViewModel の旧責務整理は #96 で継続）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
