### PR TITLE
feat(file-op): ファイル移動の上書き確認・プログレス・キャンセル・スキップ対応 (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 ## [Unreleased]
 
 ### 追加
+- ファイル移動操作の強化（#69）
+  - 移動先に同名の項目がある場合に、上書き / スキップ / すべて上書き / すべてスキップ / 中止 の 5 択ダイアログを表示。
+  - 移動中はステータスバーに「移動中… N/M 件」をリアルタイム表示（300ms 間隔ポーリング）。
+  - 移動完了後に「移動完了: 成功 N 件、スキップ M 件、失敗 K 件」をステータスバーに表示。
+  - ステータスバー右端に「中止」ボタンを追加。移動中のみ表示し、クリックで `CancellationToken` をキャンセル。
+  - `IFileOperationService.MoveItemsAsync` を新規追加（非同期競合コールバック・`IProgress<int>`・`CancellationToken` 対応）。
+  - `ConflictResolution` enum を追加（`Overwrite`, `Skip`, `Cancel`, `OverwriteAll`, `SkipAll`）。
+  - `FileOperationError.Cancelled` を追加。
+  - `FileOperationSummary` に `SkipCount` を追加。
+  - `MoveItemsAsync` の単体テスト 5 件を追加。
 - Explorer 風の複数選択と右クリック操作（#87）
   - 右クリック選択挙動を Explorer 風に変更（選択済み項目→複数選択を維持 / 未選択項目→その項目のみ選択）。
   - ステータスバーに複数選択時の件数表示（「N 件を選択中」）を追加。複数選択中はステータスバーの GPS アイコンを非表示に統一。

--- a/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using PhotoGeoExplorer.Models;
@@ -883,7 +884,7 @@ public class FileBrowserPaneViewModelTests
     {
         var failure = new FileOperationFailure("path", "photo.jpg", FileOperationError.AlreadyExists);
         using var vm = CreateViewModelWithFakes(out var fakePaneService, out var stubOp);
-        stubOp.MoveItemsResult = new FileOperationSummary(0, new[] { failure });
+        stubOp.MoveItemsResult = new FileOperationSummary(0, 0, new[] { failure });
 
         var summary = await vm.ExecuteMoveItemsToFolderAsync(new List<PhotoListItem>(), Path.GetTempPath());
 
@@ -900,7 +901,7 @@ public class FileBrowserPaneViewModelTests
         {
             var failure = new FileOperationFailure("path2", "file2.jpg", FileOperationError.AlreadyExists);
             using var vm = CreateViewModelWithFakes(out var fakePaneService, out var stubOp);
-            stubOp.MoveItemsResult = new FileOperationSummary(1, new[] { failure });
+            stubOp.MoveItemsResult = new FileOperationSummary(1, 0, new[] { failure });
             await vm.LoadFolderAsync(tempDir).ConfigureAwait(true);
             var before = fakePaneService.LoadFolderCallCount;
 
@@ -924,7 +925,7 @@ public class FileBrowserPaneViewModelTests
     {
         var failure = new FileOperationFailure("path", "locked.jpg", FileOperationError.IoError);
         using var vm = CreateViewModelWithFakes(out var fakePaneService, out var stubOp);
-        stubOp.DeleteItemsResult = new FileOperationSummary(0, new[] { failure });
+        stubOp.DeleteItemsResult = new FileOperationSummary(0, 0, new[] { failure });
 
         var summary = await vm.ExecuteDeleteItemsAsync(new List<PhotoListItem>());
 
@@ -940,7 +941,7 @@ public class FileBrowserPaneViewModelTests
         try
         {
             using var vm = CreateViewModelWithFakes(out var fakePaneService, out var stubOp);
-            stubOp.DeleteItemsResult = new FileOperationSummary(1, Array.Empty<FileOperationFailure>());
+            stubOp.DeleteItemsResult = new FileOperationSummary(1, 0, Array.Empty<FileOperationFailure>());
             await vm.LoadFolderAsync(tempDir).ConfigureAwait(true);
             var before = fakePaneService.LoadFolderCallCount;
 
@@ -1044,9 +1045,9 @@ public class FileBrowserPaneViewModelTests
     {
         public FileOperationResult CreateFolderResult { get; set; } = FileOperationResult.Success("result");
         public FileOperationResult RenameItemResult { get; set; } = FileOperationResult.Success("result");
-        public FileOperationSummary MoveItemsResult { get; set; } = new(1, Array.Empty<FileOperationFailure>());
-        public FileOperationSummary CopyItemsResult { get; set; } = new(1, Array.Empty<FileOperationFailure>());
-        public FileOperationSummary DeleteItemsResult { get; set; } = new(1, Array.Empty<FileOperationFailure>());
+        public FileOperationSummary MoveItemsResult { get; set; } = new(1, 0, Array.Empty<FileOperationFailure>());
+        public FileOperationSummary CopyItemsResult { get; set; } = new(1, 0, Array.Empty<FileOperationFailure>());
+        public FileOperationSummary DeleteItemsResult { get; set; } = new(1, 0, Array.Empty<FileOperationFailure>());
         public string? ParentPath { get; set; } = Path.GetTempPath();
         public bool RenameItemWasCalled { get; private set; }
 
@@ -1090,6 +1091,12 @@ public class FileBrowserPaneViewModelTests
         }
 
         public FileOperationSummary MoveItems(IReadOnlyList<PhotoListItem> items, string destinationFolder) => MoveItemsResult;
+        public Task<FileOperationSummary> MoveItemsAsync(
+            IReadOnlyList<PhotoListItem> items,
+            string destinationFolder,
+            Func<string, bool, Task<ConflictResolution>> resolveConflictAsync,
+            IProgress<int>? progress = null,
+            CancellationToken cancellationToken = default) => Task.FromResult(MoveItemsResult);
         public FileOperationSummary CopyItems(IReadOnlyList<PhotoListItem> items, string destinationFolder) => CopyItemsResult;
         public FileOperationSummary DeleteItems(IReadOnlyList<PhotoListItem> items) => DeleteItemsResult;
     }

--- a/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
@@ -926,12 +926,10 @@ public class FileBrowserPaneViewModelTests
             stubOp.MoveItemsResult = new FileOperationSummary(1, 0, Array.Empty<FileOperationFailure>());
             await vm.LoadFolderAsync(tempDir).ConfigureAwait(true);
             var before = fakePaneService.LoadFolderCallCount;
-            var callbackCalled = false;
-
             var summary = await vm.ExecuteMoveItemsToFolderAsync(
                 new List<PhotoListItem>(),
                 Path.GetTempPath(),
-                (_, _) => { callbackCalled = true; return Task.FromResult(ConflictResolution.Skip); });
+                (_, _) => Task.FromResult(ConflictResolution.Skip));
 
             Assert.Equal(1, summary.SuccessCount);
             Assert.Equal(before + 1, fakePaneService.LoadFolderCallCount);

--- a/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
@@ -916,6 +916,32 @@ public class FileBrowserPaneViewModelTests
         }
     }
 
+    [Fact]
+    public async Task ExecuteMoveItemsToFolderAsync_WithConflictCallback_UsesAsyncPath()
+    {
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            using var vm = CreateViewModelWithFakes(out var fakePaneService, out var stubOp);
+            stubOp.MoveItemsResult = new FileOperationSummary(1, 0, Array.Empty<FileOperationFailure>());
+            await vm.LoadFolderAsync(tempDir).ConfigureAwait(true);
+            var before = fakePaneService.LoadFolderCallCount;
+            var callbackCalled = false;
+
+            var summary = await vm.ExecuteMoveItemsToFolderAsync(
+                new List<PhotoListItem>(),
+                Path.GetTempPath(),
+                (_, _) => { callbackCalled = true; return Task.FromResult(ConflictResolution.Skip); });
+
+            Assert.Equal(1, summary.SuccessCount);
+            Assert.Equal(before + 1, fakePaneService.LoadFolderCallCount);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
     // =========================================================
     // ExecuteDeleteItemsAsync
     // =========================================================

--- a/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
@@ -472,7 +472,7 @@ public sealed class FileOperationServiceTests
         try
         {
             var srcPath = Path.Combine(tempDir, "photo.jpg");
-            File.WriteAllText(srcPath, "content");
+            await File.WriteAllTextAsync(srcPath, "content");
             var items = new List<PhotoListItem> { CreateFileItem(srcPath) };
 
             var summary = await _service.MoveItemsAsync(items, destDir, (_, _) => Task.FromResult(ConflictResolution.Skip));
@@ -498,15 +498,15 @@ public sealed class FileOperationServiceTests
         {
             var srcPath = Path.Combine(tempDir, "photo.jpg");
             var conflictPath = Path.Combine(destDir, "photo.jpg");
-            File.WriteAllText(srcPath, "original");
-            File.WriteAllText(conflictPath, "conflict");
+            await File.WriteAllTextAsync(srcPath, "original");
+            await File.WriteAllTextAsync(conflictPath, "conflict");
             var items = new List<PhotoListItem> { CreateFileItem(srcPath) };
 
             var summary = await _service.MoveItemsAsync(items, destDir, (_, _) => Task.FromResult(ConflictResolution.Skip));
 
             Assert.Equal(0, summary.SuccessCount);
             Assert.Equal(1, summary.SkipCount);
-            Assert.Equal("conflict", File.ReadAllText(conflictPath));
+            Assert.Equal("conflict", await File.ReadAllTextAsync(conflictPath));
         }
         finally
         {
@@ -524,15 +524,15 @@ public sealed class FileOperationServiceTests
         {
             var srcPath = Path.Combine(tempDir, "photo.jpg");
             var conflictPath = Path.Combine(destDir, "photo.jpg");
-            File.WriteAllText(srcPath, "original");
-            File.WriteAllText(conflictPath, "conflict");
+            await File.WriteAllTextAsync(srcPath, "original");
+            await File.WriteAllTextAsync(conflictPath, "conflict");
             var items = new List<PhotoListItem> { CreateFileItem(srcPath) };
 
             var summary = await _service.MoveItemsAsync(items, destDir, (_, _) => Task.FromResult(ConflictResolution.Overwrite));
 
             Assert.Equal(1, summary.SuccessCount);
             Assert.Equal(0, summary.SkipCount);
-            Assert.Equal("original", File.ReadAllText(conflictPath));
+            Assert.Equal("original", await File.ReadAllTextAsync(conflictPath));
         }
         finally
         {
@@ -550,8 +550,8 @@ public sealed class FileOperationServiceTests
         {
             var srcPath = Path.Combine(tempDir, "photo.jpg");
             var conflictPath = Path.Combine(destDir, "photo.jpg");
-            File.WriteAllText(srcPath, "original");
-            File.WriteAllText(conflictPath, "conflict");
+            await File.WriteAllTextAsync(srcPath, "original");
+            await File.WriteAllTextAsync(conflictPath, "conflict");
             var items = new List<PhotoListItem> { CreateFileItem(srcPath) };
 
             var summary = await _service.MoveItemsAsync(items, destDir, (_, _) => Task.FromResult(ConflictResolution.Cancel));
@@ -576,11 +576,11 @@ public sealed class FileOperationServiceTests
         {
             var src1 = Path.Combine(tempDir, "a.jpg");
             var src2 = Path.Combine(tempDir, "b.jpg");
-            File.WriteAllText(src1, "a");
-            File.WriteAllText(src2, "b");
+            await File.WriteAllTextAsync(src1, "a");
+            await File.WriteAllTextAsync(src2, "b");
             var items = new List<PhotoListItem> { CreateFileItem(src1), CreateFileItem(src2) };
             using var cts = new CancellationTokenSource();
-            cts.Cancel();
+            await cts.CancelAsync();
 
             var summary = await _service.MoveItemsAsync(items, destDir, (_, _) => Task.FromResult(ConflictResolution.Skip), cancellationToken: cts.Token);
 

--- a/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using PhotoGeoExplorer.Models;
 using PhotoGeoExplorer.Services;
 using PhotoGeoExplorer.ViewModels;
@@ -450,6 +452,140 @@ public sealed class FileOperationServiceTests
             Assert.True(summary.HasFailures);
             Assert.Equal(1, summary.FailureCount);
             Assert.Equal(FileOperationError.IoError, summary.Failures[0].Error);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+            CleanupTempDirectory(destDir);
+        }
+    }
+
+    // =========================================================
+    // MoveItemsAsync
+    // =========================================================
+
+    [Fact]
+    public async Task MoveItemsAsync_SingleFile_ReturnsSuccessCount1()
+    {
+        var tempDir = CreateTempTestDirectory();
+        var destDir = CreateTempTestDirectory();
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "photo.jpg");
+            File.WriteAllText(srcPath, "content");
+            var items = new List<PhotoListItem> { CreateFileItem(srcPath) };
+
+            var summary = await _service.MoveItemsAsync(items, destDir, (_, _) => Task.FromResult(ConflictResolution.Skip));
+
+            Assert.Equal(1, summary.SuccessCount);
+            Assert.Equal(0, summary.SkipCount);
+            Assert.True(summary.IsAllSuccess);
+            Assert.True(File.Exists(Path.Combine(destDir, "photo.jpg")));
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+            CleanupTempDirectory(destDir);
+        }
+    }
+
+    [Fact]
+    public async Task MoveItemsAsync_Conflict_Skip_ReturnsSkipCount1()
+    {
+        var tempDir = CreateTempTestDirectory();
+        var destDir = CreateTempTestDirectory();
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "photo.jpg");
+            var conflictPath = Path.Combine(destDir, "photo.jpg");
+            File.WriteAllText(srcPath, "original");
+            File.WriteAllText(conflictPath, "conflict");
+            var items = new List<PhotoListItem> { CreateFileItem(srcPath) };
+
+            var summary = await _service.MoveItemsAsync(items, destDir, (_, _) => Task.FromResult(ConflictResolution.Skip));
+
+            Assert.Equal(0, summary.SuccessCount);
+            Assert.Equal(1, summary.SkipCount);
+            Assert.Equal("conflict", File.ReadAllText(conflictPath));
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+            CleanupTempDirectory(destDir);
+        }
+    }
+
+    [Fact]
+    public async Task MoveItemsAsync_Conflict_Overwrite_ReplacesFile()
+    {
+        var tempDir = CreateTempTestDirectory();
+        var destDir = CreateTempTestDirectory();
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "photo.jpg");
+            var conflictPath = Path.Combine(destDir, "photo.jpg");
+            File.WriteAllText(srcPath, "original");
+            File.WriteAllText(conflictPath, "conflict");
+            var items = new List<PhotoListItem> { CreateFileItem(srcPath) };
+
+            var summary = await _service.MoveItemsAsync(items, destDir, (_, _) => Task.FromResult(ConflictResolution.Overwrite));
+
+            Assert.Equal(1, summary.SuccessCount);
+            Assert.Equal(0, summary.SkipCount);
+            Assert.Equal("original", File.ReadAllText(conflictPath));
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+            CleanupTempDirectory(destDir);
+        }
+    }
+
+    [Fact]
+    public async Task MoveItemsAsync_Conflict_Cancel_StopsAndReturnsCancelledError()
+    {
+        var tempDir = CreateTempTestDirectory();
+        var destDir = CreateTempTestDirectory();
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "photo.jpg");
+            var conflictPath = Path.Combine(destDir, "photo.jpg");
+            File.WriteAllText(srcPath, "original");
+            File.WriteAllText(conflictPath, "conflict");
+            var items = new List<PhotoListItem> { CreateFileItem(srcPath) };
+
+            var summary = await _service.MoveItemsAsync(items, destDir, (_, _) => Task.FromResult(ConflictResolution.Cancel));
+
+            Assert.Equal(0, summary.SuccessCount);
+            Assert.Equal(1, summary.FailureCount);
+            Assert.Equal(FileOperationError.Cancelled, summary.Failures[0].Error);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+            CleanupTempDirectory(destDir);
+        }
+    }
+
+    [Fact]
+    public async Task MoveItemsAsync_CancellationToken_StopsEarly()
+    {
+        var tempDir = CreateTempTestDirectory();
+        var destDir = CreateTempTestDirectory();
+        try
+        {
+            var src1 = Path.Combine(tempDir, "a.jpg");
+            var src2 = Path.Combine(tempDir, "b.jpg");
+            File.WriteAllText(src1, "a");
+            File.WriteAllText(src2, "b");
+            var items = new List<PhotoListItem> { CreateFileItem(src1), CreateFileItem(src2) };
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var summary = await _service.MoveItemsAsync(items, destDir, (_, _) => Task.FromResult(ConflictResolution.Skip), cancellationToken: cts.Token);
+
+            Assert.Equal(1, summary.FailureCount);
+            Assert.Equal(FileOperationError.Cancelled, summary.Failures[0].Error);
         }
         finally
         {

--- a/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
@@ -594,6 +594,103 @@ public sealed class FileOperationServiceTests
         }
     }
 
