### PR TITLE
feat(delete): ファイル削除をゴミ箱移動に変更 (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - `DeleteItems`（直接削除）を `DeleteItemsAsync`（非同期ゴミ箱移動）に置き換え。
   - `Windows.Storage.StorageFile/StorageFolder.DeleteAsync(StorageDeleteOption.Default)` を使用。
   - ドライブ種別によってゴミ箱を経由しない場合（ネットワーク・リムーバブルドライブ等）は OS の既定挙動に従う。
+  - UI 文言を「削除」から「ゴミ箱へ移動」に統一（メニュー・確認ダイアログ・エラーダイアログ）。
 
 ### 追加
 - Explorer 風のキーボードショートカット対応（#88）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### 変更
+- ファイル削除をゴミ箱移動に変更（#90）
+  - `DeleteItems`（直接削除）を `DeleteItemsAsync`（非同期ゴミ箱移動）に置き換え。
+  - `Windows.Storage.StorageFile/StorageFolder.DeleteAsync(StorageDeleteOption.Default)` を使用。
+  - ドライブ種別によってゴミ箱を経由しない場合（ネットワーク・リムーバブルドライブ等）は OS の既定挙動に従う。
+
 ### 追加
 - Explorer 風のキーボードショートカット対応（#88）
   - `Ctrl+A`: ファイル一覧を全選択。

--- a/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
@@ -1315,7 +1315,7 @@ public class FileBrowserPaneViewModelTests
             IProgress<int>? progress = null,
             CancellationToken cancellationToken = default) => Task.FromResult(MoveItemsResult);
         public FileOperationSummary CopyItems(IReadOnlyList<PhotoListItem> items, string destinationFolder) => CopyItemsResult;
-        public FileOperationSummary DeleteItems(IReadOnlyList<PhotoListItem> items) => DeleteItemsResult;
+        public Task<FileOperationSummary> DeleteItemsAsync(IReadOnlyList<PhotoListItem> items) => Task.FromResult(DeleteItemsResult);
     }
 
     private static PhotoListItem CreatePhotoListItem(string fileName)

--- a/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
@@ -801,20 +801,20 @@ public sealed class FileOperationServiceTests
     }
 
     // =========================================================
-    // DeleteItems
+    // DeleteItemsAsync
     // =========================================================
 
     [Fact]
