### PR TITLE
fix(e2e): コンテキストメニュー取得のフレーキーを追加修正 (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   - `FileOperationServiceTests` に `CopyItems` の単体テスト 3 件を追加。
 
 ### 修正
+- E2E テスト コンテキストメニュー取得のフレーキーを追加修正（#95 継続）。
+  - `WaitForListItems` を先頭アイテムだけでなく指定件数すべての BoundingRectangle が有効になるまで待機するよう強化（タイムアウト 5s → 8s）。
+  - `WaitForElementClickable` のタイムアウトを 3s → 8s に延長し、CI ランナー描画遅延への耐性を向上。
+  - `TryWaitForEditExifMenuItem` の各試行タイムアウトを 3s/2s → 5s/4s に延長。
 - E2E ワークフローの Windows App SDK runtime 1.8 インストール手順を安定化（#101）。
   - `windowsappruntimeinstall-x64.exe` を優先インストール方法として採用（winget の `0x80070002` エラー対策）。
   - winget → msix 直接インストールの順でフォールバックする3段構成に変更。

--- a/PhotoGeoExplorer.E2E/AppE2ETests.cs
+++ b/PhotoGeoExplorer.E2E/AppE2ETests.cs
@@ -216,21 +216,24 @@ public sealed class AppE2ETests
             timeout: TimeSpan.FromSeconds(20),
             interval: TimeSpan.FromMilliseconds(200));
 
-        // アイテムが画面に描画されるまで安定化を待つ（CI ランナーの描画遅延対策）
+        // 先頭アイテムだけでなく minimumCount 件すべての描画完了を待つ（CI ランナーの描画遅延対策）
         Retry.WhileTrue(
             () =>
             {
-                var firstItem = list.Items.FirstOrDefault();
-                if (firstItem is null)
+                var items = list.Items;
+                if (items.Length < minimumCount)
                 {
                     return true;
                 }
 
-                var width = SafeGet(() => firstItem.BoundingRectangle.Width, 0d);
-                var height = SafeGet(() => firstItem.BoundingRectangle.Height, 0d);
-                return width <= 1 || height <= 1;
+                return items.Take(minimumCount).Any(item =>
+                {
+                    var width = SafeGet(() => item.BoundingRectangle.Width, 0d);
+                    var height = SafeGet(() => item.BoundingRectangle.Height, 0d);
+                    return width <= 1 || height <= 1;
+                });
             },
-            timeout: TimeSpan.FromSeconds(5),
+            timeout: TimeSpan.FromSeconds(8),
             interval: TimeSpan.FromMilliseconds(100),
             throwOnTimeout: false);
     }
@@ -320,7 +323,7 @@ public sealed class AppE2ETests
                 ClickElementCenter(listItem);
 
                 Keyboard.Type(VirtualKeyShort.APPS);
-                var byAppsKey = TryWaitForEditExifMenuItem(window, automation, processId, timeout: TimeSpan.FromSeconds(3));
+                var byAppsKey = TryWaitForEditExifMenuItem(window, automation, processId, timeout: TimeSpan.FromSeconds(5));
                 if (byAppsKey is not null)
                 {
                     return byAppsKey;
@@ -329,28 +332,28 @@ public sealed class AppE2ETests
                 // listItem.RightClick() は NoClickablePointException を投げる可能性があるため
                 // 安全な RightClickElementCenter を使用する
                 RightClickElementCenter(listItem);
-                var byRightClick = TryWaitForEditExifMenuItem(window, automation, processId, timeout: TimeSpan.FromSeconds(3));
+                var byRightClick = TryWaitForEditExifMenuItem(window, automation, processId, timeout: TimeSpan.FromSeconds(5));
                 if (byRightClick is not null)
                 {
                     return byRightClick;
                 }
 
                 RightClickElementCenter(listItem);
-                var byMouseRightClick = TryWaitForEditExifMenuItem(window, automation, processId, timeout: TimeSpan.FromSeconds(3));
+                var byMouseRightClick = TryWaitForEditExifMenuItem(window, automation, processId, timeout: TimeSpan.FromSeconds(5));
                 if (byMouseRightClick is not null)
                 {
                     return byMouseRightClick;
                 }
 
                 list.RightClick();
-                var byListRightClick = TryWaitForEditExifMenuItem(window, automation, processId, timeout: TimeSpan.FromSeconds(2));
+                var byListRightClick = TryWaitForEditExifMenuItem(window, automation, processId, timeout: TimeSpan.FromSeconds(4));
                 if (byListRightClick is not null)
                 {
                     return byListRightClick;
                 }
 
                 Keyboard.TypeSimultaneously(VirtualKeyShort.SHIFT, VirtualKeyShort.F10);
-                var byShiftF10 = TryWaitForEditExifMenuItem(window, automation, processId, timeout: TimeSpan.FromSeconds(2));
+                var byShiftF10 = TryWaitForEditExifMenuItem(window, automation, processId, timeout: TimeSpan.FromSeconds(4));
                 if (byShiftF10 is not null)
                 {
                     return byShiftF10;
@@ -416,7 +419,7 @@ public sealed class AppE2ETests
                 var height = SafeGet(() => element.BoundingRectangle.Height, 0d);
                 return width <= 1 || height <= 1;
             },
-            timeout: TimeSpan.FromSeconds(3),
+            timeout: TimeSpan.FromSeconds(8),
             interval: TimeSpan.FromMilliseconds(100),
             throwOnTimeout: false);
     }


### PR DESCRIPTION
## 概要

`ExifEditorSaveAndReopenKeepsCoordinates` / `ExifEditorContextMenuAndDateToggleWorks` で `sample.jpg` の右クリックメニューが取得できずタイムアウトするフレーキーを修正します。

## 根本原因

`WaitForListItems` が先頭アイテム（folder）の BoundingRectangle のみ描画確認するため、2番目のアイテム（sample.jpg）がまだ描画されていない状態で処理が進んでいた。

`WaitForElementClickable` のタイムアウト（3秒）が CI ランナーの描画遅延に対して不十分なケースがあり、`RightClickElementCenter` の `width <= 1` ガードで早期リターンしてクリックが届かなかった。

## 変更内容

| 変更箇所 | 変更前 | 変更後 |
|---------|--------|--------|
| `WaitForListItems` 描画確認 | 先頭アイテムのみ | minimumCount 件すべて（timeout 8s） |
| `WaitForElementClickable` timeout | 3s | 8s |
| `TryWaitForEditExifMenuItem` timeout | 3s / 2s | 5s / 4s |

## 検証方法

- CI で E2E が安定して pass することを確認
- PR #100 の E2E フレーキー再現（`26348396996`）がこの修正で解消されるかを CI で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)