+    [Fact]
+    public async Task MoveItemsAsync_Conflict_OverwriteAll_OverwritesAllSubsequentItems()
+    {
+        var tempDir = CreateTempTestDirectory();
+        var destDir = CreateTempTestDirectory();
+        try
+        {
+            var src1 = Path.Combine(tempDir, "a.jpg");
+            var src2 = Path.Combine(tempDir, "b.jpg");
+            var dest1 = Path.Combine(destDir, "a.jpg");
+            var dest2 = Path.Combine(destDir, "b.jpg");
+            await File.WriteAllTextAsync(src1, "src-a");
+            await File.WriteAllTextAsync(src2, "src-b");
+            await File.WriteAllTextAsync(dest1, "old-a");
+            await File.WriteAllTextAsync(dest2, "old-b");
+            var items = new List<PhotoListItem> { CreateFileItem(src1), CreateFileItem(src2) };
+            var callCount = 0;
+
+            var summary = await _service.MoveItemsAsync(items, destDir, (_, _) =>
+            {
+                callCount++;
+                return Task.FromResult(ConflictResolution.OverwriteAll);
+            });
+
+            Assert.Equal(2, summary.SuccessCount);
+            Assert.Equal(0, summary.SkipCount);
+            Assert.Equal(1, callCount); // OverwriteAll → 2件目はコールバック不要
+            Assert.Equal("src-a", await File.ReadAllTextAsync(dest1));
+            Assert.Equal("src-b", await File.ReadAllTextAsync(dest2));
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+            CleanupTempDirectory(destDir);
+        }
+    }
+
+    [Fact]
+    public async Task MoveItemsAsync_Conflict_SkipAll_SkipsAllSubsequentItems()
+    {
+        var tempDir = CreateTempTestDirectory();
+        var destDir = CreateTempTestDirectory();
+        try
+        {
+            var src1 = Path.Combine(tempDir, "a.jpg");
+            var src2 = Path.Combine(tempDir, "b.jpg");
+            var dest1 = Path.Combine(destDir, "a.jpg");
+            var dest2 = Path.Combine(destDir, "b.jpg");
+            await File.WriteAllTextAsync(src1, "src-a");
+            await File.WriteAllTextAsync(src2, "src-b");
+            await File.WriteAllTextAsync(dest1, "old-a");
+            await File.WriteAllTextAsync(dest2, "old-b");
+            var items = new List<PhotoListItem> { CreateFileItem(src1), CreateFileItem(src2) };
+            var callCount = 0;
+
+            var summary = await _service.MoveItemsAsync(items, destDir, (_, _) =>
+            {
+                callCount++;
+                return Task.FromResult(ConflictResolution.SkipAll);
+            });
+
+            Assert.Equal(0, summary.SuccessCount);
+            Assert.Equal(2, summary.SkipCount);
+            Assert.Equal(1, callCount); // SkipAll → 2件目はコールバック不要
+            Assert.Equal("old-a", await File.ReadAllTextAsync(dest1));
+            Assert.Equal("old-b", await File.ReadAllTextAsync(dest2));
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+            CleanupTempDirectory(destDir);
+        }
+    }
+
+    [Fact]
+    public async Task MoveItemsAsync_FolderIntoDescendant_ReturnsDescendantPathError()
+    {
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            var srcFolder = Path.Combine(tempDir, "Parent");
+            var destFolder = Path.Combine(srcFolder, "Child");
+            Directory.CreateDirectory(srcFolder);
+            Directory.CreateDirectory(destFolder);
+            var items = new List<PhotoListItem> { CreateFolderItem(srcFolder) };
+
+            var summary = await _service.MoveItemsAsync(items, destFolder, (_, _) => Task.FromResult(ConflictResolution.Skip));
+
+            Assert.Equal(0, summary.SuccessCount);
+            Assert.Equal(FileOperationError.DescendantPath, summary.Failures[0].Error);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
     // =========================================================
     // CopyItems
     // =========================================================

--- a/PhotoGeoExplorer/MainWindow.xaml
+++ b/PhotoGeoExplorer/MainWindow.xaml
@@ -187,18 +187,31 @@
                 Padding="8,4"
                 Background="{ThemeResource SystemControlBackgroundBaseLowBrush}"
                 CornerRadius="4">
-                <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                    <SymbolIcon
-                        Symbol="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.StatusBarLocationSymbol}"
-                        Visibility="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.StatusBarLocationVisibility}"
-                        Width="16"
-                        Height="16"
-                        ToolTipService.ToolTip="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.StatusBarLocationTooltip}" />
-                    <TextBlock
-                        Text="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.StatusBarText}"
-                        TextTrimming="CharacterEllipsis"
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                        <SymbolIcon
+                            Symbol="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.StatusBarLocationSymbol}"
+                            Visibility="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.StatusBarLocationVisibility}"
+                            Width="16"
+                            Height="16"
+                            ToolTipService.ToolTip="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.StatusBarLocationTooltip}" />
+                        <TextBlock
+                            Text="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.StatusBarText}"
+                            TextTrimming="CharacterEllipsis"
+                            VerticalAlignment="Center" />
+                    </StackPanel>
+                    <Button
+                        Grid.Column="1"
+                        x:Uid="CancelMoveButton"
+                        Command="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.CancelMoveCommand}"
+                        Visibility="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.CancelMoveVisibility}"
+                        Padding="8,2"
                         VerticalAlignment="Center" />
-                </StackPanel>
+                </Grid>
             </Border>
         </Grid>
     </Grid>

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
@@ -753,7 +753,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
             Content = LocalizationService.GetString("Dialog.MoveConflict.SkipAll"),
         };
 
