### PR TITLE
ci(e2e): Windows App SDK runtime 1.8 の導入方法を安定化する (#101)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,9 +36,33 @@ jobs:
           $runtime = Get-AppxPackage -Name "Microsoft.WindowsAppRuntime.1.8*" -ErrorAction SilentlyContinue
           if (-not $runtime) {
             Write-Host "Windows App SDK runtime 1.8 not found. Installing..."
-            if (Get-Command winget -ErrorAction SilentlyContinue) {
+            $installed = $false
+
+            # 方法1: 公式インストーラー exe（winget より安定）
+            try {
+              $installerUri = "https://aka.ms/windowsappsdk/1.8/latest/windowsappruntimeinstall-x64.exe"
+              $installerPath = Join-Path $env:RUNNER_TEMP "windowsappruntimeinstall-x64.exe"
+              Invoke-WebRequest -Uri $installerUri -OutFile $installerPath -ErrorAction Stop
+              $proc = Start-Process -FilePath $installerPath -ArgumentList "--quiet" -Wait -PassThru
+              if ($proc.ExitCode -eq 0 -or $proc.ExitCode -eq 3010) {
+                $installed = $true
+                Write-Host "Installed via WindowsAppRuntimeInstall.exe (exit: $($proc.ExitCode))"
+              } else {
+                Write-Warning "WindowsAppRuntimeInstall.exe failed (exit: $($proc.ExitCode))"
+              }
+            } catch {
+              Write-Warning "WindowsAppRuntimeInstall.exe method failed: $_"
+            }
+
+            # 方法2: winget（フォールバック）
+            if (-not $installed -and (Get-Command winget -ErrorAction SilentlyContinue)) {
               winget install --id Microsoft.WindowsAppRuntime.1.8 --accept-source-agreements --accept-package-agreements --silent
-            } else {
+              if ($LASTEXITCODE -eq 0) { $installed = $true }
+              else { Write-Warning "winget install failed (exit: $LASTEXITCODE)" }
+            }
+
+            # 方法3: msix 直接インストール（最終フォールバック）
+            if (-not $installed) {
               $uri = "https://aka.ms/windowsappsdk/1.8/latest/Microsoft.WindowsAppRuntime.1.8.x64.msix"
               $msix = Join-Path $env:RUNNER_TEMP "Microsoft.WindowsAppRuntime.1.8.x64.msix"
               Invoke-WebRequest -Uri $uri -OutFile $msix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ## [Unreleased]
 
+### 追加
+- Explorer 風の複数選択と右クリック操作（#87）
+  - 右クリック選択挙動を Explorer 風に変更（選択済み項目→複数選択を維持 / 未選択項目→その項目のみ選択）。
+  - ステータスバーに複数選択時の件数表示（「N 件を選択中」）を追加。複数選択中はステータスバーの GPS アイコンを非表示に統一。
+  - 右クリックメニューに「ファイルの場所を開く」「Explorer で開く」「パスをコピー」「Google Maps で開く」「コピー」を追加。
+  - `FileOperationService.CopyItems` を追加し、選択ファイルを指定フォルダへコピーする基本機能を実装（上書き確認・進捗は #69 対応）。
+  - `FileOperationServiceTests` に `CopyItems` の単体テスト 3 件を追加。
+
 ### 修正
 - E2E テスト `ExifEditorSaveAndReopenKeepsCoordinates` のフレーキー修正（#95）。
   - `OpenExifMenuForItemName` の catch 節に `NoClickablePointException` を追加。`listItem.RightClick()` が `NoClickablePointException` を投げると catch されずにテスト失敗していた問題を解消。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   - `FileOperationServiceTests` に `CopyItems` の単体テスト 3 件を追加。
 
 ### 修正
+- E2E ワークフローの Windows App SDK runtime 1.8 インストール手順を安定化（#101）。
+  - `windowsappruntimeinstall-x64.exe` を優先インストール方法として採用（winget の `0x80070002` エラー対策）。
+  - winget → msix 直接インストールの順でフォールバックする3段構成に変更。
 - E2E テスト `ExifEditorSaveAndReopenKeepsCoordinates` のフレーキー修正（#95）。
   - `OpenExifMenuForItemName` の catch 節に `NoClickablePointException` を追加。`listItem.RightClick()` が `NoClickablePointException` を投げると catch されずにテスト失敗していた問題を解消。
   - `TryScrollIntoView` / `WaitForElementClickable` ヘルパーを追加し、右クリック前にリスト項目を可視領域にスクロールして描画完了を待機するよう改善。

--- a/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
@@ -1045,6 +1045,7 @@ public class FileBrowserPaneViewModelTests
         public FileOperationResult CreateFolderResult { get; set; } = FileOperationResult.Success("result");
         public FileOperationResult RenameItemResult { get; set; } = FileOperationResult.Success("result");
         public FileOperationSummary MoveItemsResult { get; set; } = new(1, Array.Empty<FileOperationFailure>());
+        public FileOperationSummary CopyItemsResult { get; set; } = new(1, Array.Empty<FileOperationFailure>());
         public FileOperationSummary DeleteItemsResult { get; set; } = new(1, Array.Empty<FileOperationFailure>());
         public string? ParentPath { get; set; } = Path.GetTempPath();
         public bool RenameItemWasCalled { get; private set; }
@@ -1089,6 +1090,7 @@ public class FileBrowserPaneViewModelTests
         }
 
         public FileOperationSummary MoveItems(IReadOnlyList<PhotoListItem> items, string destinationFolder) => MoveItemsResult;
+        public FileOperationSummary CopyItems(IReadOnlyList<PhotoListItem> items, string destinationFolder) => CopyItemsResult;
         public FileOperationSummary DeleteItems(IReadOnlyList<PhotoListItem> items) => DeleteItemsResult;
     }
 

--- a/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
@@ -505,7 +505,7 @@ public sealed class FileOperationServiceTests
             Assert.False(summary.IsAllSuccess);
             Assert.Equal(1, summary.FailureCount);
             Assert.Equal(FileOperationError.AlreadyExists, summary.Failures[0].Error);
-            Assert.Equal("conflict", File.ReadAllText(conflictPath), "コピー先は上書きされていない");
+            Assert.Equal("conflict", File.ReadAllText(conflictPath));
         }
         finally
         {

--- a/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
@@ -459,6 +459,93 @@ public sealed class FileOperationServiceTests
     }
 
     // =========================================================
+    // CopyItems
+    // =========================================================
+
+    [Fact]
+    public void CopyItems_SingleFile_ReturnsSuccessCount1AndSourceRemains()
+    {
+        var tempDir = CreateTempTestDirectory();
+        var destDir = CreateTempTestDirectory();
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "photo.jpg");
+            File.WriteAllText(srcPath, "content");
+            var items = new List<PhotoListItem> { CreateFileItem(srcPath) };
+
+            var summary = _service.CopyItems(items, destDir);
+
+            Assert.Equal(1, summary.SuccessCount);
+            Assert.True(summary.IsAllSuccess);
+            Assert.True(File.Exists(Path.Combine(destDir, "photo.jpg")));
+            Assert.True(File.Exists(srcPath), "コピー元は残っている");
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+            CleanupTempDirectory(destDir);
+        }
+    }
+
+    [Fact]
+    public void CopyItems_TargetAlreadyExists_ReturnsAlreadyExistsError()
+    {
+        var tempDir = CreateTempTestDirectory();
+        var destDir = CreateTempTestDirectory();
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "photo.jpg");
+            var conflictPath = Path.Combine(destDir, "photo.jpg");
+            File.WriteAllText(srcPath, "original");
+            File.WriteAllText(conflictPath, "conflict");
+            var items = new List<PhotoListItem> { CreateFileItem(srcPath) };
+
+            var summary = _service.CopyItems(items, destDir);
+
+            Assert.False(summary.IsAllSuccess);
+            Assert.Equal(1, summary.FailureCount);
+            Assert.Equal(FileOperationError.AlreadyExists, summary.Failures[0].Error);
+            Assert.Equal("conflict", File.ReadAllText(conflictPath), "コピー先は上書きされていない");
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+            CleanupTempDirectory(destDir);
+        }
+    }
+
+    [Fact]
+    public void CopyItems_MultipleFiles_ReturnsSuccessCountForAll()
+    {
+        var tempDir = CreateTempTestDirectory();
+        var destDir = CreateTempTestDirectory();
+        try
+        {
+            var src1 = Path.Combine(tempDir, "a.jpg");
+            var src2 = Path.Combine(tempDir, "b.jpg");
+            File.WriteAllText(src1, "a");
+            File.WriteAllText(src2, "b");
+            var items = new List<PhotoListItem>
+            {
+                CreateFileItem(src1),
+                CreateFileItem(src2)
+            };
+
+            var summary = _service.CopyItems(items, destDir);
+
+            Assert.Equal(2, summary.SuccessCount);
+            Assert.True(summary.IsAllSuccess);
+            Assert.True(File.Exists(Path.Combine(destDir, "a.jpg")));
+            Assert.True(File.Exists(Path.Combine(destDir, "b.jpg")));
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+            CleanupTempDirectory(destDir);
+        }
+    }
+
+    // =========================================================
     // DeleteItems
     // =========================================================
 

