### PR TITLE
feat(dnd): Explorer 風のドラッグアウト・Ctrl コピー対応 (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
   - UI 文言を「削除」から「ゴミ箱へ移動」に統一（メニュー・確認ダイアログ・エラーダイアログ）。
 
 ### 追加
+- Explorer 風のドラッグアウト対応（#89）
+  - `DragItemsStarting` で `SetDataProvider(StorageItems)` を追加し、Explorer や他アプリへのドラッグアウトを実現。
+  - `RequestedOperation = Copy | Move` に変更して、同一/別ドライブの挙動を Explorer 側に委ねる。
+  - `Ctrl+ドラッグ` でコピー、通常ドラッグで移動として扱われるよう内部ドラッグに Ctrl 判定を追加。
+  - ドラッグ中にキャプション「コピー」/「移動」を表示して操作フィードバックを明示。
+  - 外部アプリへの Move 完了後（`DragItemsCompleted.DropResult == Move`）にリストを自動更新。
 - Explorer 風のキーボードショートカット対応（#88）
   - `Ctrl+A`: ファイル一覧を全選択。
   - `Ctrl+C` / `Ctrl+X`: 選択ファイルをコピー / 切り取り対象として記録。

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.UI.Input;
@@ -602,7 +604,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
                             : await StorageFile.GetFileFromPathAsync(item.FilePath);
                         storageItems.Add(storageItem);
                     }
-                    catch (Exception) { }
+                    catch (Exception ex) when (ex is FileNotFoundException or UnauthorizedAccessException or IOException or COMException) { }
                 }
 
                 request.SetData(storageItems);

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
@@ -412,7 +412,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
         e.AcceptedOperation = accepted;
         if (accepted != DataPackageOperation.None)
         {
-            e.DragUIOverride.Caption = "移動";
+            e.DragUIOverride.Caption = LocalizationService.GetString("DragCaption.Move");
             e.DragUIOverride.IsCaptionVisible = true;
         }
 
@@ -460,7 +460,9 @@ internal sealed partial class FileBrowserPaneView : UserControl
                 var ctrlState = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control);
                 var isCopy = (ctrlState & Windows.UI.Core.CoreVirtualKeyStates.Down) != 0;
                 e.AcceptedOperation = isCopy ? DataPackageOperation.Copy : DataPackageOperation.Move;
-                e.DragUIOverride.Caption = isCopy ? "コピー" : "移動";
+                e.DragUIOverride.Caption = isCopy
+                    ? LocalizationService.GetString("DragCaption.Copy")
+                    : LocalizationService.GetString("DragCaption.Move");
                 e.DragUIOverride.IsCaptionVisible = true;
             }
             else
@@ -475,7 +477,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
         if (e.DataView.Contains(StandardDataFormats.StorageItems))
         {
             e.AcceptedOperation = DataPackageOperation.Copy;
-            e.DragUIOverride.Caption = "コピー";
+            e.DragUIOverride.Caption = LocalizationService.GetString("DragCaption.Copy");
             e.DragUIOverride.IsCaptionVisible = true;
         }
         else
@@ -604,7 +606,15 @@ internal sealed partial class FileBrowserPaneView : UserControl
                             : await StorageFile.GetFileFromPathAsync(item.FilePath);
                         storageItems.Add(storageItem);
                     }
-                    catch (Exception ex) when (ex is FileNotFoundException or UnauthorizedAccessException or IOException or COMException) { }
+                    catch (Exception ex) when (ex is FileNotFoundException
+                        or UnauthorizedAccessException
+                        or ArgumentException
+                        or NotSupportedException
+                        or PathTooLongException
+                        or COMException)
+                    {
+                        AppLog.Error($"Failed to provide drag storage item: {item.FilePath}", ex);
+                    }
                 }
 
                 request.SetData(storageItems);

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
@@ -30,6 +30,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
     private const string DetailsColumnTakenAtTag = "TakenAt";
     private const string DetailsColumnLocationTag = "Location";
     private List<PhotoListItem>? _dragItems;
+    private bool _wasInternalDrop;
     private bool _suppressBreadcrumbNavigation;
     private bool _isWaitingForXamlRoot;
     private FileBrowserPaneViewModel? _previousViewModel;
@@ -402,9 +403,16 @@ internal sealed partial class FileBrowserPaneView : UserControl
             return;
         }
 
-        e.AcceptedOperation = TryGetBreadcrumbTarget(breadcrumbBar, e, out _)
+        var accepted = TryGetBreadcrumbTarget(breadcrumbBar, e, out _)
             ? DataPackageOperation.Move
             : DataPackageOperation.None;
