### PR TITLE
fix(ui): クラッシュレポートバナーの x:Uid 命名衝突による起動クラッシュを修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   - 自動送信なし・ローカル収集のみ。
 
 ### 修正
+- クラッシュレポートバナーの `x:Uid` 命名衝突による起動クラッシュを修正
+  - `InfoBar` の `x:Uid="CrashReportBanner"` と子 `Button` の `x:Uid="CrashReportBanner.OpenFolderButton"` が WinUI 3 のプレフィックス走査で衝突し `XamlParseException` が発生していた問題を解消。
+  - `Button` の `x:Uid` を `CrashReportOpenFolderButton` に変更し、両リソースファイルのキーも合わせて更新。
 - EXIF編集ボタン連打による `ContentDialog` 二重表示クラッシュを修正（#116）
   - `RelayCommand` / `RelayCommand<T>` に `_isExecuting` フラグを追加し、非同期実行中は `CanExecute = false` を返すよう変更。
   - `finally` での `RaiseCanExecuteChanged()` を `DispatcherQueue.TryEnqueue` 経由で UI スレッドから通知するよう修正。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [1.8.2] - 2026-05-27
+
 ### 追加
 - クラッシュレポート基盤を実装（#118）
   - `CrashReportService` を新規追加: `running.lock` による異常終了検出・`CrashReports/crash_<timestamp>.log` へのクラッシュログ保存・パス/UNCパスのマスク処理。
@@ -12,7 +14,7 @@
   - 自動送信なし・ローカル収集のみ。
 
 ### 修正
-- クラッシュレポートバナーの `x:Uid` 命名衝突による起動クラッシュを修正
+- クラッシュレポートバナーの `x:Uid` 命名衝突による起動クラッシュを修正（#120）
   - `InfoBar` の `x:Uid="CrashReportBanner"` と子 `Button` の `x:Uid="CrashReportBanner.OpenFolderButton"` が WinUI 3 のプレフィックス走査で衝突し `XamlParseException` が発生していた問題を解消。
   - `Button` の `x:Uid` を `CrashReportOpenFolderButton` に変更し、両リソースファイルのキーも合わせて更新。
 - EXIF編集ボタン連打による `ContentDialog` 二重表示クラッシュを修正（#116）

--- a/PhotoGeoExplorer/Assets/propose/listingData-9P0WNR54441B-1152921505701101354.csv
+++ b/PhotoGeoExplorer/Assets/propose/listingData-9P0WNR54441B-1152921505701101354.csv
@@ -4,11 +4,13 @@ This app requires the .NET Desktop Runtime to run. It is automatically provided 
 It targets Windows 10/11 and renders maps using WinUI 3 and Mapsui.","PhotoGeoExplorer は、GPS 情報（ジオタグ）を含む写真を地図上に表示し、撮影場所から写真を整理・探索できる Windows デスクトップアプリです。
 このアプリを実行するには .NET Desktop Runtime が必要です。Microsoft Store からのインストール時に自動的に提供されます。
 Windows 10/11 を対象とし、WinUI 3 と Mapsui で地図を描画します。"
-ReleaseNotes,3,テキスト,,"Release Notes (v1.8.1)
-- Fixed: App crashed on repeated folder navigation
-- Fixed: Right-click on a multi-selected file collapsed selection to a single item","リリースノート（v1.8.1）
-- 修正: フォルダを繰り返し遷移するとクラッシュする問題
-- 修正: 複数選択中のファイルを右クリックすると選択が単数になる問題"
+ReleaseNotes,3,テキスト,,"Release Notes (v1.8.2)
+- Fixed: App crashed on startup due to x:Uid naming conflict in crash report banner (introduced in v1.8.2)
+- Added: Crash report detection — on startup after an abnormal exit, a warning banner with a link to the crash log folder is shown
+- Fixed: Buttons using async commands are now protected against double-execution","リリースノート（v1.8.2）
+- 修正: クラッシュレポートバナーの x:Uid 命名衝突により起動時にクラッシュする問題
+- 追加: 異常終了検知 — 前回クラッシュ時の次回起動時に警告バナーとクラッシュログフォルダーへのリンクを表示
+- 修正: 非同期コマンドボタンの二重実行を防止"
 Title,4,テキスト,,PhotoGeoExplorer,PhotoGeoExplorer
 ShortTitle,5,テキスト,,Explore Photos on a Map,写真を地図で整理・探索
 SortTitle,6,テキスト,,,

--- a/PhotoGeoExplorer/MainWindow.xaml
+++ b/PhotoGeoExplorer/MainWindow.xaml
@@ -176,7 +176,7 @@
                 IsClosable="True">
                 <controls:InfoBar.ActionButton>
                     <Button
-                        x:Uid="CrashReportBanner.OpenFolderButton"
+                        x:Uid="CrashReportOpenFolderButton"
                         Click="OnOpenCrashReportFolderClicked" />
                 </controls:InfoBar.ActionButton>
             </controls:InfoBar>

--- a/PhotoGeoExplorer/Package.appxmanifest
+++ b/PhotoGeoExplorer/Package.appxmanifest
@@ -5,7 +5,7 @@
   xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap uap10 rescap">