-        ConflictResolution extraChoice = ConflictResolution.Cancel;
+        ConflictResolution? extraChoice = null;
         overwriteAllButton.Click += (_, _) =>
         {
             extraChoice = ConflictResolution.OverwriteAll;
@@ -780,9 +780,9 @@ internal sealed partial class FileBrowserPaneView : UserControl
         };
 
         var result = await dialog.ShowAsync();
-        if (extraChoice != ConflictResolution.Cancel)
+        if (extraChoice.HasValue)
         {
-            return extraChoice;
+            return extraChoice.Value;
         }
 
         return result switch

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
@@ -720,12 +720,77 @@ internal sealed partial class FileBrowserPaneView : UserControl
             return;
         }
 
-        var summary = await ViewModel.ExecuteMoveItemsToFolderAsync(ViewModel.SelectedItems, destination.Path)
+        var summary = await ViewModel.ExecuteMoveItemsToFolderAsync(
+            ViewModel.SelectedItems, destination.Path, ShowMoveConflictDialogAsync)
             .ConfigureAwait(true);
-        if (summary.HasFailures)
+        if (summary.HasFailures && summary.Failures.All(f => f.Error != FileOperationError.Cancelled))
         {
             await ShowMoveOperationErrorDialogAsync(summary).ConfigureAwait(true);
         }