-    public void DeleteItems_SingleFile_ReturnsSuccessCount1()
+    public async Task DeleteItemsAsync_SingleFile_ReturnsSuccessCount1()
     {
         var tempDir = CreateTempTestDirectory();
         try
         {
             var srcPath = Path.Combine(tempDir, "photo.jpg");
-            File.WriteAllText(srcPath, "content");
+            await File.WriteAllTextAsync(srcPath, "content");
             var items = new List<PhotoListItem> { CreateFileItem(srcPath) };
 
-            var summary = _service.DeleteItems(items);
+            var summary = await _service.DeleteItemsAsync(items);
 
             Assert.Equal(1, summary.SuccessCount);
             Assert.True(summary.IsAllSuccess);
@@ -827,17 +827,17 @@ public sealed class FileOperationServiceTests
     }
 
     [Fact]
-    public void DeleteItems_Directory_ReturnsSuccessCount1()
+    public async Task DeleteItemsAsync_Directory_ReturnsSuccessCount1()
     {
         var tempDir = CreateTempTestDirectory();
         try
         {
             var srcDir = Path.Combine(tempDir, "SubFolder");
             Directory.CreateDirectory(srcDir);
-            File.WriteAllText(Path.Combine(srcDir, "file.txt"), "content");
+            await File.WriteAllTextAsync(Path.Combine(srcDir, "file.txt"), "content");
             var items = new List<PhotoListItem> { CreateFolderItem(srcDir) };
 
-            var summary = _service.DeleteItems(items);
+            var summary = await _service.DeleteItemsAsync(items);
 
             Assert.Equal(1, summary.SuccessCount);
             Assert.True(summary.IsAllSuccess);
@@ -850,23 +850,49 @@ public sealed class FileOperationServiceTests
     }
 
     [Fact]
-    public void DeleteItems_FileLockedByAnotherProcess_ReturnsIoError()
+    public async Task DeleteItemsAsync_FileLockedByAnotherProcess_ReturnsIoError()
     {
         var tempDir = CreateTempTestDirectory();
         try
         {
             var srcPath = Path.Combine(tempDir, "locked.txt");
-            File.WriteAllText(srcPath, "content");
+            await File.WriteAllTextAsync(srcPath, "content");
 
             using var fs = File.Open(srcPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
             var items = new List<PhotoListItem> { CreateFileItem(srcPath) };
 
-            var summary = _service.DeleteItems(items);
+            var summary = await _service.DeleteItemsAsync(items);
 
             Assert.False(summary.IsAllSuccess);
             Assert.True(summary.HasFailures);
             Assert.Equal(1, summary.FailureCount);
             Assert.Equal(FileOperationError.IoError, summary.Failures[0].Error);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public async Task DeleteItemsAsync_OneMissingFile_ContinuesAndDeletesRemainder()
+    {
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            var missingPath = Path.Combine(tempDir, "missing.txt");
+            var existingPath = Path.Combine(tempDir, "existing.txt");
+            await File.WriteAllTextAsync(existingPath, "data");
+
+            var missingItem = CreateFileItem(missingPath);
+            var existingItem = CreateFileItem(existingPath);
+            var items = new List<PhotoListItem> { missingItem, existingItem };
+
+            var summary = await _service.DeleteItemsAsync(items);
+
+            Assert.Equal(1, summary.SuccessCount);
+            Assert.Equal(1, summary.FailureCount);
+            Assert.False(File.Exists(existingPath));
         }
         finally
         {

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -816,7 +816,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     internal async Task<FileOperationSummary> ExecuteDeleteItemsAsync(
         IReadOnlyList<PhotoListItem> items)
     {
-        var summary = _fileOperationService.DeleteItems(items);
+        var summary = await _fileOperationService.DeleteItemsAsync(items).ConfigureAwait(false);
         if (summary.SuccessCount > 0)
         {
             await RefreshAsync().ConfigureAwait(false);

--- a/PhotoGeoExplorer/Services/FileOperationService.cs
+++ b/PhotoGeoExplorer/Services/FileOperationService.cs
@@ -445,7 +445,14 @@ internal sealed class FileOperationService : IFileOperationService
                 failures.Add(new FileOperationFailure(item.FilePath, item.FileName, FileOperationError.Unauthorized));
                 break;
             }
-            catch (Exception ex) when (ex is COMException or FileNotFoundException)
+            catch (FileNotFoundException)
+            {
+                // 別操作や同期ツールで既に消えている場合は次のアイテムへ継続
+                AppLog.Info($"Delete skipped: item already missing: {item.FilePath}");
+                failures.Add(new FileOperationFailure(item.FilePath, item.FileName, FileOperationError.IoError));
+                continue;
+            }
+            catch (Exception ex) when (ex is COMException)
             {
                 AppLog.Error($"Failed to delete item: {item.FilePath}", ex);
                 failures.Add(new FileOperationFailure(item.FilePath, item.FileName, FileOperationError.IoError));

--- a/PhotoGeoExplorer/Services/FileOperationService.cs
+++ b/PhotoGeoExplorer/Services/FileOperationService.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using PhotoGeoExplorer.Models;
 using PhotoGeoExplorer.ViewModels;
+using Windows.Storage;
 
 namespace PhotoGeoExplorer.Services;
 
@@ -409,7 +411,7 @@ internal sealed class FileOperationService : IFileOperationService
         return new FileOperationSummary(successCount, skipCount, failures);
     }
 
-    public FileOperationSummary DeleteItems(IReadOnlyList<PhotoListItem> items)
+    public async Task<FileOperationSummary> DeleteItemsAsync(IReadOnlyList<PhotoListItem> items)
     {
         var successCount = 0;
         var failures = new List<FileOperationFailure>();
@@ -426,11 +428,13 @@ internal sealed class FileOperationService : IFileOperationService
             {
                 if (item.IsFolder)
                 {
-                    Directory.Delete(item.FilePath, recursive: true);
+                    var folder = await StorageFolder.GetFolderFromPathAsync(item.FilePath);
+                    await folder.DeleteAsync(StorageDeleteOption.Default);
                 }
                 else
                 {
-                    File.Delete(item.FilePath);
+                    var file = await StorageFile.GetFileFromPathAsync(item.FilePath);
+                    await file.DeleteAsync(StorageDeleteOption.Default);
                 }
 
                 successCount++;
@@ -439,6 +443,12 @@ internal sealed class FileOperationService : IFileOperationService
             {
                 AppLog.Error($"Failed to delete item: {item.FilePath}", ex);
                 failures.Add(new FileOperationFailure(item.FilePath, item.FileName, FileOperationError.Unauthorized));
+                break;
+            }
+            catch (Exception ex) when (ex is COMException or FileNotFoundException)
+            {
+                AppLog.Error($"Failed to delete item: {item.FilePath}", ex);
+                failures.Add(new FileOperationFailure(item.FilePath, item.FileName, FileOperationError.IoError));
                 break;
             }
             catch (Exception ex) when (ex is IOException or NotSupportedException or ArgumentException or PathTooLongException)

--- a/PhotoGeoExplorer/Services/IFileOperationService.cs
+++ b/PhotoGeoExplorer/Services/IFileOperationService.cs
@@ -32,5 +32,5 @@ internal interface IFileOperationService
         IProgress<int>? progress = null,
         CancellationToken cancellationToken = default);
     FileOperationSummary CopyItems(IReadOnlyList<PhotoListItem> items, string destinationFolder);
-    FileOperationSummary DeleteItems(IReadOnlyList<PhotoListItem> items);
+    Task<FileOperationSummary> DeleteItemsAsync(IReadOnlyList<PhotoListItem> items);
 }

--- a/PhotoGeoExplorer/Strings/en-US/Resources.resw
+++ b/PhotoGeoExplorer/Strings/en-US/Resources.resw
@@ -672,19 +672,19 @@
     <value>Rename failed</value>
   </data>
   <data name="Dialog.DeleteConfirm.Multiple" xml:space="preserve">
-    <value>Delete {0} items?</value>
+    <value>Move {0} items to Recycle Bin?</value>
   </data>
   <data name="Dialog.DeleteConfirm.Title" xml:space="preserve">
-    <value>Delete</value>
+    <value>Move to Recycle Bin</value>
   </data>
   <data name="Dialog.DeleteConfirm.Folder" xml:space="preserve">
-    <value>Delete folder "{0}"?</value>
+    <value>Move folder "{0}" to Recycle Bin?</value>
   </data>
   <data name="Dialog.DeleteConfirm.File" xml:space="preserve">
-    <value>Delete file "{0}"?</value>
+    <value>Move file "{0}" to Recycle Bin?</value>
   </data>
   <data name="Common.Delete" xml:space="preserve">
-    <value>Delete</value>
+    <value>Move to Recycle Bin</value>
   </data>
   <data name="Common.Cancel" xml:space="preserve">
     <value>Cancel</value>
@@ -723,7 +723,7 @@
     <value>Open in Google Maps</value>
   </data>
   <data name="Menu.Delete" xml:space="preserve">
-    <value>Delete</value>
+    <value>Move to Recycle Bin</value>
   </data>
   <data name="Dialog.CopyFailed.Title" xml:space="preserve">
     <value>Copy failed</value>
@@ -738,13 +738,13 @@
     <value>An item with the same name already exists in the destination.</value>
   </data>
   <data name="Dialog.DeleteNotAvailable.Title" xml:space="preserve">
-    <value>Delete not available</value>
+    <value>Move to Recycle Bin not available</value>
   </data>
   <data name="Dialog.DeleteNotAvailable.Detail" xml:space="preserve">
-    <value>This item cannot be deleted.</value>
+    <value>This item cannot be moved to the Recycle Bin.</value>
   </data>
   <data name="Dialog.DeleteFailed.Title" xml:space="preserve">
-    <value>Delete failed</value>
+    <value>Move to Recycle Bin failed</value>
   </data>
   <data name="Flyout.TakenAtLabel.Text" xml:space="preserve">
     <value>Taken At</value>

--- a/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
+++ b/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
@@ -672,19 +672,19 @@
     <value>名前変更に失敗しました</value>
   </data>
   <data name="Dialog.DeleteConfirm.Multiple" xml:space="preserve">
-    <value>{0} 件を削除しますか？</value>
+    <value>{0} 件をゴミ箱へ移動しますか？</value>
   </data>
   <data name="Dialog.DeleteConfirm.Title" xml:space="preserve">
-    <value>削除</value>
+    <value>ゴミ箱へ移動</value>
   </data>
   <data name="Dialog.DeleteConfirm.Folder" xml:space="preserve">
-    <value>フォルダー「{0}」を削除しますか？</value>
+    <value>フォルダー「{0}」をゴミ箱へ移動しますか？</value>
   </data>
   <data name="Dialog.DeleteConfirm.File" xml:space="preserve">
-    <value>ファイル「{0}」を削除しますか？</value>
+    <value>ファイル「{0}」をゴミ箱へ移動しますか？</value>
   </data>
   <data name="Common.Delete" xml:space="preserve">
-    <value>削除</value>
+    <value>ゴミ箱へ移動</value>
   </data>
   <data name="Common.Cancel" xml:space="preserve">
     <value>キャンセル</value>
@@ -723,7 +723,7 @@
     <value>Google Maps で開く</value>
   </data>
   <data name="Menu.Delete" xml:space="preserve">
-    <value>削除</value>
+    <value>ゴミ箱へ移動</value>
   </data>
   <data name="Dialog.CopyFailed.Title" xml:space="preserve">
     <value>コピーに失敗しました</value>
@@ -738,13 +738,13 @@
     <value>移動先に同名の項目が既に存在します。</value>
   </data>
   <data name="Dialog.DeleteNotAvailable.Title" xml:space="preserve">
-    <value>削除できません</value>
+    <value>ゴミ箱へ移動できません</value>
   </data>
   <data name="Dialog.DeleteNotAvailable.Detail" xml:space="preserve">
-    <value>この項目は削除できません。</value>
+    <value>この項目はゴミ箱へ移動できません。</value>
   </data>
   <data name="Dialog.DeleteFailed.Title" xml:space="preserve">
-    <value>削除に失敗しました</value>
+    <value>ゴミ箱への移動に失敗しました</value>
   </data>
   <data name="Flyout.TakenAtLabel.Text" xml:space="preserve">
     <value>撮影日時</value>


### PR DESCRIPTION
## Summary

- `DeleteItems`（`File.Delete` / `Directory.Delete` による直接削除）を廃止し、`DeleteItemsAsync` に置き換え
- `Windows.Storage.StorageFile.DeleteAsync(StorageDeleteOption.Default)` / `StorageFolder.DeleteAsync(Default)` でゴミ箱移動を実現
- ドライブ種別によってゴミ箱を経由しない場合（ネットワーク・リムーバブルドライブ等）は OS の既定挙動に従う

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `IFileOperationService.cs` | `DeleteItems` → `DeleteItemsAsync (Task<>)` に署名変更 |
| `FileOperationService.cs` | WinRT API でゴミ箱移動を実装 |
| `FileBrowserPaneViewModel.cs` | `ExecuteDeleteItemsAsync` に `await` 追加 |
| `FileBrowserPaneViewModelTests.cs` | `StubFileOperationService` を `Task.FromResult` 返却に更新 |
| `CHANGELOG.md` | #90 エントリを追加 |

## 受け入れ条件の対応状況

| 条件 | 状態 |
|---|---|
| 右クリックメニューから選択ファイルをゴミ箱へ移動できる | ✅ 既存の「削除」メニューが本変更でゴミ箱移動になった |
| `Delete` キーでゴミ箱移動操作を開始できる | ✅ #88 で実装済み |
| 複数ファイル削除時に対象件数が分かる | ✅ 既存の確認ダイアログに件数表示あり |
| 削除は直接削除ではなくゴミ箱へ移動される | ✅ 本 PR で対応 |
| `F2` で単一ファイルをリネームできる | ✅ #88 で実装済み |
| 複数選択時のリネームが誤動作しない | ✅ `CanRenameSelection = SelectedCount == 1` で防止 |
| 同名ファイルや不正ファイル名の扱いが明確 | ✅ `AlreadyExists` / `InvalidName` エラーダイアログあり |
| リネーム後に一覧・選択状態・プレビュー・地図連動が回帰しない | ✅ `RefreshAsync` + `SelectItemByPath` で対応済み |
| MainWindow に操作ロジックが増えていない | ✅ |

## Test plan

- [ ] `dotnet test` がすべて SUCCESS（CI で確認）
- [ ] アプリで Delete キーまたは右クリック「削除」でゴミ箱への移動を目視確認

Closes #90