-  <Identity Name="scottlz0310.PhotoGeoExplorer" Publisher="CN=39FB3D39-1F1A-4B82-B081-47469FD12CA6" Version="1.8.1.0" />
+  <Identity Name="scottlz0310.PhotoGeoExplorer" Publisher="CN=39FB3D39-1F1A-4B82-B081-47469FD12CA6" Version="1.8.2.0" />
   <Properties>
     <DisplayName>PhotoGeoExplorer</DisplayName>
     <PublisherDisplayName>scottlz0310</PublisherDisplayName>

--- a/PhotoGeoExplorer/PhotoGeoExplorer.csproj
+++ b/PhotoGeoExplorer/PhotoGeoExplorer.csproj
@@ -9,10 +9,10 @@
     <WindowsPackageType Condition="'$(WindowsPackageType)'==''">None</WindowsPackageType>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PhotoGeoExplorer</RootNamespace>
-    <Version>1.8.1</Version>
-    <AssemblyVersion>1.8.1.0</AssemblyVersion>
-    <FileVersion>1.8.1.0</FileVersion>
-    <InformationalVersion>1.8.1</InformationalVersion>
+    <Version>1.8.2</Version>
+    <AssemblyVersion>1.8.2.0</AssemblyVersion>
+    <FileVersion>1.8.2.0</FileVersion>
+    <InformationalVersion>1.8.2</InformationalVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <WindowsSdkPackageVersion>10.0.26100.81</WindowsSdkPackageVersion>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>

--- a/PhotoGeoExplorer/Strings/en-US/Resources.resw
+++ b/PhotoGeoExplorer/Strings/en-US/Resources.resw
@@ -902,7 +902,7 @@
   <data name="CrashReportBanner.Message" xml:space="preserve">
     <value>PhotoGeoExplorer did not shut down properly last time. Diagnostic logs have been saved. Attaching logs when reporting an issue helps with investigation.</value>
   </data>
-  <data name="CrashReportBanner.OpenFolderButton.Content" xml:space="preserve">
+  <data name="CrashReportOpenFolderButton.Content" xml:space="preserve">
     <value>Open Crash Log Folder</value>
   </data>
 </root>

--- a/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
+++ b/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
@@ -902,7 +902,7 @@
   <data name="CrashReportBanner.Message" xml:space="preserve">
     <value>前回 PhotoGeoExplorer は正常に終了しませんでした。診断用ログが保存されています。問題報告時にログを添付すると原因調査に役立ちます。</value>
   </data>
-  <data name="CrashReportBanner.OpenFolderButton.Content" xml:space="preserve">
+  <data name="CrashReportOpenFolderButton.Content" xml:space="preserve">
     <value>クラッシュログフォルダーを開く</value>
   </data>
 </root>


### PR DESCRIPTION
## 概要

- PR #119 で追加したクラッシュレポートバナーの `x:Uid` 命名が WinUI 3 の x:Uid プレフィックス走査と衝突し、起動時に `XamlParseException` でクラッシュする問題を修正。
- v1.8.2 へのバージョンバンプおよび Store listing data の更新を含む。

## 原因

WinUI 3 の x:Uid 解決は「指定された Uid をプレフィックスとするすべてのリソースキーを走査し、サフィックス部分をプロパティ名として適用する」仕様。

- `InfoBar` に `x:Uid="CrashReportBanner"` を設定
- `Button` に `x:Uid="CrashReportBanner.OpenFolderButton"` を設定
- リソースキー `CrashReportBanner.OpenFolderButton.Content` が存在

→ InfoBar の x:Uid 処理時に `CrashReportBanner.OpenFolderButton.Content` を発見し、InfoBar のプロパティ `OpenFolderButton.Content` を設定しようとして `XamlParseException` が発生。

## 修正内容

`Button` の `x:Uid` を `InfoBar` と異なるプレフィックスに変更し、両リソースファイルのキーも更新。

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `MainWindow.xaml` | `x:Uid="CrashReportBanner.OpenFolderButton"` | `x:Uid="CrashReportOpenFolderButton"` |
| `ja-JP/Resources.resw` | `CrashReportBanner.OpenFolderButton.Content` | `CrashReportOpenFolderButton.Content` |
| `en-US/Resources.resw` | `CrashReportBanner.OpenFolderButton.Content` | `CrashReportOpenFolderButton.Content` |

## バージョン

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `Package.appxmanifest` | 1.8.1.0 | 1.8.2.0 |
| `PhotoGeoExplorer.csproj` | 1.8.1 | 1.8.2 |
| `CHANGELOG.md` | [Unreleased] | [1.8.2] - 2026-05-27 |
| Store listing data | v1.8.1 リリースノート | v1.8.2 リリースノート |

## 検証

実機テスト（MSIX インストール）で以下を確認済み：

- 修正後に起動クラッシュが解消されること
- クラッシュ後の再起動でバナーが正しく表示されること（メッセージ・ボタン文字列ともに正常）
- 「クラッシュログフォルダーを開く」ボタンが正常動作すること
- 正常終了後の再起動でバナーが表示されないこと
- フォルダー開くボタンを連打しても二重実行されないこと（RelayCommand ガード確認）