--- a/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
@@ -515,6 +515,28 @@ public sealed class FileOperationServiceTests
     }
 
     [Fact]
+    public void CopyItems_FolderIntoDescendant_ReturnsDescendantPathError()
+    {
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            var subDir = Path.Combine(tempDir, "sub");
+            Directory.CreateDirectory(subDir);
+            var items = new List<PhotoListItem> { CreateFolderItem(tempDir) };
+
+            var summary = _service.CopyItems(items, subDir);
+
+            Assert.False(summary.IsAllSuccess);
+            Assert.Equal(1, summary.FailureCount);
+            Assert.Equal(FileOperationError.DescendantPath, summary.Failures[0].Error);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    [Fact]
     public void CopyItems_MultipleFiles_ReturnsSuccessCountForAll()
     {
         var tempDir = CreateTempTestDirectory();

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
@@ -562,6 +562,15 @@ internal sealed partial class FileBrowserPaneView : UserControl
             if (container is not null
                 && listView.ItemFromContainer(container) is PhotoListItem item)
             {
+                // 選択済み項目を右クリック → 複数選択状態を維持
+                // 未選択項目を右クリック → その項目のみ選択（Explorer 風）
+                if (!listView.SelectedItems.Contains(item))
+                {
+                    listView.SelectedItems.Clear();
+                    listView.SelectedItems.Add(item);
+                    ViewModel.UpdateSelection(new[] { item });
+                }
+
                 ViewModel.SelectedItem = item;
             }
             else
@@ -770,6 +779,116 @@ internal sealed partial class FileBrowserPaneView : UserControl
         }
     }
 
