### PR TITLE
fix(e2e): ExifEditorSaveAndReopenKeepsCoordinates フレーキー対策 (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+### 修正
+- E2E テスト `ExifEditorSaveAndReopenKeepsCoordinates` のフレーキー修正（#95）。
+  - `OpenExifMenuForItemName` の catch 節に `NoClickablePointException` を追加。`listItem.RightClick()` が `NoClickablePointException` を投げると catch されずにテスト失敗していた問題を解消。
+  - `TryScrollIntoView` / `WaitForElementClickable` ヘルパーを追加し、右クリック前にリスト項目を可視領域にスクロールして描画完了を待機するよう改善。
+  - `listItem.RightClick()` を `RightClickElementCenter(listItem)` に統一し、BoundingRectangle が無効な場合のクリックを回避。
+  - `WaitForListItems` に安定化待機を追加。アイテム数が揃った後、先頭アイテムの BoundingRectangle が非ゼロになるまで待機することで CI ランナーの描画遅延に対応。
+
 ### リファクタリング
 - MVVM 境界違反修正（#92 PR-C）: `MainViewModel` から旧ファイルブラウザ責務を完全削除。
   - `Items`, `BreadcrumbItems`, `CurrentFolderPath`, `SelectedItem`, `SelectedMetadata`, `SelectedPreview` など旧ファイルブラウザ状態フィールドをすべて削除。

--- a/PhotoGeoExplorer.E2E/AppE2ETests.cs
+++ b/PhotoGeoExplorer.E2E/AppE2ETests.cs
@@ -215,6 +215,24 @@ public sealed class AppE2ETests
             () => list.Items.Length < minimumCount,
             timeout: TimeSpan.FromSeconds(20),
             interval: TimeSpan.FromMilliseconds(200));
+
+        // アイテムが画面に描画されるまで安定化を待つ（CI ランナーの描画遅延対策）
+        Retry.WhileTrue(
+            () =>
+            {
+                var firstItem = list.Items.FirstOrDefault();
+                if (firstItem is null)
+                {
+                    return true;
+                }
+
+                var width = SafeGet(() => firstItem.BoundingRectangle.Width, 0d);
+                var height = SafeGet(() => firstItem.BoundingRectangle.Height, 0d);
+                return width <= 1 || height <= 1;
+            },
+            timeout: TimeSpan.FromSeconds(5),
+            interval: TimeSpan.FromMilliseconds(100),
+            throwOnTimeout: false);
     }
 
     private static void TerminateApp(Application? app)
@@ -295,6 +313,10 @@ public sealed class AppE2ETests
                 TryFocusElement(window);
                 SelectListItem(listItem);
                 TryFocusElement(listItem);
+
+                // スクロールして可視領域に入れ、描画完了を待つ
+                TryScrollIntoView(listItem);
+                WaitForElementClickable(listItem);
                 ClickElementCenter(listItem);
 
                 Keyboard.Type(VirtualKeyShort.APPS);
@@ -304,7 +326,9 @@ public sealed class AppE2ETests
                     return byAppsKey;
                 }
 
-                listItem.RightClick();
+                // listItem.RightClick() は NoClickablePointException を投げる可能性があるため
+                // 安全な RightClickElementCenter を使用する
+                RightClickElementCenter(listItem);
                 var byRightClick = TryWaitForEditExifMenuItem(window, automation, processId, timeout: TimeSpan.FromSeconds(3));
                 if (byRightClick is not null)
                 {
@@ -332,7 +356,7 @@ public sealed class AppE2ETests
                     return byShiftF10;
                 }
             }
-            catch (Exception ex) when (ex is COMException or ElementNotAvailableException or InvalidOperationException)
+            catch (Exception ex) when (ex is COMException or ElementNotAvailableException or InvalidOperationException or NoClickablePointException)
             {
             }
 
@@ -362,6 +386,39 @@ public sealed class AppE2ETests
             interval: TimeSpan.FromMilliseconds(150),
             ignoreException: true,
             throwOnTimeout: false).Result;
+    }
+
+    private static void TryScrollIntoView(AutomationElement element)
+    {
+        try
+        {
+            if (element.Patterns.ScrollItem.IsSupported)
+            {
+                element.Patterns.ScrollItem.Pattern.ScrollIntoView();
+            }
+        }
+        catch (Exception ex) when (ex is COMException or InvalidOperationException or ElementNotAvailableException or NoClickablePointException)
+        {
+        }
+    }
+
+    private static void WaitForElementClickable(AutomationElement element)
+    {
+        Retry.WhileTrue(
+            () =>
+            {
+                if (SafeGet(() => element.IsOffscreen, false))
+                {
+                    return true;
+                }
+
+                var width = SafeGet(() => element.BoundingRectangle.Width, 0d);
+                var height = SafeGet(() => element.BoundingRectangle.Height, 0d);
+                return width <= 1 || height <= 1;
+            },
+            timeout: TimeSpan.FromSeconds(3),
+            interval: TimeSpan.FromMilliseconds(100),
+            throwOnTimeout: false);
     }
 
     private static void RightClickElementCenter(AutomationElement element)


### PR DESCRIPTION
## Summary

- `OpenExifMenuForItemName` の catch 節に `NoClickablePointException` を追加 — `listItem.RightClick()` が投げると catch されずテスト即失敗していた問題（Pattern B）を解消
- `TryScrollIntoView` / `WaitForElementClickable` ヘルパーを追加し、右クリック前にリスト項目を可視領域にスクロールして描画完了を待機（Pattern A 対策）
- `listItem.RightClick()` を `RightClickElementCenter(listItem)` に統一し、BoundingRectangle が無効な場合のクリックを回避
- `WaitForListItems` に安定化待機を追加 — アイテム数が揃った後、先頭アイテムの BoundingRectangle が非ゼロになるまで待機することで CI ランナーの描画遅延に対応

## 修正の背景

### Pattern A（タイムアウト）
`WaitForListItems` でアイテム数は揃っているが、まだ描画が完了していない状態で右クリックするとコンテキストメニューが開かない。6 回 × 5 手法 ≈ 78 秒かけて失敗（約 3 分）。

### Pattern B（NoClickablePointException）
`listItem.RightClick()` がアイテムのスクロール外/描画未完了で `NoClickablePointException` を投げるが、catch 節に含まれていないため即テスト失敗。

## 検証

- `dotnet build PhotoGeoExplorer.E2E/PhotoGeoExplorer.E2E.csproj -c Release` → 警告 0、エラー 0
- E2E テストは CI の Windows ランナーで確認予定

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)