### PR TITLE
feat(copy): Ctrl+ドラッグ内部コピーに競合確認・進捗・キャンセル対応を追加 (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@
   - UI 文言を「削除」から「ゴミ箱へ移動」に統一（メニュー・確認ダイアログ・エラーダイアログ）。
 
 ### 追加
+- Ctrl+ドラッグ（内部コピー）に競合確認・進捗・キャンセル対応を追加（#108）
+  - `IFileOperationService.CopyItemsAsync` を追加。競合ダイアログコールバック・`IProgress<int>`・`CancellationToken` に対応。
+  - `FileOperationService.CopyItemsAsync` を実装（`MoveItemsAsync` と同パターン: 上書き/スキップ/中止 選択可能）。
+  - `FileBrowserPaneViewModel` にコピー進捗フィールド・`IsCopyInProgress`・`CancelCopyCommand`・`CancelCopyVisibility` を追加。
+  - `ExecuteCopyItemsToFolderAsync` を `resolveConflictAsync` 対応の非同期版に更新。
+  - `ExecutePasteAsync` をコピー貼り付け時も競合ダイアログを表示するよう更新。
+  - `ShowCopyConflictDialogAsync` をView 層に追加（上書き/すべて上書き/スキップ/すべてスキップ/中止）。
+  - ステータスバーにコピー中止ボタン `CancelCopyButton` を追加。
+  - リソースファイルに `Dialog.CopyConflict.*`、`Message.CopyProgress`、`Message.CopyDone`、`CancelCopyButton.Content` を追加。
 - Explorer 風のドラッグアウト対応（#89）
   - `DragItemsStarting` で `SetDataProvider(StorageItems)` を追加し、Explorer や他アプリへのドラッグアウトを実現。
   - `RequestedOperation = Copy | Move` に変更して、同一/別ドライブの挙動を Explorer 側に委ねる。

--- a/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
@@ -1099,6 +1099,53 @@ public class FileBrowserPaneViewModelTests
     }
 
     [Fact]
+    public async Task ExecuteCopyItemsToFolderAsync_WithConflictCallback_ReturnsAsyncSummary()
+    {
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            using var vm = CreateViewModelWithFakes(out var fakePaneService, out var stubOp);
+            stubOp.CopyItemsResult = new FileOperationSummary(2, 0, Array.Empty<FileOperationFailure>());
+            await vm.LoadFolderAsync(tempDir);
+            var before = fakePaneService.LoadFolderCallCount;
+            var items = new List<PhotoListItem> { CreatePhotoListItem("a.jpg"), CreatePhotoListItem("b.jpg") };
+
+            var summary = await vm.ExecuteCopyItemsToFolderAsync(
+                items, tempDir, (_, _) => Task.FromResult(ConflictResolution.Skip));
+
+            Assert.Equal(2, summary.SuccessCount);
+            Assert.Equal(before + 1, fakePaneService.LoadFolderCallCount);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public async Task ExecutePasteAsync_CopyOperation_WithConflictCallback_ReturnsSuccess()
+    {
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            using var vm = CreateViewModelWithFakes(out _, out var stubOp);
+            stubOp.CopyItemsResult = new FileOperationSummary(1, 0, Array.Empty<FileOperationFailure>());
+            await vm.LoadFolderAsync(tempDir);
+            vm.SetClipboard(new List<PhotoListItem> { CreatePhotoListItem("photo.jpg") }, ClipboardOperation.Copy);
+
+            var summary = await vm.ExecutePasteAsync(
+                resolveMoveConflictAsync: null,
+                resolveCopyConflictAsync: (_, _) => Task.FromResult(ConflictResolution.Skip));
+
+            Assert.Equal(1, summary.SuccessCount);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    [Fact]
     public async Task ExecutePasteAsync_CutOperation_CallsMoveItemsAndClearsClipboard()
     {
         var tempDir = CreateTempTestDirectory();
@@ -1315,6 +1362,12 @@ public class FileBrowserPaneViewModelTests
             IProgress<int>? progress = null,
             CancellationToken cancellationToken = default) => Task.FromResult(MoveItemsResult);
         public FileOperationSummary CopyItems(IReadOnlyList<PhotoListItem> items, string destinationFolder) => CopyItemsResult;
+        public Task<FileOperationSummary> CopyItemsAsync(
+            IReadOnlyList<PhotoListItem> items,
+            string destinationFolder,
+            Func<string, bool, Task<ConflictResolution>> resolveConflictAsync,
+            IProgress<int>? progress = null,
+            CancellationToken cancellationToken = default) => Task.FromResult(CopyItemsResult);
         public Task<FileOperationSummary> DeleteItemsAsync(IReadOnlyList<PhotoListItem> items) => Task.FromResult(DeleteItemsResult);
     }
 

--- a/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/FileOperationServiceTests.cs
@@ -801,6 +801,119 @@ public sealed class FileOperationServiceTests
     }
 
     // =========================================================