+    }
+
+    private async Task<ConflictResolution> ShowMoveConflictDialogAsync(string fileName, bool isFolder)
+    {
+        var detail = LocalizationService.Format("Dialog.MoveConflict.Detail", fileName);
+        var dialog = new ContentDialog
+        {
+            Title = LocalizationService.GetString("Dialog.MoveConflict.Title"),
+            Content = detail,
+            PrimaryButtonText = LocalizationService.GetString("Dialog.MoveConflict.Overwrite"),
+            SecondaryButtonText = LocalizationService.GetString("Dialog.MoveConflict.Skip"),
+            CloseButtonText = LocalizationService.GetString("Dialog.MoveConflict.Cancel"),
+            XamlRoot = XamlRoot,
+        };
+
+        // StackPanel で「すべて上書き」「すべてスキップ」ボタンを追加
+        var overwriteAllButton = new Button
+        {
+            Content = LocalizationService.GetString("Dialog.MoveConflict.OverwriteAll"),
+            Margin = new Microsoft.UI.Xaml.Thickness(0, 0, 8, 0),
+        };
+        var skipAllButton = new Button
+        {
+            Content = LocalizationService.GetString("Dialog.MoveConflict.SkipAll"),
+        };
+
+        ConflictResolution extraChoice = ConflictResolution.Cancel;
+        overwriteAllButton.Click += (_, _) =>
+        {
+            extraChoice = ConflictResolution.OverwriteAll;
+            dialog.Hide();
+        };
+        skipAllButton.Click += (_, _) =>
+        {
+            extraChoice = ConflictResolution.SkipAll;
+            dialog.Hide();
+        };
+
+        dialog.Content = new StackPanel
+        {
+            Spacing = 12,
+            Children =
+            {
+                new TextBlock { Text = detail, TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap },
+                new StackPanel
+                {
+                    Orientation = Microsoft.UI.Xaml.Controls.Orientation.Horizontal,
+                    Children = { overwriteAllButton, skipAllButton },
+                },
+            },
+        };
+
+        var result = await dialog.ShowAsync();
+        if (extraChoice != ConflictResolution.Cancel)
+        {
+            return extraChoice;
+        }
+
+        return result switch
+        {
+            ContentDialogResult.Primary => ConflictResolution.Overwrite,
+            ContentDialogResult.Secondary => ConflictResolution.Skip,
+            _ => ConflictResolution.Cancel,
+        };
     }
 
     private async void OnMoveToParentClicked(object sender, RoutedEventArgs e)

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
@@ -723,7 +723,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
         var summary = await ViewModel.ExecuteMoveItemsToFolderAsync(
             ViewModel.SelectedItems, destination.Path, ShowMoveConflictDialogAsync)
             .ConfigureAwait(true);
