### PR TITLE
feat(crash-report): クラッシュレポート基盤の実装（#118）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+### 追加
+- クラッシュレポート基盤を実装（#118）
+  - `CrashReportService` を新規追加: `running.lock` による異常終了検出・`CrashReports/crash_<timestamp>.log` へのクラッシュログ保存・パス/UNCパスのマスク処理。
+  - 未処理例外（UI スレッド例外・AppDomain 例外）発生時にクラッシュログを自動保存。
+  - 次回起動時に前回異常終了を検出した場合、InfoBar バナーで通知し「クラッシュログフォルダーを開く」ボタンを表示。
+  - 自動送信なし・ローカル収集のみ。
+
 ### 修正
 - EXIF編集ボタン連打による `ContentDialog` 二重表示クラッシュを修正（#116）
   - `RelayCommand` / `RelayCommand<T>` に `_isExecuting` フラグを追加し、非同期実行中は `CanExecute = false` を返すよう変更。

--- a/PhotoGeoExplorer.Tests/CrashReportServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/CrashReportServiceTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.IO;
+using PhotoGeoExplorer.Services;
+using Xunit;
+
+namespace PhotoGeoExplorer.Tests;
+
+public class CrashReportServiceTests
+{
+    [Theory]
+    [InlineData(@"C:\Users\testuser\Pictures\photo.jpg", "<path:masked>")]
+    [InlineData(@"C:\Users\testuser\AppData\Local\app", "<path:masked>")]
+    [InlineData(@"\\server\share\file.txt", "<unc:masked>")]
+    [InlineData("No path here, just text", "No path here, just text")]
+    [InlineData("", "")]
+    public void MaskSensitiveData_MasksPathsCorrectly(string input, string expected)
+    {
+        var result = CrashReportService.MaskSensitiveData(input);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void MaskSensitiveData_PreservesStackTraceSymbols()
+    {
+        var input = "   at PhotoGeoExplorer.Services.ExifEditorService.EditExifAsync()";
+
+        var result = CrashReportService.MaskSensitiveData(input);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void MaskSensitiveData_MasksPathInExceptionMessage()
+    {
+        var input = @"Could not find file 'C:\Users\testuser\photo.jpg'.";
+
+        var result = CrashReportService.MaskSensitiveData(input);
+
+        Assert.DoesNotContain(@"C:\Users\testuser\photo.jpg", result, StringComparison.Ordinal);
+        Assert.Contains("<path:masked>", result, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    public void MaskSensitiveData_HandlesNull(string? input)
+    {
+        var result = CrashReportService.MaskSensitiveData(input!);
+
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void RecordStartup_SetsAbnormalTerminationFalse_WhenNoLockFile()
+    {
+        var service = new CrashReportService();
+        EnsureNoLockFile();
+
+        service.RecordStartup();
+
+        Assert.False(service.PreviouslyTerminatedAbnormally);
+        CleanupLockFile();
+    }
+
+    [Fact]
+    public void RecordNormalExit_DeletesLockFile()
+    {
+        var service = new CrashReportService();
+        service.RecordStartup();
+        var lockPath = GetLockFilePath();
+        Assert.True(File.Exists(lockPath));
+
+        service.RecordNormalExit();
+
+        Assert.False(File.Exists(lockPath));
+    }
+
+    [Fact]
+    public void WriteCrashLog_CreatesFileInCrashReportsDirectory()
+    {
+        var service = new CrashReportService();
+        var dir = service.CrashReportsDirectoryPath;
+        CleanupCrashReports(dir);
+
+        service.WriteCrashLog(new InvalidOperationException("test crash"));
+
+        var files = Directory.GetFiles(dir, "crash_*.log");
+        Assert.Single(files);
+        CleanupCrashReports(dir);
+    }
+
+    [Fact]
+    public void WriteCrashLog_MasksSensitiveDataInLog()
+    {
+        var service = new CrashReportService();
+        var dir = service.CrashReportsDirectoryPath;
+        CleanupCrashReports(dir);
+
+        service.WriteCrashLog(new FileNotFoundException(@"File not found: C:\Users\testuser\photo.jpg"));
+
+        var files = Directory.GetFiles(dir, "crash_*.log");
+        Assert.Single(files);
+        var content = File.ReadAllText(files[0]);
+        Assert.DoesNotContain(@"C:\Users\testuser\photo.jpg", content, StringComparison.Ordinal);
+        Assert.Contains("<path:masked>", content, StringComparison.Ordinal);
+        CleanupCrashReports(dir);
+    }
+
+    [Fact]
+    public void WriteCrashLog_DoesNotThrow_WhenExceptionIsNull()
+    {
+        var service = new CrashReportService();
+
+        var ex = Record.Exception(() => service.WriteCrashLog(null));
+
+        Assert.Null(ex);
+    }
+
+    private static string GetLockFilePath()
+    {
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "PhotoGeoExplorer",
+            "running.lock");
+    }
+
+    private static void EnsureNoLockFile()
+    {
+        var path = GetLockFilePath();
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static void CleanupLockFile()
+    {
+        var path = GetLockFilePath();
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static void CleanupCrashReports(string dir)
+    {
+        if (!Directory.Exists(dir))
+        {
+            return;
+        }
+
+        foreach (var file in Directory.GetFiles(dir, "crash_*.log"))
+        {
+            File.Delete(file);
+        }
+    }
+}

--- a/PhotoGeoExplorer.Tests/CrashReportServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/CrashReportServiceTests.cs
@@ -5,8 +5,26 @@ using Xunit;
 
 namespace PhotoGeoExplorer.Tests;
 
-public class CrashReportServiceTests
+public sealed class CrashReportServiceTests : IDisposable
 {
+    private readonly string _tempDir;
+
+    public CrashReportServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"PhotoGeoExplorerTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
     [Theory]
     [InlineData(@"C:\Users\testuser\Pictures\photo.jpg", "<path:masked>")]
     [InlineData(@"C:\Users\testuser\AppData\Local\app", "<path:masked>")]
@@ -53,21 +71,31 @@ public class CrashReportServiceTests
     [Fact]
     public void RecordStartup_SetsAbnormalTerminationFalse_WhenNoLockFile()
     {
-        var service = new CrashReportService();
-        EnsureNoLockFile();
+        var service = new CrashReportService(_tempDir);
 
         service.RecordStartup();
 
         Assert.False(service.PreviouslyTerminatedAbnormally);
-        CleanupLockFile();
+    }
+
+    [Fact]
+    public void RecordStartup_SetsAbnormalTerminationTrue_WhenLockFileExists()
+    {
+        var service = new CrashReportService(_tempDir);
+        var lockPath = Path.Combine(_tempDir, "running.lock");
+        File.WriteAllText(lockPath, "stale");
+
+        service.RecordStartup();
+
+        Assert.True(service.PreviouslyTerminatedAbnormally);
     }
 
     [Fact]
     public void RecordNormalExit_DeletesLockFile()
     {
-        var service = new CrashReportService();
+        var service = new CrashReportService(_tempDir);
         service.RecordStartup();
-        var lockPath = GetLockFilePath();
+        var lockPath = Path.Combine(_tempDir, "running.lock");
         Assert.True(File.Exists(lockPath));
 
         service.RecordNormalExit();
@@ -78,23 +106,20 @@ public class CrashReportServiceTests
     [Fact]
     public void WriteCrashLog_CreatesFileInCrashReportsDirectory()
     {
-        var service = new CrashReportService();
+        var service = new CrashReportService(_tempDir);
         var dir = service.CrashReportsDirectoryPath;
-        CleanupCrashReports(dir);
 
         service.WriteCrashLog(new InvalidOperationException("test crash"));
 
         var files = Directory.GetFiles(dir, "crash_*.log");
         Assert.Single(files);
-        CleanupCrashReports(dir);
     }
 
     [Fact]
     public void WriteCrashLog_MasksSensitiveDataInLog()
     {
-        var service = new CrashReportService();
+        var service = new CrashReportService(_tempDir);
         var dir = service.CrashReportsDirectoryPath;
-        CleanupCrashReports(dir);
 
         service.WriteCrashLog(new FileNotFoundException(@"File not found: C:\Users\testuser\photo.jpg"));
 
@@ -103,55 +128,34 @@ public class CrashReportServiceTests
         var content = File.ReadAllText(files[0]);
         Assert.DoesNotContain(@"C:\Users\testuser\photo.jpg", content, StringComparison.Ordinal);
         Assert.Contains("<path:masked>", content, StringComparison.Ordinal);
-        CleanupCrashReports(dir);
     }
 
     [Fact]
     public void WriteCrashLog_DoesNotThrow_WhenExceptionIsNull()
     {
-        var service = new CrashReportService();
+        var service = new CrashReportService(_tempDir);
 
         var ex = Record.Exception(() => service.WriteCrashLog(null));
 
         Assert.Null(ex);
     }
 
-    private static string GetLockFilePath()
+    [Fact]
+    public void WriteCrashLog_PrunesOldLogs_WhenExceedingMaxCount()
     {
-        return Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-            "PhotoGeoExplorer",
-            "running.lock");
-    }
+        var service = new CrashReportService(_tempDir);
+        var dir = service.CrashReportsDirectoryPath;
+        Directory.CreateDirectory(dir);
 
-    private static void EnsureNoLockFile()
-    {
-        var path = GetLockFilePath();
-        if (File.Exists(path))
+        for (var i = 0; i < 22; i++)
         {
-            File.Delete(path);
-        }
-    }
-
-    private static void CleanupLockFile()
-    {
-        var path = GetLockFilePath();
-        if (File.Exists(path))
-        {
-            File.Delete(path);
-        }
-    }
-
-    private static void CleanupCrashReports(string dir)
-    {
-        if (!Directory.Exists(dir))
-        {
-            return;
+            var fileName = $"crash_20240101{i:D6}.log";
+            File.WriteAllText(Path.Combine(dir, fileName), "dummy");
         }
 
-        foreach (var file in Directory.GetFiles(dir, "crash_*.log"))
-        {
-            File.Delete(file);
-        }
+        service.WriteCrashLog(new InvalidOperationException("trigger prune"));
+
+        var files = Directory.GetFiles(dir, "crash_*.log");
+        Assert.True(files.Length <= 20, $"Expected <=20 files, got {files.Length}");
     }
 }

--- a/PhotoGeoExplorer/App.xaml.cs
+++ b/PhotoGeoExplorer/App.xaml.cs
@@ -20,9 +20,11 @@ public partial class App : Application
     private string? _startupFilePath;
     private DateTimeOffset _splashShownAt;
     private bool _splashCloseRequested;
+    private static readonly Services.CrashReportService CrashReporter = new();
 
     public App()
     {
+        CrashReporter.RecordStartup();
         InitializeComponent();
         UnhandledException += OnUnhandledException;
         AppDomain.CurrentDomain.UnhandledException += OnDomainUnhandledException;
@@ -42,6 +44,7 @@ public partial class App : Application
         _splashShownAt = DateTimeOffset.UtcNow;
 
         var mainWindow = new MainWindow();
+        mainWindow.SetCrashReportService(CrashReporter);
         _window = mainWindow;
         if (!string.IsNullOrWhiteSpace(_startupFilePath))
         {
@@ -106,6 +109,10 @@ public partial class App : Application
         {
             e.Handled = true;
         }
+        else
+        {
+            CrashReporter.WriteCrashLog(e.Exception);
+        }
     }
 
     private void OnDomainUnhandledException(object sender, System.UnhandledExceptionEventArgs e)
@@ -113,6 +120,7 @@ public partial class App : Application
         var exception = e.ExceptionObject as Exception;
         var exceptionInfo = $"IsTerminating: {e.IsTerminating}, Type: {exception?.GetType().FullName ?? "Unknown"}, Message: {exception?.Message ?? "Unknown"}";
         AppLog.Error($"AppDomain unhandled exception. {exceptionInfo}", exception);
+        CrashReporter.WriteCrashLog(exception);
     }
 
     private void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
@@ -123,6 +131,7 @@ public partial class App : Application
 
     private void OnProcessExit(object? sender, EventArgs e)
     {
+        CrashReporter.RecordNormalExit();
         AppLog.Info("ProcessExit event received.");
     }
 

--- a/PhotoGeoExplorer/App.xaml.cs
+++ b/PhotoGeoExplorer/App.xaml.cs
@@ -20,6 +20,7 @@ public partial class App : Application
     private string? _startupFilePath;
     private DateTimeOffset _splashShownAt;
     private bool _splashCloseRequested;
+    private bool _crashDetected;
     private static readonly Services.CrashReportService CrashReporter = new();
 
     public App()
@@ -111,12 +112,14 @@ public partial class App : Application
         }
         else
         {
+            _crashDetected = true;
             CrashReporter.WriteCrashLog(e.Exception);
         }
     }
 
     private void OnDomainUnhandledException(object sender, System.UnhandledExceptionEventArgs e)
     {
+        _crashDetected = true;
         var exception = e.ExceptionObject as Exception;
         var exceptionInfo = $"IsTerminating: {e.IsTerminating}, Type: {exception?.GetType().FullName ?? "Unknown"}, Message: {exception?.Message ?? "Unknown"}";
         AppLog.Error($"AppDomain unhandled exception. {exceptionInfo}", exception);
@@ -131,7 +134,12 @@ public partial class App : Application
 
     private void OnProcessExit(object? sender, EventArgs e)
     {
-        CrashReporter.RecordNormalExit();
+        // クラッシュ検出済みの場合は running.lock を残して次回起動時に異常終了を通知する
+        if (!_crashDetected)
+        {
+            CrashReporter.RecordNormalExit();
+        }
+
         AppLog.Info("ProcessExit event received.");
     }
 

--- a/PhotoGeoExplorer/MainWindow.xaml
+++ b/PhotoGeoExplorer/MainWindow.xaml
@@ -166,9 +166,22 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <controls:InfoBar
                 Grid.Row="0"
+                x:Uid="CrashReportBanner"
+                IsOpen="{Binding IsCrashReportBannerOpen, Mode=TwoWay}"
+                Severity="Warning"
+                IsClosable="True">
+                <controls:InfoBar.ActionButton>
+                    <Button
+                        x:Uid="CrashReportBanner.OpenFolderButton"
+                        Click="OnOpenCrashReportFolderClicked" />
+                </controls:InfoBar.ActionButton>
+            </controls:InfoBar>
+            <controls:InfoBar
+                Grid.Row="1"
                 IsOpen="{Binding IsNotificationOpen, Mode=TwoWay}"
                 Message="{Binding NotificationMessage}"
                 Severity="{Binding NotificationSeverity}"
@@ -182,7 +195,7 @@
                 </controls:InfoBar.ActionButton>
             </controls:InfoBar>
             <Border
-                Grid.Row="1"
+                Grid.Row="2"
                 Margin="0,6,0,0"
                 Padding="8,4"
                 Background="{ThemeResource SystemControlBackgroundBaseLowBrush}"

--- a/PhotoGeoExplorer/MainWindow.xaml.cs
+++ b/PhotoGeoExplorer/MainWindow.xaml.cs
@@ -30,6 +30,7 @@ public sealed partial class MainWindow : Window, IDisposable
     private readonly FileBrowserPaneViewModel _fileBrowserPaneViewModel;
     private readonly PreviewPaneViewModel _previewPaneViewModel;
     private readonly MapPaneViewModel _mapPaneViewModel;
+    private Services.ICrashReportService? _crashReportService;
     private bool _mapInitialized;
     private bool _disposed;
     private bool _windowSized;
@@ -37,6 +38,11 @@ public sealed partial class MainWindow : Window, IDisposable
     private readonly HelpService _helpService;
     private readonly MainWindowLayoutCoordinator _layoutCoordinator;
     internal FileBrowserPaneViewModel FileBrowserPaneViewModel => _fileBrowserPaneViewModel;
+
+    internal void SetCrashReportService(Services.ICrashReportService crashReportService)
+    {
+        _crashReportService = crashReportService ?? throw new ArgumentNullException(nameof(crashReportService));
+    }
 
     public MainWindow()
     {
@@ -167,9 +173,13 @@ public sealed partial class MainWindow : Window, IDisposable
         // XamlRoot が確定するまでワンテンポ遅らせてからダイアログを表示
         DispatcherQueue.TryEnqueue(async () =>
         {
+            if (_crashReportService?.PreviouslyTerminatedAbnormally == true)
+            {
+                _viewModel.ShowCrashReportBanner(_crashReportService.CrashReportsDirectoryPath);
+            }
+
             await _helpService.ShowQuickStartIfNeededAsync().ConfigureAwait(true);
         });
-
     }
 
     private void EnsureWindowSize()
@@ -431,6 +441,41 @@ public sealed partial class MainWindow : Window, IDisposable
         {
             AppLog.Info("MainWindow dispose completed.");
             GC.SuppressFinalize(this);
+        }
+    }
+
+    private async void OnOpenCrashReportFolderClicked(object sender, RoutedEventArgs e)
+    {
+        var path = _viewModel.CrashReportsDirectoryPath;
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        try
+        {
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+            }
+
+            _ = await Windows.System.Launcher.LaunchFolderPathAsync(path);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            HandleOpenLogFolderFailure(ex);
+        }
+        catch (IOException ex)
+        {
+            HandleOpenLogFolderFailure(ex);
+        }
+        catch (ArgumentException ex)
+        {
+            HandleOpenLogFolderFailure(ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            HandleOpenLogFolderFailure(ex);
         }
     }
 

--- a/PhotoGeoExplorer/Services/CrashReportService.cs
+++ b/PhotoGeoExplorer/Services/CrashReportService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -8,37 +9,51 @@ namespace PhotoGeoExplorer.Services;
 
 internal sealed class CrashReportService : ICrashReportService
 {
-    private static readonly string AppDataDirectory = Path.Combine(
+    private const int MaxCrashLogCount = 20;
+
+    private static readonly string DefaultAppDataDirectory = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "PhotoGeoExplorer");
 
-    private static readonly string LockFilePath = Path.Combine(AppDataDirectory, "running.lock");
+    private readonly string _appDataDirectory;
+    private readonly string _lockFilePath;
+    private readonly string _crashReportsDir;
 
-    private static readonly string CrashReportsDir = Path.Combine(AppDataDirectory, "CrashReports");
+    public CrashReportService()
+        : this(DefaultAppDataDirectory)
+    {
+    }
+
+    internal CrashReportService(string appDataDirectory)
+    {
+        _appDataDirectory = appDataDirectory ?? throw new ArgumentNullException(nameof(appDataDirectory));
+        _lockFilePath = Path.Combine(_appDataDirectory, "running.lock");
+        _crashReportsDir = Path.Combine(_appDataDirectory, "CrashReports");
+    }
 
     public bool PreviouslyTerminatedAbnormally { get; private set; }
 
-    public string CrashReportsDirectoryPath => CrashReportsDir;
+    public string CrashReportsDirectoryPath => _crashReportsDir;
 
     public void RecordStartup()
     {
-        PreviouslyTerminatedAbnormally = File.Exists(LockFilePath);
+        PreviouslyTerminatedAbnormally = File.Exists(_lockFilePath);
         TryCreateLockFile();
     }
 
     public void RecordNormalExit()
     {
-        TryDeleteFile(LockFilePath);
+        TryDeleteFile(_lockFilePath);
     }
 
     public void WriteCrashLog(Exception? exception)
     {
         try
         {
-            Directory.CreateDirectory(CrashReportsDir);
+            Directory.CreateDirectory(_crashReportsDir);
             var timestamp = DateTimeOffset.Now;
             var fileName = $"crash_{timestamp:yyyyMMddHHmmss}.log";
-            var filePath = Path.Combine(CrashReportsDir, fileName);
+            var filePath = Path.Combine(_crashReportsDir, fileName);
 
             var version = typeof(CrashReportService).Assembly.GetName().Version?.ToString() ?? "unknown";
             var osVersion = Environment.OSVersion.ToString();
@@ -54,6 +69,7 @@ internal sealed class CrashReportService : ICrashReportService
             builder.Append(MaskSensitiveData(exception?.ToString() ?? "No stack trace"));
 
             File.WriteAllText(filePath, builder.ToString(), Encoding.UTF8);
+            PruneOldCrashLogs();
         }
         catch (UnauthorizedAccessException) { }
         catch (IOException) { }
@@ -88,12 +104,32 @@ internal sealed class CrashReportService : ICrashReportService
         return text;
     }
 
-    private static void TryCreateLockFile()
+    private void PruneOldCrashLogs()
     {
         try
         {
-            Directory.CreateDirectory(AppDataDirectory);
-            File.WriteAllText(LockFilePath, DateTimeOffset.Now.ToString("O"));
+            var files = Directory.GetFiles(_crashReportsDir, "crash_*.log")
+                .OrderByDescending(f => f)
+                .Skip(MaxCrashLogCount)
+                .ToList();
+
+            foreach (var file in files)
+            {
+                File.Delete(file);
+            }
+        }
+        catch (UnauthorizedAccessException) { }
+        catch (IOException) { }
+        catch (ArgumentException) { }
+        catch (NotSupportedException) { }
+    }
+
+    private void TryCreateLockFile()
+    {
+        try
+        {
+            Directory.CreateDirectory(_appDataDirectory);
+            File.WriteAllText(_lockFilePath, DateTimeOffset.Now.ToString("O"));
         }
         catch (UnauthorizedAccessException) { }
         catch (IOException) { }

--- a/PhotoGeoExplorer/Services/CrashReportService.cs
+++ b/PhotoGeoExplorer/Services/CrashReportService.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace PhotoGeoExplorer.Services;
+
+internal sealed class CrashReportService : ICrashReportService
+{
+    private static readonly string AppDataDirectory = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "PhotoGeoExplorer");
+
+    private static readonly string LockFilePath = Path.Combine(AppDataDirectory, "running.lock");
+
+    private static readonly string CrashReportsDir = Path.Combine(AppDataDirectory, "CrashReports");
+
+    public bool PreviouslyTerminatedAbnormally { get; private set; }
+
+    public string CrashReportsDirectoryPath => CrashReportsDir;
+
+    public void RecordStartup()
+    {
+        PreviouslyTerminatedAbnormally = File.Exists(LockFilePath);
+        TryCreateLockFile();
+    }
+
+    public void RecordNormalExit()
+    {
+        TryDeleteFile(LockFilePath);
+    }
+
+    public void WriteCrashLog(Exception? exception)
+    {
+        try
+        {
+            Directory.CreateDirectory(CrashReportsDir);
+            var timestamp = DateTimeOffset.Now;
+            var fileName = $"crash_{timestamp:yyyyMMddHHmmss}.log";
+            var filePath = Path.Combine(CrashReportsDir, fileName);
+
+            var version = typeof(CrashReportService).Assembly.GetName().Version?.ToString() ?? "unknown";
+            var osVersion = Environment.OSVersion.ToString();
+
+            var builder = new StringBuilder();
+            builder.AppendLine("PhotoGeoExplorer Crash Report");
+            builder.AppendLine(CultureInfo.InvariantCulture, $"Timestamp: {timestamp:yyyy-MM-dd HH:mm:ss zzz}");
+            builder.AppendLine(CultureInfo.InvariantCulture, $"App Version: {version}");
+            builder.AppendLine(CultureInfo.InvariantCulture, $"OS Version: {osVersion}");
+            builder.AppendLine(CultureInfo.InvariantCulture, $"Exception Type: {exception?.GetType().FullName ?? "Unknown"}");
+            builder.AppendLine(CultureInfo.InvariantCulture, $"Exception Message: {MaskSensitiveData(exception?.Message ?? "Unknown")}");
+            builder.AppendLine("Stack Trace:");
+            builder.Append(MaskSensitiveData(exception?.ToString() ?? "No stack trace"));
+
+            File.WriteAllText(filePath, builder.ToString(), Encoding.UTF8);
+        }
+        catch (UnauthorizedAccessException) { }
+        catch (IOException) { }
+        catch (ArgumentException) { }
+        catch (NotSupportedException) { }
+        catch (System.Security.SecurityException) { }
+    }
+
+    internal static string MaskSensitiveData(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
+
+        // Windows パス（ドライブレター付き）をマスク
+        text = Regex.Replace(
+            text,
+            @"[A-Za-z]:\\[^\s,'""\r\n]+",
+            "<path:masked>",
+            RegexOptions.None,
+            TimeSpan.FromSeconds(1));
+
+        // UNC パス
+        text = Regex.Replace(
+            text,
+            @"\\\\[^\s,'""\r\n]+",
+            "<unc:masked>",
+            RegexOptions.None,
+            TimeSpan.FromSeconds(1));
+
+        return text;
+    }
+
+    private static void TryCreateLockFile()
+    {
+        try
+        {
+            Directory.CreateDirectory(AppDataDirectory);
+            File.WriteAllText(LockFilePath, DateTimeOffset.Now.ToString("O"));
+        }
+        catch (UnauthorizedAccessException) { }
+        catch (IOException) { }
+        catch (ArgumentException) { }
+        catch (NotSupportedException) { }
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (UnauthorizedAccessException) { }
+        catch (IOException) { }
+        catch (ArgumentException) { }
+        catch (NotSupportedException) { }
+    }
+}

--- a/PhotoGeoExplorer/Services/ICrashReportService.cs
+++ b/PhotoGeoExplorer/Services/ICrashReportService.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace PhotoGeoExplorer.Services;
+
+internal interface ICrashReportService
+{
+    bool PreviouslyTerminatedAbnormally { get; }
+
+    string CrashReportsDirectoryPath { get; }
+
+    void RecordStartup();
+
+    void RecordNormalExit();
+
+    void WriteCrashLog(Exception? exception);
+}

--- a/PhotoGeoExplorer/Strings/en-US/Resources.resw
+++ b/PhotoGeoExplorer/Strings/en-US/Resources.resw
@@ -899,4 +899,10 @@
   <data name="CancelCopyButton.Content" xml:space="preserve">
     <value>Cancel</value>
   </data>
+  <data name="CrashReportBanner.Message" xml:space="preserve">
+    <value>PhotoGeoExplorer did not shut down properly last time. Diagnostic logs have been saved. Attaching logs when reporting an issue helps with investigation.</value>
+  </data>
+  <data name="CrashReportBanner.OpenFolderButton.Content" xml:space="preserve">
+    <value>Open Crash Log Folder</value>
+  </data>
 </root>

--- a/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
+++ b/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
@@ -899,4 +899,10 @@
   <data name="CancelCopyButton.Content" xml:space="preserve">
     <value>中止</value>
   </data>
+  <data name="CrashReportBanner.Message" xml:space="preserve">
+    <value>前回 PhotoGeoExplorer は正常に終了しませんでした。診断用ログが保存されています。問題報告時にログを添付すると原因調査に役立ちます。</value>
+  </data>
+  <data name="CrashReportBanner.OpenFolderButton.Content" xml:space="preserve">
+    <value>クラッシュログフォルダーを開く</value>
+  </data>
 </root>

--- a/PhotoGeoExplorer/ViewModels/MainViewModel.cs
+++ b/PhotoGeoExplorer/ViewModels/MainViewModel.cs
@@ -22,6 +22,8 @@ internal sealed class MainViewModel : BindableBase
     private MapTileSourceType _currentMapTileSource = MapTileSourceType.OpenStreetMap;
     private IHelpService? _helpService;
     private ISettingsCoordinator? _settingsCoordinator;
+    private bool _isCrashReportBannerOpen;
+    private string? _crashReportsDirectoryPath;
 
     public MainViewModel()
         : this(new State.WorkspaceState())
@@ -137,6 +139,14 @@ internal sealed class MainViewModel : BindableBase
         private set => SetProperty(ref _notificationActionVisibility, value);
     }
 
+    public bool IsCrashReportBannerOpen
+    {
+        get => _isCrashReportBannerOpen;
+        set => SetProperty(ref _isCrashReportBannerOpen, value);
+    }
+
+    public string? CrashReportsDirectoryPath => _crashReportsDirectoryPath;
+
     public ICommand ShowGettingStartedCommand { get; }
     public ICommand ShowBasicOperationsCommand { get; }
     public ICommand ShowDetailedHelpCommand { get; }
@@ -202,6 +212,12 @@ internal sealed class MainViewModel : BindableBase
         NotificationActionLabel = actionLabel;
         NotificationActionUrl = actionUrl;
         NotificationActionVisibility = Visibility.Visible;
+    }
+
+    public void ShowCrashReportBanner(string crashReportsDirectoryPath)
+    {
+        _crashReportsDirectoryPath = crashReportsDirectoryPath;
+        IsCrashReportBannerOpen = true;
     }
 
     public void ConfigureHelpService(IHelpService helpService)


### PR DESCRIPTION
## 概要

MS Store の分析でクラッシュが多いことが判明しているが、クラッシュ時にアプリがサイレントに落ちるだけで情報が残らない問題に対処する。

Closes #118

## 変更内容

### 新規ファイル
- `PhotoGeoExplorer/Services/ICrashReportService.cs` — インターフェース定義
- `PhotoGeoExplorer/Services/CrashReportService.cs` — 実装（異常終了検出・クラッシュログ保存・パスマスク）
- `PhotoGeoExplorer.Tests/CrashReportServiceTests.cs` — ユニットテスト（13ケース）

### 変更ファイル
- `App.xaml.cs` — 起動時に `RecordStartup()`、`_crashDetected` フラグ管理、例外ハンドラで `WriteCrashLog()` を呼ぶ
- `MainWindow.xaml(.cs)` — クラッシュレポートバナー用 InfoBar 追加、`SetCrashReportService()` メソッド追加
- `MainViewModel.cs` — `IsCrashReportBannerOpen` / `CrashReportsDirectoryPath` / `ShowCrashReportBanner()` を追加
- `Resources.resw` (ja-JP / en-US) — バナーメッセージ・ボタンラベルを追加

## 動作フロー

```
起動時: running.lock が存在 → PreviouslyTerminatedAbnormally = true → InfoBar バナー表示
       running.lock を新規作成

クラッシュ時: WriteCrashLog() → CrashReports/crash_<timestamp>.log を保存
             _crashDetected = true をセット

正常終了時: ProcessExit → _crashDetected が false の場合のみ running.lock を削除
          ※ クラッシュ検出済みの場合は running.lock を残存させ、次回起動時の異常終了検出を保証
```

## テスト計画

- [x] `dotnet test` 489件全パス
- [ ] 手動: アプリを強制終了 → 次回起動時にバナーが表示されること
- [ ] 手動: 「クラッシュログフォルダーを開く」でフォルダが開くこと
- [ ] 手動: 正常終了後の再起動でバナーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)