+    // CopyItemsAsync
+    // =========================================================
+
+    [Fact]
+    public async Task CopyItemsAsync_SamePath_SkipsWithoutDeletingSource()
+    {
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "photo.jpg");
+            await File.WriteAllTextAsync(srcPath, "content");
+            var items = new List<PhotoListItem> { CreateFileItem(srcPath) };
+
+            // 同一フォルダへのコピーは同一パスになる
+            var summary = await _service.CopyItemsAsync(
+                items, tempDir, (_, _) => Task.FromResult(ConflictResolution.Overwrite));
+
+            Assert.Equal(0, summary.SuccessCount);
+            Assert.Equal(1, summary.SkipCount);
+            Assert.True(File.Exists(srcPath), "ソースファイルが削除されていないこと");
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public async Task CopyItemsAsync_ConflictOverwrite_OverwritesExisting()
+    {
+        var tempDir = CreateTempTestDirectory();
+        var destDir = CreateTempTestDirectory();
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "photo.jpg");
+            var conflictPath = Path.Combine(destDir, "photo.jpg");
+            await File.WriteAllTextAsync(srcPath, "new");
+            await File.WriteAllTextAsync(conflictPath, "old");
+            var items = new List<PhotoListItem> { CreateFileItem(srcPath) };
+
+            var summary = await _service.CopyItemsAsync(
+                items, destDir, (_, _) => Task.FromResult(ConflictResolution.Overwrite));
+
+            Assert.Equal(1, summary.SuccessCount);
+            Assert.Equal("new", await File.ReadAllTextAsync(conflictPath));
+            Assert.True(File.Exists(srcPath), "コピー元は残っていること");
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+            CleanupTempDirectory(destDir);
+        }
+    }
+
+    [Fact]
+    public async Task CopyItemsAsync_ConflictSkip_LeavesExistingAndCounts()
+    {
+        var tempDir = CreateTempTestDirectory();
+        var destDir = CreateTempTestDirectory();
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "photo.jpg");
+            var conflictPath = Path.Combine(destDir, "photo.jpg");
+            await File.WriteAllTextAsync(srcPath, "new");
+            await File.WriteAllTextAsync(conflictPath, "old");
+            var items = new List<PhotoListItem> { CreateFileItem(srcPath) };
+
+            var summary = await _service.CopyItemsAsync(
+                items, destDir, (_, _) => Task.FromResult(ConflictResolution.Skip));
+
+            Assert.Equal(0, summary.SuccessCount);
+            Assert.Equal(1, summary.SkipCount);
+            Assert.Equal("old", await File.ReadAllTextAsync(conflictPath));
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+            CleanupTempDirectory(destDir);
+        }
+    }
+
+    [Fact]
+    public async Task CopyItemsAsync_Cancelled_StopsProcessing()
+    {
+        var tempDir = CreateTempTestDirectory();
+        var destDir = CreateTempTestDirectory();
+        try
+        {
+            var src1 = Path.Combine(tempDir, "a.jpg");
+            var src2 = Path.Combine(tempDir, "b.jpg");
+            await File.WriteAllTextAsync(src1, "a");
+            await File.WriteAllTextAsync(src2, "b");
+            var items = new List<PhotoListItem> { CreateFileItem(src1), CreateFileItem(src2) };
+
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+
+            var summary = await _service.CopyItemsAsync(
+                items, destDir, (_, _) => Task.FromResult(ConflictResolution.Skip),
+                cancellationToken: cts.Token);
+
+            Assert.Equal(0, summary.SuccessCount);
+            Assert.True(summary.HasFailures);
+            Assert.Equal(FileOperationError.Cancelled, summary.Failures[0].Error);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+            CleanupTempDirectory(destDir);
+        }
+    }
+
+    // =========================================================
     // DeleteItemsAsync
     // =========================================================
 