-        if (summary.HasFailures && summary.Failures.All(f => f.Error != FileOperationError.Cancelled))
+        if (summary.Failures.Any(f => f.Error != FileOperationError.Cancelled))
         {
             await ShowMoveOperationErrorDialogAsync(summary).ConfigureAwait(true);
         }

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -681,6 +681,11 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 
         StartMoveProgressTimer();
 
+        // ファイル操作はバックグラウンドスレッドで実行し UI スレッドをブロックしない。
+        // 競合ダイアログは UI スレッドへ marshal してから表示する。
+        Func<string, bool, Task<ConflictResolution>> marshalledCallback = async (name, isFolder) =>
+            await EnqueueOnUIThreadAsync(() => resolveConflictAsync(name, isFolder)).ConfigureAwait(false);
+
         FileOperationSummary result;
         try
         {
@@ -689,8 +694,9 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
                 Interlocked.Exchange(ref _moveCompleted, completed);
             });
 
-            result = await _fileOperationService.MoveItemsAsync(
-                items, destinationFolder, resolveConflictAsync, progress, _moveCts.Token)
+            result = await Task.Run(() => _fileOperationService.MoveItemsAsync(
+                items, destinationFolder, marshalledCallback, progress, _moveCts.Token))
+                .Unwrap()
                 .ConfigureAwait(false);
         }
         finally
@@ -1804,6 +1810,34 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         {
             var ex = new InvalidOperationException("DispatcherQueue へのエンキューに失敗しました。");
             AppLog.Error("RunOnUIThreadAsync: DispatcherQueue.TryEnqueue が false を返しました。", ex);
+            tcs.SetException(ex);
+        }
+        return tcs.Task;
+    }
+
+    private Task<T> EnqueueOnUIThreadAsync<T>(Func<Task<T>> asyncFunc)
+    {
+        if (_dispatcherQueue is null)
+        {
+            return asyncFunc();
+        }
+
+        var tcs = new TaskCompletionSource<T>();
+        if (!_dispatcherQueue.TryEnqueue(async () =>
+            {
+                try
+                {
+                    var result = await asyncFunc().ConfigureAwait(false);
+                    tcs.SetResult(result);
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                }
+            }))
+        {
+            var ex = new InvalidOperationException("DispatcherQueue へのエンキューに失敗しました。");
+            AppLog.Error("EnqueueOnUIThreadAsync: DispatcherQueue.TryEnqueue が false を返しました。", ex);
             tcs.SetException(ex);
         }
         return tcs.Task;

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -167,7 +167,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         DeleteSelectionCommand = new RelayCommand(
             async () => await ExecuteUiActionAsync(_deleteSelectionAction).ConfigureAwait(false),
             () => _deleteSelectionAction is not null && CanModifySelection);
-        CancelMoveCommand = new RelayCommand(() => _moveCts?.Cancel(), () => IsMoveInProgress);
+        CancelMoveCommand = new RelayCommand(async () => { _moveCts?.Cancel(); await Task.CompletedTask.ConfigureAwait(false); }, () => IsMoveInProgress);
     }
 
     public ObservableCollection<PhotoListItem> Items { get; }
@@ -677,7 +677,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         _moveTotal = items.Count;
         _moveCompleted = 0;
         IsMoveInProgress = true;
-        ((RelayCommand)CancelMoveCommand).NotifyCanExecuteChanged();
+        ((RelayCommand)CancelMoveCommand).RaiseCanExecuteChanged();
 
         StartMoveProgressTimer();
 
@@ -696,14 +696,13 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 
             result = await Task.Run(() => _fileOperationService.MoveItemsAsync(
                 items, destinationFolder, marshalledCallback, progress, _moveCts.Token))
-                .Unwrap()
                 .ConfigureAwait(false);
         }
         finally
         {
             StopMoveProgressTimer();
             IsMoveInProgress = false;
-            ((RelayCommand)CancelMoveCommand).NotifyCanExecuteChanged();
+            ((RelayCommand)CancelMoveCommand).RaiseCanExecuteChanged();
             _moveCts.Dispose();
             _moveCts = null;
         }

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -82,6 +82,11 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     private Func<Task>? _moveSelectionAction;
     private Func<Task>? _moveSelectionToParentAction;
     private Func<Task>? _deleteSelectionAction;
+    private CancellationTokenSource? _moveCts;
+    private int _moveTotal;
+    private int _moveCompleted;
+    private bool _isMoveInProgress;
+    private DispatcherQueueTimer? _moveProgressTimer;
 
     public FileBrowserPaneViewModel()
         : this(new FileBrowserPaneService(), new WorkspaceState())