+
+        e.AcceptedOperation = accepted;
+        if (accepted != DataPackageOperation.None)
+        {
+            e.DragUIOverride.Caption = "移動";
+            e.DragUIOverride.IsCaptionVisible = true;
+        }
 
         e.Handled = true;
     }
@@ -426,6 +434,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
             return;
         }
 
+        _wasInternalDrop = true;
         var items = _dragItems ?? ViewModel.SelectedItems;
         var summary = await ViewModel.ExecuteMoveItemsToFolderAsync(items, target.FullPath).ConfigureAwait(true);
         if (summary.HasFailures)
@@ -444,18 +453,34 @@ internal sealed partial class FileBrowserPaneView : UserControl
                 return;
             }
 
-            e.AcceptedOperation = sender is ListViewBase listView
-                && TryGetDropTargetFolder(listView, RootGrid, e, out _)
-                ? DataPackageOperation.Move
-                : DataPackageOperation.None;
+            if (sender is ListViewBase listView && TryGetDropTargetFolder(listView, RootGrid, e, out _))
+            {
+                var ctrlState = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control);
+                var isCopy = (ctrlState & Windows.UI.Core.CoreVirtualKeyStates.Down) != 0;
+                e.AcceptedOperation = isCopy ? DataPackageOperation.Copy : DataPackageOperation.Move;
+                e.DragUIOverride.Caption = isCopy ? "コピー" : "移動";
+                e.DragUIOverride.IsCaptionVisible = true;
+            }
+            else
+            {
+                e.AcceptedOperation = DataPackageOperation.None;
+            }
 
             e.Handled = true;
             return;
         }
 
-        e.AcceptedOperation = e.DataView.Contains(StandardDataFormats.StorageItems)
-            ? DataPackageOperation.Copy
-            : DataPackageOperation.None;
+        if (e.DataView.Contains(StandardDataFormats.StorageItems))
+        {
+            e.AcceptedOperation = DataPackageOperation.Copy;
+            e.DragUIOverride.Caption = "コピー";
+            e.DragUIOverride.IsCaptionVisible = true;
+        }
+        else
+        {
+            e.AcceptedOperation = DataPackageOperation.None;
+        }
+
         e.Handled = true;
     }
 
@@ -476,12 +501,26 @@ internal sealed partial class FileBrowserPaneView : UserControl
             if (sender is ListViewBase listView
                 && TryGetDropTargetFolder(listView, RootGrid, e, out var targetFolder))
             {
+                _wasInternalDrop = true;
                 var selectedItems = _dragItems ?? ViewModel.SelectedItems;
-                var summary = await ViewModel.ExecuteMoveItemsToFolderAsync(selectedItems, targetFolder.FilePath)
-                    .ConfigureAwait(true);
-                if (summary.HasFailures)
+                FileOperationSummary summary;
+                if (e.AcceptedOperation == DataPackageOperation.Copy)
                 {
-                    await ShowMoveOperationErrorDialogAsync(summary).ConfigureAwait(true);
+                    summary = await ViewModel.ExecuteCopyItemsToFolderAsync(selectedItems, targetFolder.FilePath)
+                        .ConfigureAwait(true);
+                    if (summary.HasFailures)
+                    {
+                        await ShowCopyOperationErrorDialogAsync(summary).ConfigureAwait(true);
+                    }
+                }
+                else
+                {
+                    summary = await ViewModel.ExecuteMoveItemsToFolderAsync(selectedItems, targetFolder.FilePath)
+                        .ConfigureAwait(true);
+                    if (summary.HasFailures)
+                    {
+                        await ShowMoveOperationErrorDialogAsync(summary).ConfigureAwait(true);
+                    }
                 }
             }
 
@@ -541,13 +580,55 @@ internal sealed partial class FileBrowserPaneView : UserControl
         {
             _dragItems = ViewModel.SelectedItems.ToList();
         }
-        e.Data.RequestedOperation = DataPackageOperation.Move;
+
+        // Copy と Move の両方を提供することで、外部アプリがドライブ情報に基づき操作を決定できる
+        e.Data.RequestedOperation = DataPackageOperation.Copy | DataPackageOperation.Move;
         e.Data.Properties[InternalDragKey] = true;
+
+        // ドラッグアウト: StorageItems を遅延提供して Explorer や他アプリが受け取れるようにする
+        var capturedItems = _dragItems.ToList();
+        e.Data.SetDataProvider(StandardDataFormats.StorageItems, async request =>
+        {
+            var deferral = request.GetDeferral();
+            try
+            {
+                var storageItems = new List<IStorageItem>();
+                foreach (var item in capturedItems)
+                {
+                    try
+                    {
+                        IStorageItem storageItem = item.IsFolder
+                            ? await StorageFolder.GetFolderFromPathAsync(item.FilePath)
+                            : await StorageFile.GetFileFromPathAsync(item.FilePath);
+                        storageItems.Add(storageItem);
+                    }
+                    catch (Exception) { }
+                }
+
+                request.SetData(storageItems);
+            }
+            finally
+            {
+                deferral.Complete();
+            }
+        });
     }
 