--- a/PhotoGeoExplorer/MainWindow.xaml
+++ b/PhotoGeoExplorer/MainWindow.xaml
@@ -191,6 +191,7 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                         <SymbolIcon
@@ -209,6 +210,13 @@
                         x:Uid="CancelMoveButton"
                         Command="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.CancelMoveCommand}"
                         Visibility="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.CancelMoveVisibility}"
+                        Padding="8,2"
+                        VerticalAlignment="Center" />
+                    <Button
+                        Grid.Column="2"
+                        x:Uid="CancelCopyButton"
+                        Command="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.CancelCopyCommand}"
+                        Visibility="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.CancelCopyVisibility}"
                         Padding="8,2"
                         VerticalAlignment="Center" />
                 </Grid>

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
@@ -510,9 +510,10 @@ internal sealed partial class FileBrowserPaneView : UserControl
                 FileOperationSummary summary;
                 if (e.AcceptedOperation == DataPackageOperation.Copy)
                 {
-                    summary = await ViewModel.ExecuteCopyItemsToFolderAsync(selectedItems, targetFolder.FilePath)
+                    summary = await ViewModel.ExecuteCopyItemsToFolderAsync(
+                        selectedItems, targetFolder.FilePath, ShowCopyConflictDialogAsync)
                         .ConfigureAwait(true);
-                    if (summary.HasFailures)
+                    if (summary.HasFailures && summary.Failures.Any(f => f.Error != FileOperationError.Cancelled))
                     {
                         await ShowCopyOperationErrorDialogAsync(summary).ConfigureAwait(true);
                     }
@@ -790,8 +791,9 @@ internal sealed partial class FileBrowserPaneView : UserControl
 
         var isCut = ViewModel.IsCutClipboard;
         var summary = await ViewModel.ExecutePasteAsync(
-            isCut ? ShowMoveConflictDialogAsync : null).ConfigureAwait(true);
-        if (summary.HasFailures)
+            resolveMoveConflictAsync: isCut ? ShowMoveConflictDialogAsync : null,
+            resolveCopyConflictAsync: isCut ? null : ShowCopyConflictDialogAsync).ConfigureAwait(true);
+        if (summary.HasFailures && summary.Failures.Any(f => f.Error != FileOperationError.Cancelled))
         {
             if (isCut)
             {
@@ -926,6 +928,69 @@ internal sealed partial class FileBrowserPaneView : UserControl
         var skipAllButton = new Button
         {
             Content = LocalizationService.GetString("Dialog.MoveConflict.SkipAll"),
+        };
+
+        ConflictResolution? extraChoice = null;
+        overwriteAllButton.Click += (_, _) =>
+        {
+            extraChoice = ConflictResolution.OverwriteAll;
+            dialog.Hide();
+        };
+        skipAllButton.Click += (_, _) =>
+        {
+            extraChoice = ConflictResolution.SkipAll;
+            dialog.Hide();
+        };
+
+        dialog.Content = new StackPanel
+        {
+            Spacing = 12,
+            Children =
+            {
+                new TextBlock { Text = detail, TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap },
+                new StackPanel
+                {
+                    Orientation = Microsoft.UI.Xaml.Controls.Orientation.Horizontal,
+                    Children = { overwriteAllButton, skipAllButton },
+                },
+            },
+        };
+
+        var result = await dialog.ShowAsync();
+        if (extraChoice.HasValue)
+        {
+            return extraChoice.Value;
+        }
+
+        return result switch
+        {
+            ContentDialogResult.Primary => ConflictResolution.Overwrite,
+            ContentDialogResult.Secondary => ConflictResolution.Skip,
+            _ => ConflictResolution.Cancel,
+        };
+    }
+
+    private async Task<ConflictResolution> ShowCopyConflictDialogAsync(string fileName, bool isFolder)
+    {
+        var detail = LocalizationService.Format("Dialog.CopyConflict.Detail", fileName);
+        var dialog = new ContentDialog
+        {
+            Title = LocalizationService.GetString("Dialog.CopyConflict.Title"),
+            Content = detail,
+            PrimaryButtonText = LocalizationService.GetString("Dialog.CopyConflict.Overwrite"),
+            SecondaryButtonText = LocalizationService.GetString("Dialog.CopyConflict.Skip"),
+            CloseButtonText = LocalizationService.GetString("Dialog.CopyConflict.Cancel"),
+            XamlRoot = XamlRoot,
+        };
+
+        var overwriteAllButton = new Button
+        {
+            Content = LocalizationService.GetString("Dialog.CopyConflict.OverwriteAll"),
+            Margin = new Microsoft.UI.Xaml.Thickness(0, 0, 8, 0),
+        };
+        var skipAllButton = new Button
+        {
+            Content = LocalizationService.GetString("Dialog.CopyConflict.SkipAll"),
         };
 
         ConflictResolution? extraChoice = null;

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -87,6 +87,11 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     private int _moveCompleted;
     private bool _isMoveInProgress;
     private DispatcherQueueTimer? _moveProgressTimer;
+    private CancellationTokenSource? _copyCts;
+    private int _copyTotal;
+    private int _copyCompleted;
+    private bool _isCopyInProgress;
+    private DispatcherQueueTimer? _copyProgressTimer;
     private IReadOnlyList<PhotoListItem> _clipboardItems = Array.Empty<PhotoListItem>();
     private ClipboardOperation _clipboardOperation = ClipboardOperation.None;
 
@@ -170,6 +175,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
             async () => await ExecuteUiActionAsync(_deleteSelectionAction).ConfigureAwait(false),
             () => _deleteSelectionAction is not null && CanModifySelection);
         CancelMoveCommand = new RelayCommand(async () => await (_moveCts?.CancelAsync() ?? Task.CompletedTask).ConfigureAwait(false), () => IsMoveInProgress);
+        CancelCopyCommand = new RelayCommand(async () => await (_copyCts?.CancelAsync() ?? Task.CompletedTask).ConfigureAwait(false), () => IsCopyInProgress);
     }
 
     public ObservableCollection<PhotoListItem> Items { get; }