@@ -162,6 +167,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         DeleteSelectionCommand = new RelayCommand(
             async () => await ExecuteUiActionAsync(_deleteSelectionAction).ConfigureAwait(false),
             () => _deleteSelectionAction is not null && CanModifySelection);
+        CancelMoveCommand = new RelayCommand(() => _moveCts?.Cancel(), () => IsMoveInProgress);
     }
 
     public ObservableCollection<PhotoListItem> Items { get; }
@@ -486,6 +492,22 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         private set => SetProperty(ref _statusBarText, value);
     }
 
+    public bool IsMoveInProgress
+    {
+        get => _isMoveInProgress;
+        private set
+        {
+            if (SetProperty(ref _isMoveInProgress, value))
+            {
+                OnPropertyChanged(nameof(CancelMoveVisibility));
+            }
+        }
+    }
+
+    public Visibility CancelMoveVisibility => _isMoveInProgress ? Visibility.Visible : Visibility.Collapsed;
+
+    public ICommand CancelMoveCommand { get; private set; }
+
     public Symbol StatusBarLocationSymbol
     {
         get => _statusBarLocationSymbol;
@@ -636,15 +658,83 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     }
 
     internal async Task<FileOperationSummary> ExecuteMoveItemsToFolderAsync(
-        IReadOnlyList<PhotoListItem> items, string destinationFolder)
+        IReadOnlyList<PhotoListItem> items,
+        string destinationFolder,
+        Func<string, bool, Task<ConflictResolution>>? resolveConflictAsync = null)
     {
-        var summary = _fileOperationService.MoveItems(items, destinationFolder);
-        if (summary.SuccessCount > 0)
+        if (resolveConflictAsync is null)
+        {
+            var summary = _fileOperationService.MoveItems(items, destinationFolder);
+            if (summary.SuccessCount > 0)
+            {
+                await RefreshAsync().ConfigureAwait(false);
+            }
+
+            return summary;
+        }
+
+        _moveCts = new CancellationTokenSource();
+        _moveTotal = items.Count;
+        _moveCompleted = 0;
+        IsMoveInProgress = true;
+        ((RelayCommand)CancelMoveCommand).NotifyCanExecuteChanged();
+
+        StartMoveProgressTimer();
+
+        FileOperationSummary result;
+        try
+        {
+            var progress = new Progress<int>(completed =>
+            {
+                Interlocked.Exchange(ref _moveCompleted, completed);
+            });
+
+            result = await _fileOperationService.MoveItemsAsync(
+                items, destinationFolder, resolveConflictAsync, progress, _moveCts.Token)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            StopMoveProgressTimer();
+            IsMoveInProgress = false;
+            ((RelayCommand)CancelMoveCommand).NotifyCanExecuteChanged();
+            _moveCts.Dispose();
+            _moveCts = null;
+        }
+
+        if (result.SuccessCount > 0)
         {
             await RefreshAsync().ConfigureAwait(false);
         }
 
-        return summary;
+        var doneText = LocalizationService.Format(
+            "Message.MoveDone", result.SuccessCount, result.SkipCount, result.FailureCount);
+        await RunOnUIThreadAsync(() => StatusBarText = doneText).ConfigureAwait(false);
+
+        return result;
+    }
+
+    private void StartMoveProgressTimer()
+    {
+        if (_dispatcherQueue is null) return;
+
+        _moveProgressTimer = _dispatcherQueue.CreateTimer();
+        _moveProgressTimer.Interval = TimeSpan.FromMilliseconds(300);
+        _moveProgressTimer.Tick += OnMoveProgressTick;
+        _moveProgressTimer.Start();
+    }
+
+    private void StopMoveProgressTimer()
+    {
+        _moveProgressTimer?.Stop();
+        _moveProgressTimer = null;
+    }
+
+    private void OnMoveProgressTick(DispatcherQueueTimer sender, object args)
+    {
+        var completed = Volatile.Read(ref _moveCompleted);
+        StatusBarText = LocalizationService.Format(
+            "Message.MoveProgress", completed, _moveTotal);
     }
 
     internal Task<FileOperationSummary> ExecuteCopyItemsToFolderAsync(
@@ -658,13 +748,13 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     {
         if (string.IsNullOrWhiteSpace(CurrentFolderPath) || SelectedItems.Count == 0)
         {
-            return new FileOperationSummary(0, Array.Empty<FileOperationFailure>());
+            return new FileOperationSummary(0, 0, Array.Empty<FileOperationFailure>());
         }
 
         var parentPath = _fileOperationService.GetParentPath(CurrentFolderPath);
         if (parentPath is null)
         {
-            return new FileOperationSummary(0, Array.Empty<FileOperationFailure>());
+            return new FileOperationSummary(0, 0, Array.Empty<FileOperationFailure>());
         }
 
         return await ExecuteMoveItemsToFolderAsync(SelectedItems, parentPath).ConfigureAwait(false);
@@ -1044,6 +1134,9 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         CancelThumbnailGeneration();
         CancelMetadataLoad();
         CancelFolderLoad();
+        StopMoveProgressTimer();
+        _moveCts?.Cancel();
+        _moveCts?.Dispose();
         _thumbnailGenerationSemaphore.Dispose();
     }
 

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -167,7 +167,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         DeleteSelectionCommand = new RelayCommand(
             async () => await ExecuteUiActionAsync(_deleteSelectionAction).ConfigureAwait(false),
             () => _deleteSelectionAction is not null && CanModifySelection);
-        CancelMoveCommand = new RelayCommand(async () => { _moveCts?.Cancel(); await Task.CompletedTask.ConfigureAwait(false); }, () => IsMoveInProgress);
+        CancelMoveCommand = new RelayCommand(async () => await (_moveCts?.CancelAsync() ?? Task.CompletedTask).ConfigureAwait(false), () => IsMoveInProgress);
     }
 
     public ObservableCollection<PhotoListItem> Items { get; }