+    private void OnOpenInExplorerClicked(object sender, RoutedEventArgs e)
+    {
+        var item = ViewModel?.SelectedItem;
+        if (item is null)
+        {
+            return;
+        }
+
+        using var _ = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "explorer.exe",
+            Arguments = $"/select,\"{item.FilePath}\"",
+            UseShellExecute = true
+        });
+    }
+
+    private async void OnOpenFolderInExplorerClicked(object sender, RoutedEventArgs e)
+    {
+        var folderPath = ViewModel?.CurrentFolderPath;
+        if (string.IsNullOrWhiteSpace(folderPath))
+        {
+            return;
+        }
+
+        await Launcher.LaunchFolderPathAsync(folderPath);
+    }
+
+    private void OnCopyPathClicked(object sender, RoutedEventArgs e)
+    {
+        if (ViewModel is null || ViewModel.SelectedItems.Count == 0)
+        {
+            return;
+        }
+
+        var paths = string.Join(Environment.NewLine, ViewModel.SelectedItems.Select(item => item.FilePath));
+        var dataPackage = new DataPackage();
+        dataPackage.SetText(paths);
+        Clipboard.SetContent(dataPackage);
+    }
+
+    private async void OnOpenInGoogleMapsClicked(object sender, RoutedEventArgs e)
+    {
+        var metadata = ViewModel?.SelectedMetadata;
+        if (metadata?.HasValidLocation != true)
+        {
+            return;
+        }
+
+        var url = $"https://www.google.com/maps?q={metadata.Latitude!.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)},{metadata.Longitude!.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return;
+        }
+
+        try
+        {
+            await Launcher.LaunchUriAsync(uri);
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException
+            or System.Runtime.InteropServices.COMException
+            or ArgumentException)
+        {
+            AppLog.Error("Failed to launch Google Maps URL.", ex);
+        }
+    }
+
+    private async void OnCopyClicked(object sender, RoutedEventArgs e)
+    {
+        await CopySelectionAsyncCore().ConfigureAwait(true);
+    }
+
+    private async Task CopySelectionAsyncCore()
+    {
+        if (ViewModel is null || ViewModel.SelectedItems.Count == 0)
+        {
+            return;
+        }
+
+        var destination = await PickFolderAsync(PickerLocationId.PicturesLibrary).ConfigureAwait(true);
+        if (destination is null)
+        {
+            return;
+        }
+
+        var summary = await ViewModel.ExecuteCopyItemsToFolderAsync(ViewModel.SelectedItems, destination.Path)
+            .ConfigureAwait(true);
+        if (summary.HasFailures)
+        {
+            await ShowCopyOperationErrorDialogAsync(summary).ConfigureAwait(true);
+        }
+    }
+
+    private Task ShowCopyOperationErrorDialogAsync(FileOperationSummary summary)
+    {
+        var firstError = summary.Failures[0].Error;
+        var (title, message) = firstError switch
+        {
+            FileOperationError.AlreadyExists => (
+                LocalizationService.GetString("Dialog.AlreadyExists.Title"),
+                LocalizationService.GetString("Dialog.AlreadyExistsDestination.Detail")),
+            FileOperationError.Unauthorized => (
+                LocalizationService.GetString("Dialog.CopyFailed.Title"),
+                LocalizationService.GetString("Dialog.SeeLogDetail")),
+            _ => (
+                LocalizationService.GetString("Dialog.CopyFailed.Title"),
+                LocalizationService.GetString("Dialog.SeeLogDetail")),
+        };
+        return ShowMessageDialogAsync(title, message);
+    }
+
     private void OnDetailsSortClicked(object sender, RoutedEventArgs e)
     {
         if (ViewModel is null || sender is not Button button || button.Tag is not string tag)
@@ -904,6 +1023,38 @@ internal sealed partial class FileBrowserPaneView : UserControl
         };
         createFolder.Click += OnCreateFolderClicked;
 