@@ -509,10 +515,25 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 
     public Visibility CancelMoveVisibility => _isMoveInProgress ? Visibility.Visible : Visibility.Collapsed;
 
+    public bool IsCopyInProgress
+    {
+        get => _isCopyInProgress;
+        private set
+        {
+            if (SetProperty(ref _isCopyInProgress, value))
+            {
+                OnPropertyChanged(nameof(CancelCopyVisibility));
+            }
+        }
+    }
+
+    public Visibility CancelCopyVisibility => _isCopyInProgress ? Visibility.Visible : Visibility.Collapsed;
+
     public bool CanPasteSelection => _clipboardItems.Count > 0 && !string.IsNullOrWhiteSpace(CurrentFolderPath);
     public bool IsCutClipboard => _clipboardOperation == ClipboardOperation.Cut;
 
     public ICommand CancelMoveCommand { get; private set; }
+    public ICommand CancelCopyCommand { get; private set; }
 
     public Symbol StatusBarLocationSymbol
     {
@@ -748,11 +769,87 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
             "Message.MoveProgress", completed, _moveTotal);
     }
 
-    internal Task<FileOperationSummary> ExecuteCopyItemsToFolderAsync(
-        IReadOnlyList<PhotoListItem> items, string destinationFolder)
+    internal async Task<FileOperationSummary> ExecuteCopyItemsToFolderAsync(
+        IReadOnlyList<PhotoListItem> items,
+        string destinationFolder,
+        Func<string, bool, Task<ConflictResolution>>? resolveConflictAsync = null)
     {
-        var summary = _fileOperationService.CopyItems(items, destinationFolder);
-        return Task.FromResult(summary);
+        if (resolveConflictAsync is null)
+        {
+            var summary = _fileOperationService.CopyItems(items, destinationFolder);
+            if (summary.SuccessCount > 0)
+            {
+                await RefreshAsync().ConfigureAwait(false);
+            }
+
+            return summary;
+        }
+
+        _copyCts = new CancellationTokenSource();
+        _copyTotal = items.Count;
+        _copyCompleted = 0;
+        IsCopyInProgress = true;
+        ((RelayCommand)CancelCopyCommand).RaiseCanExecuteChanged();
+
+        StartCopyProgressTimer();
+
+        Func<string, bool, Task<ConflictResolution>> marshalledCallback = async (name, isFolder) =>
+            await EnqueueOnUIThreadAsync(() => resolveConflictAsync(name, isFolder)).ConfigureAwait(false);
+
+        FileOperationSummary result;
+        try
+        {
+            var progress = new Progress<int>(completed =>
+            {
+                Interlocked.Exchange(ref _copyCompleted, completed);
+            });
+
+            result = await Task.Run(() => _fileOperationService.CopyItemsAsync(
+                items, destinationFolder, marshalledCallback, progress, _copyCts.Token))
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            StopCopyProgressTimer();
+            IsCopyInProgress = false;
+            ((RelayCommand)CancelCopyCommand).RaiseCanExecuteChanged();
+            _copyCts.Dispose();
+            _copyCts = null;
+        }
+
+        if (result.SuccessCount > 0)
+        {
+            await RefreshAsync().ConfigureAwait(false);
+        }
+
+        var doneText = LocalizationService.Format(
+            "Message.CopyDone", result.SuccessCount, result.SkipCount, result.FailureCount);
+        await RunOnUIThreadAsync(() => StatusBarText = doneText).ConfigureAwait(false);
+
+        return result;
+    }
+
+    private void StartCopyProgressTimer()
+    {
+        if (_dispatcherQueue is null) return;
+
+        _copyProgressTimer = _dispatcherQueue.CreateTimer();
+        _copyProgressTimer.Interval = TimeSpan.FromMilliseconds(300);
+        _copyProgressTimer.Tick += OnCopyProgressTick;
+        _copyProgressTimer.Start();
+    }
+
+    private void StopCopyProgressTimer()
+    {
+        _copyProgressTimer?.Stop();
+        _copyProgressTimer = null;
+    }
+
+    private void OnCopyProgressTick(DispatcherQueueTimer sender, object args)
+    {
+        var completed = Volatile.Read(ref _copyCompleted);
+        StatusBarText = LocalizationService.Format(
+            "Message.CopyProgress", completed, _copyTotal);
     }
 
     internal void SetClipboard(IReadOnlyList<PhotoListItem> items, ClipboardOperation operation)