-    private void OnFileItemsDragCompleted(object sender, DragItemsCompletedEventArgs e)
+    private async void OnFileItemsDragCompleted(object sender, DragItemsCompletedEventArgs e)
     {
+        var items = _dragItems;
+        var wasInternal = _wasInternalDrop;
         _dragItems = null;
+        _wasInternalDrop = false;
+
+        // 外部アプリへの Move 完了後にリストを更新して移動済みアイテムを除去する
+        if (ViewModel is not null
+            && items is { Count: > 0 }
+            && e.DropResult == DataPackageOperation.Move
+            && !wasInternal)
+        {
+            await ViewModel.RefreshAsync().ConfigureAwait(false);
+        }
     }
 
     private void OnFileListRightTapped(object sender, RightTappedRoutedEventArgs e)

--- a/PhotoGeoExplorer/Strings/en-US/Resources.resw
+++ b/PhotoGeoExplorer/Strings/en-US/Resources.resw
@@ -863,4 +863,10 @@
   <data name="CancelMoveButton.Content" xml:space="preserve">
     <value>Cancel</value>
   </data>
+  <data name="DragCaption.Copy" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="DragCaption.Move" xml:space="preserve">
+    <value>Move</value>
+  </data>
 </root>

--- a/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
+++ b/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
@@ -863,4 +863,10 @@
   <data name="CancelMoveButton.Content" xml:space="preserve">
     <value>中止</value>
   </data>
+  <data name="DragCaption.Copy" xml:space="preserve">
+    <value>コピー</value>
+  </data>
+  <data name="DragCaption.Move" xml:space="preserve">
+    <value>移動</value>
+  </data>
 </root>


### PR DESCRIPTION
## 概要

Issue #89 の未完了受け入れ条件（ドラッグアウト・Ctrl コピー・フィードバック・自動更新）を実装します。

## 変更内容

### ドラッグアウト対応
- `OnFileItemsDragStarting` で `SetDataProvider(StandardDataFormats.StorageItems, ...)` を追加
- deferral を使って非同期で `StorageFile`/`StorageFolder` を取得し、Explorer や画像ビューア等の外部アプリが受け取れるようにした

### RequestedOperation の変更
- `DataPackageOperation.Move` のみ → `DataPackageOperation.Copy | DataPackageOperation.Move` に変更
- 同一/別ドライブの判定を外部アプリ（Explorer）側に委ねる Windows 標準動作に準拠

### Ctrl+ドラッグ でコピー
- `OnFileListDragOver` で `InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control)` を使って Ctrl キー状態を検出
- Ctrl 押下時: `AcceptedOperation = Copy`、通常時: `Move`
- `OnFileListDrop` で `e.AcceptedOperation` に応じて `ExecuteCopyItemsToFolderAsync` / `ExecuteMoveItemsToFolderAsync` を呼び分け

### ドラッグ中のフィードバック表示
- `DragUIOverride.Caption` に「コピー」/「移動」を設定（ファイルリスト・ブレッドクラム両方）

### 外部 Move 完了後の自動更新
- `OnFileItemsDragCompleted` を `async void` に変更
- `e.DropResult == Move && !_wasInternalDrop` の場合に `ViewModel.RefreshAsync()` を呼ぶ
- 内部ドロップ（`OnBreadcrumbDrop` / `OnFileListDrop`）では `_wasInternalDrop = true` をセットして二重更新を防止

## 受け入れ条件の対応状況

- [x] `Ctrl+ドラッグ` がコピーとして扱われる
- [x] ドラッグ中にコピー/移動の状態がユーザーに分かる
- [x] PhotoGeoExplorer から Explorer の別フォルダへドラッグすると同一/別ドライブで移動/コピーになる
- [x] Explorer への Move 完了後、PhotoGeoExplorer のリストから移動したファイルが消える
- [x] 画像ビューア等の他アプリへドラッグするとファイルが渡る

## 検証方法

```
# CI (SixLabors ライセンスが必要なためローカルビルド不可)
# 手動検証:
# 1. PhotoGeoExplorer からファイルを Explorer へドラッグ → 同一ドライブで移動、別ドライブでコピー
# 2. Ctrl を押しながらドラッグ → キャプション「コピー」が表示され、コピーになる
# 3. 通常ドラッグ → キャプション「移動」が表示される
# 4. 外部移動後にリストが更新されることを確認
# 5. 内部ドロップが引き続き正常動作することを確認
```

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)