@@ -1832,6 +1832,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
                 catch (Exception ex)
                 {
                     tcs.SetException(ex);
+                    throw;
                 }
             }))
         {

--- a/PhotoGeoExplorer/Services/ConflictResolution.cs
+++ b/PhotoGeoExplorer/Services/ConflictResolution.cs
@@ -1,0 +1,10 @@
+namespace PhotoGeoExplorer.Services;
+
+internal enum ConflictResolution
+{
+    Overwrite,
+    Skip,
+    Cancel,
+    OverwriteAll,
+    SkipAll,
+}

--- a/PhotoGeoExplorer/Services/FileOperationError.cs
+++ b/PhotoGeoExplorer/Services/FileOperationError.cs
@@ -9,4 +9,5 @@ internal enum FileOperationError
     NoParent,
     IoError,
     Unauthorized,
+    Cancelled,
 }

--- a/PhotoGeoExplorer/Services/FileOperationService.cs
+++ b/PhotoGeoExplorer/Services/FileOperationService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using PhotoGeoExplorer.Models;
 using PhotoGeoExplorer.ViewModels;
 
@@ -184,7 +186,7 @@ internal sealed class FileOperationService : IFileOperationService
             }
         }
 
-        return new FileOperationSummary(successCount, failures);
+        return new FileOperationSummary(successCount, 0, failures);
     }
 
     private static void CopyDirectory(string sourcePath, string targetPath)
@@ -262,7 +264,149 @@ internal sealed class FileOperationService : IFileOperationService
             }
         }
 
-        return new FileOperationSummary(successCount, failures);
+        return new FileOperationSummary(successCount, 0, failures);
+    }
+
+    public async Task<FileOperationSummary> MoveItemsAsync(
+        IReadOnlyList<PhotoListItem> items,
+        string destinationFolder,
+        Func<string, bool, Task<ConflictResolution>> resolveConflictAsync,
+        IProgress<int>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var successCount = 0;
+        var skipCount = 0;
+        var failures = new List<FileOperationFailure>();
+        var overwriteAll = false;
+        var skipAll = false;
+
+        for (var i = 0; i < items.Count; i++)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                failures.Add(new FileOperationFailure(items[i].FilePath, items[i].FileName, FileOperationError.Cancelled));
+                break;
+            }
+
+            var item = items[i];
+            var sourcePath = item.FilePath;
+            var parent = Path.GetDirectoryName(sourcePath);
+            if (string.IsNullOrWhiteSpace(parent))
+            {
+                failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.NoParent));
+                continue;
+            }
+
+            if (IsSamePath(parent, destinationFolder))
+            {
+                progress?.Report(i + 1);
+                continue;
+            }
+
+            if (item.IsFolder && IsDescendantPath(sourcePath, destinationFolder))
+            {
+                failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.DescendantPath));
+                continue;
+            }
+
+            var targetPath = Path.Combine(destinationFolder, item.FileName);
+            if (ItemExistsAtPath(targetPath))
+            {
+                ConflictResolution resolution;
+                if (overwriteAll)
+                {
+                    resolution = ConflictResolution.Overwrite;
+                }
+                else if (skipAll)
+                {
+                    resolution = ConflictResolution.Skip;
+                }
+                else
+                {
+                    resolution = await resolveConflictAsync(item.FileName, item.IsFolder).ConfigureAwait(false);
+                    if (resolution == ConflictResolution.OverwriteAll)
+                    {
+                        overwriteAll = true;
+                        resolution = ConflictResolution.Overwrite;
+                    }
+                    else if (resolution == ConflictResolution.SkipAll)
+                    {
+                        skipAll = true;
+                        resolution = ConflictResolution.Skip;
+                    }
+                }
+
+                if (resolution == ConflictResolution.Cancel)
+                {
+                    failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.Cancelled));
+                    break;
+                }
+
+                if (resolution == ConflictResolution.Skip)
+                {
+                    skipCount++;
+                    progress?.Report(i + 1);
+                    continue;
+                }
+
+                // Overwrite: 上書き移動
+                try
+                {
+                    if (item.IsFolder)
+                    {
+                        // フォルダ上書き: 既存を削除してから移動
+                        Directory.Delete(targetPath, recursive: true);
+                    }
+                    else
+                    {
+                        File.Delete(targetPath);
+                    }
+                }
+                catch (Exception ex) when (ex is UnauthorizedAccessException)
+                {
+                    AppLog.Error($"Failed to delete existing item for overwrite: {targetPath}", ex);
+                    failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.Unauthorized));
+                    progress?.Report(i + 1);
+                    continue;
+                }
+                catch (Exception ex) when (ex is IOException or NotSupportedException or ArgumentException or PathTooLongException)
+                {
+                    AppLog.Error($"Failed to delete existing item for overwrite: {targetPath}", ex);
+                    failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.IoError));
+                    progress?.Report(i + 1);
+                    continue;
+                }
+            }
+
+            try
+            {
+                if (item.IsFolder)
+                {
+                    Directory.Move(sourcePath, targetPath);
+                }
+                else
+                {
+                    File.Move(sourcePath, targetPath);
+                }
+
+                successCount++;
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException)
+            {
+                AppLog.Error($"Failed to move item: {sourcePath}", ex);
+                failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.Unauthorized));
+            }
+            catch (Exception ex) when (ex is IOException or NotSupportedException or ArgumentException or PathTooLongException)
+            {
+                AppLog.Error($"Failed to move item: {sourcePath}", ex);
+                failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.IoError));
+            }
+
+            progress?.Report(i + 1);
+        }
+
+        AppLog.Info($"MoveItemsAsync: success={successCount}, skip={skipCount}, failure={failures.Count}");
+        return new FileOperationSummary(successCount, skipCount, failures);
     }
 
     public FileOperationSummary DeleteItems(IReadOnlyList<PhotoListItem> items)
@@ -305,6 +449,6 @@ internal sealed class FileOperationService : IFileOperationService
             }
         }
 
-        return new FileOperationSummary(successCount, failures);
+        return new FileOperationSummary(successCount, 0, failures);
     }
 }

--- a/PhotoGeoExplorer/Services/FileOperationSummary.cs
+++ b/PhotoGeoExplorer/Services/FileOperationSummary.cs
@@ -4,7 +4,7 @@ namespace PhotoGeoExplorer.Services;
 
 internal sealed record FileOperationFailure(string Path, string FileName, FileOperationError Error);
 