@@ -764,7 +861,8 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     }
 
     internal async Task<FileOperationSummary> ExecutePasteAsync(
-        Func<string, bool, Task<ConflictResolution>>? resolveConflictAsync = null)
+        Func<string, bool, Task<ConflictResolution>>? resolveMoveConflictAsync = null,
+        Func<string, bool, Task<ConflictResolution>>? resolveCopyConflictAsync = null)
     {
         if (_clipboardItems.Count == 0 || string.IsNullOrWhiteSpace(CurrentFolderPath))
         {
@@ -776,16 +874,10 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 
         if (operation == ClipboardOperation.Copy)
         {
-            var summary = await ExecuteCopyItemsToFolderAsync(items, CurrentFolderPath!).ConfigureAwait(false);
-            if (summary.SuccessCount > 0)
-            {
-                await RefreshAsync().ConfigureAwait(false);
-            }
-
-            return summary;
+            return await ExecuteCopyItemsToFolderAsync(items, CurrentFolderPath!, resolveCopyConflictAsync).ConfigureAwait(false);
         }
 
-        var moveResult = await ExecuteMoveItemsToFolderAsync(items, CurrentFolderPath!, resolveConflictAsync).ConfigureAwait(false);
+        var moveResult = await ExecuteMoveItemsToFolderAsync(items, CurrentFolderPath!, resolveMoveConflictAsync).ConfigureAwait(false);
         if (moveResult.FailureCount == 0 && moveResult.SkipCount == 0)
         {
             _clipboardItems = Array.Empty<PhotoListItem>();
@@ -1190,6 +1282,9 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         StopMoveProgressTimer();
         _moveCts?.Cancel();
         _moveCts?.Dispose();
+        StopCopyProgressTimer();
+        _copyCts?.Cancel();
+        _copyCts?.Dispose();
         _thumbnailGenerationSemaphore.Dispose();
     }
 

--- a/PhotoGeoExplorer/Services/FileOperationService.cs
+++ b/PhotoGeoExplorer/Services/FileOperationService.cs
@@ -205,6 +205,136 @@ internal sealed class FileOperationService : IFileOperationService
         }
     }
 