+        var openInExplorerItem = new MenuFlyoutItem
+        {
+            Text = LocalizationService.GetString("Menu.OpenInExplorer"),
+            Icon = new SymbolIcon(Symbol.Document),
+            IsEnabled = viewModel.CanModifySelection
+        };
+        openInExplorerItem.Click += OnOpenInExplorerClicked;
+
+        var openFolderInExplorerItem = new MenuFlyoutItem
+        {
+            Text = LocalizationService.GetString("Menu.OpenFolderInExplorer"),
+            Icon = new SymbolIcon(Symbol.OpenWith),
+            IsEnabled = viewModel.CanOpenInExplorer
+        };
+        openFolderInExplorerItem.Click += OnOpenFolderInExplorerClicked;
+
+        var copyPathItem = new MenuFlyoutItem
+        {
+            Text = LocalizationService.GetString("Menu.CopyPath"),
+            Icon = new SymbolIcon(Symbol.Copy),
+            IsEnabled = viewModel.CanModifySelection
+        };
+        copyPathItem.Click += OnCopyPathClicked;
+
+        var openInGoogleMapsItem = new MenuFlyoutItem
+        {
+            Text = LocalizationService.GetString("Menu.OpenInGoogleMaps"),
+            Icon = new SymbolIcon(Symbol.Map),
+            IsEnabled = viewModel.CanOpenInGoogleMaps
+        };
+        openInGoogleMapsItem.Click += OnOpenInGoogleMapsClicked;
+
         var renameItem = new MenuFlyoutItem
         {
             Text = LocalizationService.GetString("Menu.Rename"),
@@ -928,6 +1079,14 @@ internal sealed partial class FileBrowserPaneView : UserControl
         };
         moveParentItem.Click += OnMoveToParentClicked;
 