-internal sealed record FileOperationSummary(int SuccessCount, IReadOnlyList<FileOperationFailure> Failures)
+internal sealed record FileOperationSummary(int SuccessCount, int SkipCount, IReadOnlyList<FileOperationFailure> Failures)
 {
     public int FailureCount => Failures.Count;
     public bool HasFailures => Failures.Count > 0;

--- a/PhotoGeoExplorer/Services/IFileOperationService.cs
+++ b/PhotoGeoExplorer/Services/IFileOperationService.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using PhotoGeoExplorer.Models;
 using PhotoGeoExplorer.ViewModels;
 
@@ -22,6 +25,12 @@ internal interface IFileOperationService
 
     // ファイル操作（複数件）
     FileOperationSummary MoveItems(IReadOnlyList<PhotoListItem> items, string destinationFolder);
+    Task<FileOperationSummary> MoveItemsAsync(
+        IReadOnlyList<PhotoListItem> items,
+        string destinationFolder,
+        Func<string, bool, Task<ConflictResolution>> resolveConflictAsync,
+        IProgress<int>? progress = null,
+        CancellationToken cancellationToken = default);
     FileOperationSummary CopyItems(IReadOnlyList<PhotoListItem> items, string destinationFolder);
     FileOperationSummary DeleteItems(IReadOnlyList<PhotoListItem> items);
 }

--- a/PhotoGeoExplorer/Strings/en-US/Resources.resw
+++ b/PhotoGeoExplorer/Strings/en-US/Resources.resw
@@ -830,4 +830,37 @@
   <data name="ToolTip.FullPath" xml:space="preserve">
     <value>Path</value>
   </data>
+  <data name="Dialog.MoveConflict.Title" xml:space="preserve">
+    <value>Item already exists at destination</value>
+  </data>
+  <data name="Dialog.MoveConflict.Detail" xml:space="preserve">
+    <value>"{0}" already exists at the destination. Do you want to overwrite it?</value>
+  </data>
+  <data name="Dialog.MoveConflict.Overwrite" xml:space="preserve">
+    <value>Overwrite</value>
+  </data>
+  <data name="Dialog.MoveConflict.OverwriteAll" xml:space="preserve">
+    <value>Overwrite All</value>
+  </data>
+  <data name="Dialog.MoveConflict.Skip" xml:space="preserve">
+    <value>Skip</value>
+  </data>
+  <data name="Dialog.MoveConflict.SkipAll" xml:space="preserve">
+    <value>Skip All</value>
+  </data>
+  <data name="Dialog.MoveConflict.Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Message.MoveProgress" xml:space="preserve">
+    <value>Moving… {0}/{1} items</value>
+  </data>
+  <data name="Message.MoveDone" xml:space="preserve">
+    <value>Move complete: {0} succeeded, {1} skipped, {2} failed</value>
+  </data>
+  <data name="Button.CancelMove" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="CancelMoveButton.Content" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
 </root>

--- a/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
+++ b/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
@@ -830,4 +830,37 @@
   <data name="ToolTip.FullPath" xml:space="preserve">
     <value>パス</value>
   </data>
+  <data name="Dialog.MoveConflict.Title" xml:space="preserve">
+    <value>移動先に同名の項目があります</value>
+  </data>
+  <data name="Dialog.MoveConflict.Detail" xml:space="preserve">
+    <value>移動先に「{0}」が既に存在します。上書きしますか？</value>
+  </data>
+  <data name="Dialog.MoveConflict.Overwrite" xml:space="preserve">
+    <value>上書き</value>
+  </data>
+  <data name="Dialog.MoveConflict.OverwriteAll" xml:space="preserve">
+    <value>すべて上書き</value>
+  </data>
+  <data name="Dialog.MoveConflict.Skip" xml:space="preserve">
+    <value>スキップ</value>
+  </data>
+  <data name="Dialog.MoveConflict.SkipAll" xml:space="preserve">
+    <value>すべてスキップ</value>
+  </data>
+  <data name="Dialog.MoveConflict.Cancel" xml:space="preserve">
+    <value>中止</value>
+  </data>
+  <data name="Message.MoveProgress" xml:space="preserve">
+    <value>移動中… {0}/{1} 件</value>
+  </data>
+  <data name="Message.MoveDone" xml:space="preserve">
+    <value>移動完了: 成功 {0} 件、スキップ {1} 件、失敗 {2} 件</value>
+  </data>
+  <data name="Button.CancelMove" xml:space="preserve">
+    <value>中止</value>
+  </data>
+  <data name="CancelMoveButton.Content" xml:space="preserve">
+    <value>中止</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary

- `IFileOperationService.MoveItemsAsync` を新規追加（非同期競合コールバック・`IProgress<int>`・`CancellationToken` 対応）
- 移動先に同名項目がある場合に 5 択ダイアログ（上書き / スキップ / すべて上書き / すべてスキップ / 中止）を表示
- 移動中はステータスバーに「移動中… N/M 件」をリアルタイム表示し、完了後に件数サマリーを表示
- ステータスバー右端に「中止」ボタンを追加（移動中のみ表示）
- `ConflictResolution` enum・`FileOperationError.Cancelled`・`FileOperationSummary.SkipCount` を追加

## Changes

- `Services/ConflictResolution.cs` 新規追加
- `Services/FileOperationError.cs` に `Cancelled` を追加
- `Services/FileOperationSummary.cs` に `SkipCount` を追加
- `Services/IFileOperationService.cs` に `MoveItemsAsync` シグネチャを追加
- `Services/FileOperationService.cs` に `MoveItemsAsync` 実装を追加
- `Panes/FileBrowser/FileBrowserPaneViewModel.cs` にプログレス・キャンセル管理を追加
- `Panes/FileBrowser/FileBrowserPaneView.xaml.cs` に `ShowMoveConflictDialogAsync` を追加
- `MainWindow.xaml` に「中止」ボタンを追加
- リソース文字列（ja-JP / en-US）に競合ダイアログ・プログレスメッセージを追加

## Test plan

- [x] `MoveItemsAsync` の単体テスト 5 件を追加（Success / Skip / Overwrite / Cancel / CancellationToken）
- [x] `FileBrowserPaneViewModelTests` のスタブに `MoveItemsAsync` を追加
- [ ] CI で全テスト通過を確認

Closes #69

Generated with [Claude Code](https://claude.com/claude-code)