+    public async Task<FileOperationSummary> CopyItemsAsync(
+        IReadOnlyList<PhotoListItem> items,
+        string destinationFolder,
+        Func<string, bool, Task<ConflictResolution>> resolveConflictAsync,
+        IProgress<int>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var successCount = 0;
+        var skipCount = 0;
+        var failures = new List<FileOperationFailure>();
+        var overwriteAll = false;
+        var skipAll = false;
+
+        for (var i = 0; i < items.Count; i++)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                failures.Add(new FileOperationFailure(items[i].FilePath, items[i].FileName, FileOperationError.Cancelled));
+                break;
+            }
+
+            var item = items[i];
+            var sourcePath = item.FilePath;
+            var targetPath = Path.Combine(destinationFolder, item.FileName);
+
+            if (item.IsFolder && IsDescendantPath(sourcePath, destinationFolder))
+            {
+                failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.DescendantPath));
+                progress?.Report(i + 1);
+                continue;
+            }
+
+            if (ItemExistsAtPath(targetPath))
+            {
+                ConflictResolution resolution;
+                if (overwriteAll)
+                {
+                    resolution = ConflictResolution.Overwrite;
+                }
+                else if (skipAll)
+                {
+                    resolution = ConflictResolution.Skip;
+                }
+                else
+                {
+                    resolution = await resolveConflictAsync(item.FileName, item.IsFolder).ConfigureAwait(false);
+                    if (resolution == ConflictResolution.OverwriteAll)
+                    {
+                        overwriteAll = true;
+                        resolution = ConflictResolution.Overwrite;
+                    }
+                    else if (resolution == ConflictResolution.SkipAll)
+                    {
+                        skipAll = true;
+                        resolution = ConflictResolution.Skip;
+                    }
+                }
+
+                if (resolution == ConflictResolution.Cancel)
+                {
+                    failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.Cancelled));
+                    break;
+                }
+
+                if (resolution == ConflictResolution.Skip)
+                {
+                    skipCount++;
+                    progress?.Report(i + 1);
+                    continue;
+                }
+
+                // Overwrite: 既存を削除してからコピー
+                try
+                {
+                    if (item.IsFolder)
+                    {
+                        Directory.Delete(targetPath, recursive: true);
+                    }
+                    else
+                    {
+                        File.Delete(targetPath);
+                    }
+                }
+                catch (Exception ex) when (ex is UnauthorizedAccessException)
+                {
+                    AppLog.Error($"Failed to delete existing item for overwrite: {targetPath}", ex);
+                    failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.Unauthorized));
+                    progress?.Report(i + 1);
+                    continue;
+                }
+                catch (Exception ex) when (ex is IOException or NotSupportedException or ArgumentException or PathTooLongException)
+                {
+                    AppLog.Error($"Failed to delete existing item for overwrite: {targetPath}", ex);
+                    failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.IoError));
+                    progress?.Report(i + 1);
+                    continue;
+                }
+            }
+
+            try
+            {
+                if (item.IsFolder)
+                {
+                    CopyDirectory(sourcePath, targetPath);
+                }
+                else
+                {
+                    File.Copy(sourcePath, targetPath, overwrite: false);
+                }
+
+                successCount++;
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException)
+            {
+                AppLog.Error($"Failed to copy item: {sourcePath}", ex);
+                failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.Unauthorized));
+            }
+            catch (Exception ex) when (ex is IOException or NotSupportedException or ArgumentException or PathTooLongException)
+            {
+                AppLog.Error($"Failed to copy item: {sourcePath}", ex);
+                failures.Add(new FileOperationFailure(sourcePath, item.FileName, FileOperationError.IoError));
+            }
+
+            progress?.Report(i + 1);
+        }
+
+        AppLog.Info($"CopyItemsAsync: success={successCount}, skip={skipCount}, failure={failures.Count}");
+        return new FileOperationSummary(successCount, skipCount, failures);
+    }
+
     public FileOperationSummary MoveItems(IReadOnlyList<PhotoListItem> items, string destinationFolder)
     {
         var successCount = 0;

--- a/PhotoGeoExplorer/Services/FileOperationService.cs
+++ b/PhotoGeoExplorer/Services/FileOperationService.cs
@@ -237,6 +237,14 @@ internal sealed class FileOperationService : IFileOperationService
                 continue;
             }
 