+        var copyItem = new MenuFlyoutItem
+        {
+            Text = LocalizationService.GetString("Menu.Copy"),
+            Icon = new SymbolIcon(Symbol.Copy),
+            IsEnabled = viewModel.CanCopySelection
+        };
+        copyItem.Click += OnCopyClicked;
+
         var deleteItem = new MenuFlyoutItem
         {
             Text = LocalizationService.GetString("Menu.Delete"),
@@ -947,11 +1106,18 @@ internal sealed partial class FileBrowserPaneView : UserControl
 
         flyout.Items.Add(createFolder);
         flyout.Items.Add(new MenuFlyoutSeparator());
+        flyout.Items.Add(openInExplorerItem);
+        flyout.Items.Add(openFolderInExplorerItem);
+        flyout.Items.Add(copyPathItem);
+        flyout.Items.Add(openInGoogleMapsItem);
+        flyout.Items.Add(new MenuFlyoutSeparator());
         flyout.Items.Add(renameItem);
         flyout.Items.Add(moveItem);
         flyout.Items.Add(moveParentItem);
+        flyout.Items.Add(copyItem);
         flyout.Items.Add(new MenuFlyoutSeparator());
         flyout.Items.Add(editExifItem);
+        flyout.Items.Add(new MenuFlyoutSeparator());
         flyout.Items.Add(deleteItem);
 
         return flyout;

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -177,6 +177,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
                 OnPropertyChanged(nameof(CanNavigateUp));
                 OnPropertyChanged(nameof(CanCreateFolder));
                 OnPropertyChanged(nameof(CanMoveToParentSelection));
+                OnPropertyChanged(nameof(CanOpenInExplorer));
                 UpdateNavigationCommands();
                 RaiseFileOperationCommandCanExecuteChanged();
                 UpdateStatusBar();
@@ -400,6 +401,8 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
                 OnPropertyChanged(nameof(CanRenameSelection));
                 OnPropertyChanged(nameof(CanMoveToParentSelection));
                 OnPropertyChanged(nameof(CanEditExif));
+                OnPropertyChanged(nameof(CanCopySelection));
+                OnPropertyChanged(nameof(CanOpenInGoogleMaps));
                 RaiseFileOperationCommandCanExecuteChanged();
                 (EditExifCommand as RelayCommand)?.RaiseCanExecuteChanged();
             }
@@ -417,6 +420,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
             {
                 OnSelectedItemChanged();
                 OnPropertyChanged(nameof(CanEditExif));
+                OnPropertyChanged(nameof(CanOpenInGoogleMaps));
                 (EditExifCommand as RelayCommand)?.RaiseCanExecuteChanged();
             }
         }
@@ -528,6 +532,11 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
            && !string.IsNullOrWhiteSpace(CurrentFolderPath)
            && _fileOperationService.GetParentPath(CurrentFolderPath) is not null;
     public bool CanEditExif => SelectedCount == 1 && IsJpegFile(SelectedItem);
+    public bool CanCopySelection => SelectedCount > 0;
+    public bool CanOpenInExplorer => !string.IsNullOrWhiteSpace(CurrentFolderPath);
+    public bool CanOpenInGoogleMaps => SelectedCount == 1 && SelectedItem?.HasLocation == true;
+
+    internal PhotoMetadata? SelectedMetadata => _selectedMetadata;
 
     public string NameSortIndicator => GetSortIndicator(FileSortColumn.Name);
     public string TakenAtSortIndicator => GetSortIndicator(FileSortColumn.TakenAt);
@@ -636,6 +645,13 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         }
 
         return summary;
+    }
+
+    internal Task<FileOperationSummary> ExecuteCopyItemsToFolderAsync(
+        IReadOnlyList<PhotoListItem> items, string destinationFolder)
+    {
+        var summary = _fileOperationService.CopyItems(items, destinationFolder);
+        return Task.FromResult(summary);
     }
 
     internal async Task<FileOperationSummary> ExecuteMoveToParentAsync()
@@ -1216,10 +1232,23 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
             ? LocalizationService.GetString("StatusBar.NoFolderSelected")
             : CurrentFolderPath;
         var itemCount = Items.Count;
-        var selectedLabel = SelectedItem is null
-            ? null
-            : LocalizationService.Format("StatusBar.Selected", SelectedItem.FileName);
-        var resolutionLabel = SelectedItem is null || SelectedItem.IsFolder ? null : SelectedItem.ResolutionText;
+        string? selectedLabel;
+        if (SelectedCount == 0)
+        {
+            selectedLabel = null;
+        }
+        else if (SelectedCount == 1 && SelectedItem is not null)
+        {
+            selectedLabel = LocalizationService.Format("StatusBar.Selected", SelectedItem.FileName);
+        }
+        else
+        {
+            selectedLabel = LocalizationService.Format("StatusBar.SelectedMultiple", SelectedCount);
+        }
+
+        var resolutionLabel = SelectedCount == 1 && SelectedItem is not null && !SelectedItem.IsFolder
+            ? SelectedItem.ResolutionText
+            : null;
 
         var itemsLabel = LocalizationService.Format("StatusBar.Items", itemCount);
         var statusText = selectedLabel is null
@@ -1236,7 +1265,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 
     private void UpdateStatusBarLocation()
     {
-        if (SelectedItem is null || SelectedItem.IsFolder)
+        if (SelectedCount != 1 || SelectedItem is null || SelectedItem.IsFolder)
         {
             StatusBarLocationVisibility = Visibility.Collapsed;
             StatusBarLocationSymbol = Symbol.Map;

--- a/PhotoGeoExplorer/Services/FileOperationService.cs
+++ b/PhotoGeoExplorer/Services/FileOperationService.cs
@@ -145,6 +145,12 @@ internal sealed class FileOperationService : IFileOperationService
             var sourcePath = item.FilePath;
             var targetPath = Path.Combine(destinationFolder, item.FileName);
 
+            if (item.IsFolder && IsDescendantPath(sourcePath, destinationFolder))
+            {
+                failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.DescendantPath));
+                break;
+            }
+
             if (ItemExistsAtPath(targetPath))
             {
                 failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.AlreadyExists));

--- a/PhotoGeoExplorer/Services/FileOperationService.cs
+++ b/PhotoGeoExplorer/Services/FileOperationService.cs
@@ -135,6 +135,66 @@ internal sealed class FileOperationService : IFileOperationService
         }
     }
 
+    public FileOperationSummary CopyItems(IReadOnlyList<PhotoListItem> items, string destinationFolder)
+    {
+        var successCount = 0;
+        var failures = new List<FileOperationFailure>();
+
+        foreach (var item in items)
+        {
+            var sourcePath = item.FilePath;
+            var targetPath = Path.Combine(destinationFolder, item.FileName);
+
+            if (ItemExistsAtPath(targetPath))
+            {
+                failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.AlreadyExists));
+                break;
+            }
+
+            try
+            {
+                if (item.IsFolder)
+                {
+                    CopyDirectory(sourcePath, targetPath);
+                }
+                else
+                {
+                    File.Copy(sourcePath, targetPath, overwrite: false);
+                }
+
+                successCount++;
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException)
+            {
+                AppLog.Error($"Failed to copy item: {sourcePath}", ex);
+                failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.Unauthorized));
+                break;
+            }
+            catch (Exception ex) when (ex is IOException or NotSupportedException or ArgumentException or PathTooLongException)
+            {
+                AppLog.Error($"Failed to copy item: {sourcePath}", ex);
+                failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.IoError));
+                break;
+            }
+        }
+
+        return new FileOperationSummary(successCount, failures);
+    }
+
+    private static void CopyDirectory(string sourcePath, string targetPath)
+    {
+        Directory.CreateDirectory(targetPath);
+        foreach (var file in Directory.GetFiles(sourcePath))
+        {
+            File.Copy(file, Path.Combine(targetPath, Path.GetFileName(file)), overwrite: false);
+        }
+
+        foreach (var dir in Directory.GetDirectories(sourcePath))
+        {
+            CopyDirectory(dir, Path.Combine(targetPath, Path.GetFileName(dir)));
+        }
+    }
+
     public FileOperationSummary MoveItems(IReadOnlyList<PhotoListItem> items, string destinationFolder)
     {
         var successCount = 0;

--- a/PhotoGeoExplorer/Services/IFileOperationService.cs
+++ b/PhotoGeoExplorer/Services/IFileOperationService.cs
@@ -22,5 +22,6 @@ internal interface IFileOperationService
 
     // ファイル操作（複数件）
     FileOperationSummary MoveItems(IReadOnlyList<PhotoListItem> items, string destinationFolder);
+    FileOperationSummary CopyItems(IReadOnlyList<PhotoListItem> items, string destinationFolder);
     FileOperationSummary DeleteItems(IReadOnlyList<PhotoListItem> items);
 }