+            // 同一パスへのコピーは上書きするとソースを失うため無条件スキップ
+            if (IsSamePath(sourcePath, targetPath))
+            {
+                skipCount++;
+                progress?.Report(i + 1);
+                continue;
+            }
+
             if (ItemExistsAtPath(targetPath))
             {
                 ConflictResolution resolution;

--- a/PhotoGeoExplorer/Services/IFileOperationService.cs
+++ b/PhotoGeoExplorer/Services/IFileOperationService.cs
@@ -32,5 +32,11 @@ internal interface IFileOperationService
         IProgress<int>? progress = null,
         CancellationToken cancellationToken = default);
     FileOperationSummary CopyItems(IReadOnlyList<PhotoListItem> items, string destinationFolder);
+    Task<FileOperationSummary> CopyItemsAsync(
+        IReadOnlyList<PhotoListItem> items,
+        string destinationFolder,
+        Func<string, bool, Task<ConflictResolution>> resolveConflictAsync,
+        IProgress<int>? progress = null,
+        CancellationToken cancellationToken = default);
     Task<FileOperationSummary> DeleteItemsAsync(IReadOnlyList<PhotoListItem> items);
 }

--- a/PhotoGeoExplorer/Strings/en-US/Resources.resw
+++ b/PhotoGeoExplorer/Strings/en-US/Resources.resw
@@ -869,4 +869,34 @@
   <data name="DragCaption.Move" xml:space="preserve">
     <value>Move</value>
   </data>
+  <data name="Dialog.CopyConflict.Title" xml:space="preserve">
+    <value>Item already exists at destination</value>
+  </data>
+  <data name="Dialog.CopyConflict.Detail" xml:space="preserve">
+    <value>"{0}" already exists at the destination. Do you want to overwrite it?</value>
+  </data>
+  <data name="Dialog.CopyConflict.Overwrite" xml:space="preserve">
+    <value>Overwrite</value>
+  </data>
+  <data name="Dialog.CopyConflict.OverwriteAll" xml:space="preserve">
+    <value>Overwrite All</value>
+  </data>
+  <data name="Dialog.CopyConflict.Skip" xml:space="preserve">
+    <value>Skip</value>
+  </data>
+  <data name="Dialog.CopyConflict.SkipAll" xml:space="preserve">
+    <value>Skip All</value>
+  </data>
+  <data name="Dialog.CopyConflict.Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Message.CopyProgress" xml:space="preserve">
+    <value>Copying… {0}/{1} items</value>
+  </data>
+  <data name="Message.CopyDone" xml:space="preserve">
+    <value>Copy complete: {0} succeeded, {1} skipped, {2} failed</value>
+  </data>
+  <data name="CancelCopyButton.Content" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
 </root>

--- a/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
+++ b/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
@@ -869,4 +869,34 @@
   <data name="DragCaption.Move" xml:space="preserve">
     <value>移動</value>
   </data>