--- a/PhotoGeoExplorer/Strings/en-US/Resources.resw
+++ b/PhotoGeoExplorer/Strings/en-US/Resources.resw
@@ -522,6 +522,9 @@
   <data name="StatusBar.Selected" xml:space="preserve">
     <value>Selected: {0}</value>
   </data>
+  <data name="StatusBar.SelectedMultiple" xml:space="preserve">
+    <value>{0} items selected</value>
+  </data>
   <data name="StatusBar.Items" xml:space="preserve">
     <value>{0} items</value>
   </data>
@@ -704,8 +707,26 @@
   <data name="Menu.MoveToParent" xml:space="preserve">
     <value>Move to parent</value>
   </data>
+  <data name="Menu.Copy" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="Menu.CopyPath" xml:space="preserve">
+    <value>Copy Path</value>
+  </data>
+  <data name="Menu.OpenInExplorer" xml:space="preserve">
+    <value>Show in Explorer</value>
+  </data>
+  <data name="Menu.OpenFolderInExplorer" xml:space="preserve">
+    <value>Open in Explorer</value>
+  </data>
+  <data name="Menu.OpenInGoogleMaps" xml:space="preserve">
+    <value>Open in Google Maps</value>
+  </data>
   <data name="Menu.Delete" xml:space="preserve">
     <value>Delete</value>
+  </data>
+  <data name="Dialog.CopyFailed.Title" xml:space="preserve">
+    <value>Copy failed</value>
   </data>
   <data name="Dialog.MoveFailed.Title" xml:space="preserve">
     <value>Move failed</value>

--- a/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
+++ b/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
@@ -522,6 +522,9 @@
   <data name="StatusBar.Selected" xml:space="preserve">
     <value>選択: {0}</value>
   </data>
+  <data name="StatusBar.SelectedMultiple" xml:space="preserve">
+    <value>{0} 件を選択中</value>
+  </data>
   <data name="StatusBar.Items" xml:space="preserve">
     <value>{0} 件</value>
   </data>
@@ -704,8 +707,26 @@
   <data name="Menu.MoveToParent" xml:space="preserve">
     <value>親フォルダーへ移動</value>
   </data>
+  <data name="Menu.Copy" xml:space="preserve">
+    <value>コピー</value>
+  </data>
+  <data name="Menu.CopyPath" xml:space="preserve">
+    <value>パスをコピー</value>
+  </data>
+  <data name="Menu.OpenInExplorer" xml:space="preserve">
+    <value>ファイルの場所を開く</value>
+  </data>
+  <data name="Menu.OpenFolderInExplorer" xml:space="preserve">
+    <value>Explorer で開く</value>
+  </data>
+  <data name="Menu.OpenInGoogleMaps" xml:space="preserve">
+    <value>Google Maps で開く</value>
+  </data>
   <data name="Menu.Delete" xml:space="preserve">
     <value>削除</value>
+  </data>
+  <data name="Dialog.CopyFailed.Title" xml:space="preserve">
+    <value>コピーに失敗しました</value>
   </data>
   <data name="Dialog.MoveFailed.Title" xml:space="preserve">
     <value>移動に失敗しました</value>


### PR DESCRIPTION
## 概要

`windows-latest` が `windows-2025-vs2026` へ切り替わったことで、winget による Windows App SDK runtime 1.8 のインストールが `0x80070002 (The system cannot find the file specified)` で失敗するケースが発生している問題を修正します。

Closes #101

## 変更内容

`Ensure Windows App SDK runtime` ステップのインストール戦略を以下の3段フォールバック構成に変更：

1. **公式インストーラー exe**（`windowsappruntimeinstall-x64.exe`）を優先 — winget を経由しない最も安定した方法
2. **winget**（フォールバック） — インストーラー exe が失敗した場合
3. **msix 直接インストール**（最終フォールバック） — いずれも失敗した場合

## 検証方法

- PR #100（feat/issue-87）で E2E ワークフローが3回連続でこのステップで失敗していた
- 本 PR をマージ後、PR #100 の E2E が通ることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)