+  <data name="Dialog.CopyConflict.Title" xml:space="preserve">
+    <value>コピー先に同名の項目があります</value>
+  </data>
+  <data name="Dialog.CopyConflict.Detail" xml:space="preserve">
+    <value>コピー先に「{0}」が既に存在します。上書きしますか？</value>
+  </data>
+  <data name="Dialog.CopyConflict.Overwrite" xml:space="preserve">
+    <value>上書き</value>
+  </data>
+  <data name="Dialog.CopyConflict.OverwriteAll" xml:space="preserve">
+    <value>すべて上書き</value>
+  </data>
+  <data name="Dialog.CopyConflict.Skip" xml:space="preserve">
+    <value>スキップ</value>
+  </data>
+  <data name="Dialog.CopyConflict.SkipAll" xml:space="preserve">
+    <value>すべてスキップ</value>
+  </data>
+  <data name="Dialog.CopyConflict.Cancel" xml:space="preserve">
+    <value>中止</value>
+  </data>
+  <data name="Message.CopyProgress" xml:space="preserve">
+    <value>コピー中… {0}/{1} 件</value>
+  </data>
+  <data name="Message.CopyDone" xml:space="preserve">
+    <value>コピー完了: 成功 {0} 件、スキップ {1} 件、失敗 {2} 件</value>
+  </data>
+  <data name="CancelCopyButton.Content" xml:space="preserve">
+    <value>中止</value>
+  </data>
 </root>


### PR DESCRIPTION
## 概要

Issue #108「Ctrl+ドラッグ（内部コピー）に競合確認・進捗・キャンセル対応を追加する」の実装。

移動操作（`MoveItemsAsync`）と同等の UX をコピー操作にも適用する。

## 変更内容

### Service 層
- `IFileOperationService` に `CopyItemsAsync` を追加（競合コールバック・`IProgress<int>`・`CancellationToken` 対応）
- `FileOperationService.CopyItemsAsync` を実装
  - 上書き / すべて上書き / スキップ / すべてスキップ / 中止 の選択が可能
  - `MoveItemsAsync` と同パターンで実装

### ViewModel 層
- コピー進捗管理フィールドを追加（`_copyCts`, `_copyTotal`, `_copyCompleted`, `_isCopyInProgress`, `_copyProgressTimer`）
- `IsCopyInProgress`, `CancelCopyVisibility`, `CancelCopyCommand` プロパティを追加
- `ExecuteCopyItemsToFolderAsync` を `resolveConflictAsync` 対応の非同期版に更新
  - `resolveConflictAsync` なし時は従来の同期版 `CopyItems` を使用（後方互換）
  - あり時はバックグラウンドで `CopyItemsAsync` を実行し、進捗タイマーを起動
- `ExecutePasteAsync` のシグネチャを変更（`resolveMoveConflictAsync` / `resolveCopyConflictAsync` の2引数に分離）
- `Dispose` にコピー用 CTS・タイマーのクリーンアップを追加

### View 層
- `ShowCopyConflictDialogAsync` を追加（`ShowMoveConflictDialogAsync` と同構造）
- 内部ドラッグのコピーパス（`OnFileListDrop`）と `PasteSelectionAsyncCore` に競合ダイアログを渡すよう更新
- キャンセル後のエラーダイアログ抑制（`Cancelled` エラーのみの場合は表示しない）

### UI
- `MainWindow.xaml` に `CancelCopyButton` を追加（ステータスバー 3 列目）

### リソース
- `Dialog.CopyConflict.*`（Title / Detail / Overwrite / OverwriteAll / Skip / SkipAll / Cancel）
- `Message.CopyProgress`（コピー中 {0}/{1} 件）
- `Message.CopyDone`（コピー完了: 成功 {0} 件、スキップ {1} 件、失敗 {2} 件）
- `CancelCopyButton.Content`（中止）
- ja-JP / en-US 両言語に追加

## 検証方法

```
# ビルド（SixLabors ライセンスは CI 環境でのみ通過）
# CI で確認

# 動作確認項目
# 1. Ctrl+ドラッグで同名ファイルがある場所へドロップ → 競合ダイアログが表示される
# 2. 上書き/スキップ/すべて上書き/すべてスキップ/中止 が正しく動作する
# 3. コピー中はステータスバーに進捗（コピー中… N/M 件）と中止ボタンが表示される
# 4. 中止ボタンクリックで操作が停止し、完了分は反映される
# 5. コピー完了後にステータスバーにコピー完了メッセージが表示される
# 6. Ctrl+V（コピー貼り付け）でも同様に競合ダイアログが機能する
```

Closes #108