### PR TITLE
feat(ui): クラッシュレポート送信ダイアログを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ## [Unreleased]
 
 ### 追加
+- クラッシュレポート送信ダイアログを追加
+  - バナーの「フォルダを開く」を「報告する」ボタンに変更。クリックでダイアログを表示。
+  - 「GitHub で報告する」: クラッシュログを埋め込んだ Issue 作成ページをブラウザで開く。
+  - 「ログをコピー」: ログ全文をクリップボードにコピーし、サポートメールアドレス（photogeoexplorer@outlook.com）を案内するトースト通知を表示。
+  - ダイアログ内に「ログフォルダーを開く」リンクを設置。
 - Partner Center へのストア提出を CI から自動化（#121）
   - `scripts/Submit-ToPartnerCenter.ps1`: MSIX/appxupload API（`manage.devcenter.microsoft.com/v1.0/my/`）を使いリリースビルドを自動提出。
   - `release.yml` に `Submit to Partner Center` ステップを追加し、タグプッシュ後に自動実行。

--- a/PhotoGeoExplorer.Tests/CrashReportServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/CrashReportServiceTests.cs
@@ -158,4 +158,56 @@ public sealed class CrashReportServiceTests : IDisposable
         var files = Directory.GetFiles(dir, "crash_*.log");
         Assert.True(files.Length <= 20, $"Expected <=20 files, got {files.Length}");
     }
+
+    [Fact]
+    public void GetLatestCrashLogContent_ReturnsNull_WhenCrashReportsDirDoesNotExist()
+    {
+        var service = new CrashReportService(_tempDir);
+
+        var result = service.GetLatestCrashLogContent();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetLatestCrashLogContent_ReturnsNull_WhenNoLogFilesExist()
+    {
+        var service = new CrashReportService(_tempDir);
+        Directory.CreateDirectory(service.CrashReportsDirectoryPath);
+
+        var result = service.GetLatestCrashLogContent();
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetLatestCrashLogContent_ReturnsLatestLog_WhenMultipleFilesExist()
+    {
+        var service = new CrashReportService(_tempDir);
+        var dir = service.CrashReportsDirectoryPath;
+        Directory.CreateDirectory(dir);
+
+        File.WriteAllText(Path.Combine(dir, "crash_20260101000000.log"), "older log");
+        File.WriteAllText(Path.Combine(dir, "crash_20260201000000.log"), "newer log");
+
+        var result = service.GetLatestCrashLogContent();
+
+        Assert.Equal("newer log", result);
+    }
+
+    [Fact]
+    public void GetLatestCrashLogContent_ReturnsNull_WhenFileIsLocked()
+    {
+        var service = new CrashReportService(_tempDir);
+        var dir = service.CrashReportsDirectoryPath;
+        Directory.CreateDirectory(dir);
+        var logPath = Path.Combine(dir, "crash_20260101000000.log");
+        File.WriteAllText(logPath, "locked content");
+
+        using var fs = File.Open(logPath, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        var result = service.GetLatestCrashLogContent();
+
+        Assert.Null(result);
+    }
 }

--- a/PhotoGeoExplorer/MainWindow.xaml
+++ b/PhotoGeoExplorer/MainWindow.xaml
@@ -176,8 +176,8 @@
                 IsClosable="True">
                 <controls:InfoBar.ActionButton>
                     <Button
-                        x:Uid="CrashReportOpenFolderButton"
-                        Click="OnOpenCrashReportFolderClicked" />
+                        x:Uid="CrashReportReportButton"
+                        Click="OnReportCrashClicked" />
                 </controls:InfoBar.ActionButton>
             </controls:InfoBar>
             <controls:InfoBar

--- a/PhotoGeoExplorer/MainWindow.xaml.cs
+++ b/PhotoGeoExplorer/MainWindow.xaml.cs
@@ -468,7 +468,7 @@ public sealed partial class MainWindow : Window, IDisposable
         }
         else if (result == ContentDialogResult.Secondary)
         {
-            CopyCrashLogToClipboard(logContent);
+            await CopyLogAndOpenMailAsync(logContent).ConfigureAwait(true);
         }
     }
 
@@ -544,15 +544,19 @@ public sealed partial class MainWindow : Window, IDisposable
         _ = await Windows.System.Launcher.LaunchUriAsync(new Uri(url)).AsTask().ConfigureAwait(true);
     }
 
-    private void CopyCrashLogToClipboard(string? logContent)
+    private static async Task CopyLogAndOpenMailAsync(string? logContent)
     {
         var text = logContent ?? LocalizationService.GetString("CrashReportDialog.NoLog");
         var dataPackage = new Windows.ApplicationModel.DataTransfer.DataPackage();
         dataPackage.SetText(text);
         Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(dataPackage);
-        _viewModel.ShowNotificationMessage(
-            LocalizationService.GetString("CrashReportDialog.CopiedNotification"),
-            InfoBarSeverity.Success);
+
+        var version = ParseCrashLogField(logContent, "App Version:") ?? string.Empty;
+        var exType = ParseCrashLogField(logContent, "Exception Type:") ?? "Unknown";
+        var subject = Uri.EscapeDataString($"[Crash Report] v{version} {exType}");
+        var body = Uri.EscapeDataString(LocalizationService.GetString("CrashReportDialog.MailBody"));
+        var mailto = new Uri($"mailto:photogeoexplorer@outlook.com?subject={subject}&body={body}");
+        _ = await Windows.System.Launcher.LaunchUriAsync(mailto).AsTask().ConfigureAwait(true);
     }
 
     private async void OnOpenCrashReportFolderClicked(object sender, RoutedEventArgs e)

--- a/PhotoGeoExplorer/MainWindow.xaml.cs
+++ b/PhotoGeoExplorer/MainWindow.xaml.cs
@@ -444,6 +444,117 @@ public sealed partial class MainWindow : Window, IDisposable
         }
     }
 
+    private async void OnReportCrashClicked(object sender, RoutedEventArgs e)
+    {
+        var logContent = _crashReportService?.GetLatestCrashLogContent();
+
+        var summaryPanel = BuildCrashReportSummaryPanel(logContent);
+
+        var dialog = new ContentDialog
+        {
+            Title = LocalizationService.GetString("CrashReportDialog.Title"),
+            Content = summaryPanel,
+            PrimaryButtonText = LocalizationService.GetString("CrashReportDialog.GitHubButton"),
+            SecondaryButtonText = LocalizationService.GetString("CrashReportDialog.CopyButton"),
+            CloseButtonText = LocalizationService.GetString("CrashReportDialog.CloseButton"),
+            XamlRoot = Content.XamlRoot
+        };
+
+        var result = await dialog.ShowAsync();
+
+        if (result == ContentDialogResult.Primary)
+        {
+            await OpenCrashReportGitHubIssueAsync(logContent).ConfigureAwait(true);
+        }
+        else if (result == ContentDialogResult.Secondary)
+        {
+            CopyCrashLogToClipboard(logContent);
+        }
+    }
+
+    private StackPanel BuildCrashReportSummaryPanel(string? logContent)
+    {
+        var panel = new StackPanel { Spacing = 8, MaxWidth = 480 };
+
+        var version = ParseCrashLogField(logContent, "App Version:");
+        var timestamp = ParseCrashLogField(logContent, "Timestamp:");
+        var exType = ParseCrashLogField(logContent, "Exception Type:");
+
+        if (!string.IsNullOrEmpty(version) || !string.IsNullOrEmpty(timestamp) || !string.IsNullOrEmpty(exType))
+        {
+            var infoLines = new StackPanel { Spacing = 2 };
+            if (!string.IsNullOrEmpty(version))
+                infoLines.Children.Add(new TextBlock { Text = $"{LocalizationService.GetString("CrashReportDialog.LabelVersion")} {version}" });
+            if (!string.IsNullOrEmpty(timestamp))
+                infoLines.Children.Add(new TextBlock { Text = $"{LocalizationService.GetString("CrashReportDialog.LabelTimestamp")} {timestamp}" });
+            if (!string.IsNullOrEmpty(exType))
+                infoLines.Children.Add(new TextBlock { Text = $"{LocalizationService.GetString("CrashReportDialog.LabelException")} {exType}", TextWrapping = TextWrapping.Wrap });
+            panel.Children.Add(infoLines);
+        }
+
+        panel.Children.Add(new TextBlock
+        {
+            Text = LocalizationService.GetString("CrashReportDialog.SupportNote"),
+            TextWrapping = TextWrapping.Wrap,
+            Opacity = 0.7,
+            FontSize = 12
+        });
+
+        var folderLink = new HyperlinkButton
+        {
+            Content = LocalizationService.GetString("CrashReportDialog.OpenFolderLink"),
+            Padding = new Microsoft.UI.Xaml.Thickness(0)
+        };
+        folderLink.Click += OnOpenCrashReportFolderClicked;
+        panel.Children.Add(folderLink);
+
+        return panel;
+    }
+
+    private static string? ParseCrashLogField(string? logContent, string fieldName)
+    {
+        if (string.IsNullOrEmpty(logContent)) return null;
+        foreach (var line in logContent.Split('\n'))
+        {
+            if (line.StartsWith(fieldName, StringComparison.Ordinal))
+                return line[fieldName.Length..].Trim();
+        }
+        return null;
+    }
+
+    private static async Task OpenCrashReportGitHubIssueAsync(string? logContent)
+    {
+        const string baseUrl = "https://github.com/scottlz0310/PhotoGeoExplorer/issues/new";
+        var exType = ParseCrashLogField(logContent, "Exception Type:") ?? "Unknown";
+        var title = Uri.EscapeDataString($"[Crash] {exType}");
+
+        var truncated = logContent is { Length: > 2000 }
+            ? logContent[..2000] + "\n...(truncated)"
+            : logContent ?? "(no log)";
+
+        var body = Uri.EscapeDataString(
+            "## クラッシュレポート\n\n" +
+            "PhotoGeoExplorer が予期せず終了しました。\n\n" +
+            "<details>\n<summary>クラッシュログ</summary>\n\n```\n" +
+            truncated +
+            "\n```\n\n</details>\n\n" +
+            "---\n*PhotoGeoExplorer から自動生成されました。*");
+
+        var url = $"{baseUrl}?title={title}&labels=bug&body={body}";
+        _ = await Windows.System.Launcher.LaunchUriAsync(new Uri(url)).AsTask().ConfigureAwait(true);
+    }
+
+    private void CopyCrashLogToClipboard(string? logContent)
+    {
+        var text = logContent ?? LocalizationService.GetString("CrashReportDialog.NoLog");
+        var dataPackage = new Windows.ApplicationModel.DataTransfer.DataPackage();
+        dataPackage.SetText(text);
+        Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(dataPackage);
+        _viewModel.ShowNotificationMessage(
+            LocalizationService.GetString("CrashReportDialog.CopiedNotification"),
+            InfoBarSeverity.Success);
+    }
+
     private async void OnOpenCrashReportFolderClicked(object sender, RoutedEventArgs e)
     {
         var path = _viewModel.CrashReportsDirectoryPath;

--- a/PhotoGeoExplorer/Services/CrashReportService.cs
+++ b/PhotoGeoExplorer/Services/CrashReportService.cs
@@ -78,6 +78,25 @@ internal sealed class CrashReportService : ICrashReportService
         catch (System.Security.SecurityException) { }
     }
 
+    public string? GetLatestCrashLogContent()
+    {
+        try
+        {
+            if (!Directory.Exists(_crashReportsDir))
+                return null;
+            var latest = Directory.GetFiles(_crashReportsDir, "crash_*.log")
+                .OrderByDescending(f => f)
+                .FirstOrDefault();
+            if (latest is null)
+                return null;
+            return File.ReadAllText(latest, Encoding.UTF8);
+        }
+        catch (UnauthorizedAccessException) { return null; }
+        catch (IOException) { return null; }
+        catch (ArgumentException) { return null; }
+        catch (NotSupportedException) { return null; }
+    }
+
     internal static string MaskSensitiveData(string text)
     {
         if (string.IsNullOrEmpty(text))

--- a/PhotoGeoExplorer/Services/ICrashReportService.cs
+++ b/PhotoGeoExplorer/Services/ICrashReportService.cs
@@ -13,4 +13,6 @@ internal interface ICrashReportService
     void RecordNormalExit();
 
     void WriteCrashLog(Exception? exception);
+
+    string? GetLatestCrashLogContent();
 }

--- a/PhotoGeoExplorer/Strings/en-US/Resources.resw
+++ b/PhotoGeoExplorer/Strings/en-US/Resources.resw
@@ -905,4 +905,40 @@
   <data name="CrashReportOpenFolderButton.Content" xml:space="preserve">
     <value>Open Crash Log Folder</value>
   </data>
+  <data name="CrashReportReportButton.Content" xml:space="preserve">
+    <value>Report</value>
+  </data>
+  <data name="CrashReportDialog.Title" xml:space="preserve">
+    <value>Submit Crash Report</value>
+  </data>
+  <data name="CrashReportDialog.GitHubButton" xml:space="preserve">
+    <value>Report on GitHub</value>
+  </data>
+  <data name="CrashReportDialog.CopyButton" xml:space="preserve">
+    <value>Copy Log</value>
+  </data>
+  <data name="CrashReportDialog.CloseButton" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="CrashReportDialog.LabelVersion" xml:space="preserve">
+    <value>Version:</value>
+  </data>
+  <data name="CrashReportDialog.LabelTimestamp" xml:space="preserve">
+    <value>Occurred:</value>
+  </data>
+  <data name="CrashReportDialog.LabelException" xml:space="preserve">
+    <value>Exception:</value>
+  </data>
+  <data name="CrashReportDialog.SupportNote" xml:space="preserve">
+    <value>If you don't have a GitHub account, copy the log and send it to photogeoexplorer@outlook.com.</value>
+  </data>
+  <data name="CrashReportDialog.OpenFolderLink" xml:space="preserve">
+    <value>Open log folder</value>
+  </data>
+  <data name="CrashReportDialog.NoLog" xml:space="preserve">
+    <value>(No log found)</value>
+  </data>
+  <data name="CrashReportDialog.CopiedNotification" xml:space="preserve">
+    <value>Log copied to clipboard. Please send it to photogeoexplorer@outlook.com.</value>
+  </data>
 </root>

--- a/PhotoGeoExplorer/Strings/en-US/Resources.resw
+++ b/PhotoGeoExplorer/Strings/en-US/Resources.resw
@@ -915,7 +915,7 @@
     <value>Report on GitHub</value>
   </data>
   <data name="CrashReportDialog.CopyButton" xml:space="preserve">
-    <value>Copy Log</value>
+    <value>Report by Email</value>
   </data>
   <data name="CrashReportDialog.CloseButton" xml:space="preserve">
     <value>Close</value>
@@ -930,7 +930,7 @@
     <value>Exception:</value>
   </data>
   <data name="CrashReportDialog.SupportNote" xml:space="preserve">
-    <value>If you don't have a GitHub account, copy the log and send it to photogeoexplorer@outlook.com.</value>
+    <value>If you don't have a GitHub account, use "Report by Email" to open your mail app.</value>
   </data>
   <data name="CrashReportDialog.OpenFolderLink" xml:space="preserve">
     <value>Open log folder</value>
@@ -938,7 +938,7 @@
   <data name="CrashReportDialog.NoLog" xml:space="preserve">
     <value>(No log found)</value>
   </data>
-  <data name="CrashReportDialog.CopiedNotification" xml:space="preserve">
-    <value>Log copied to clipboard. Please send it to photogeoexplorer@outlook.com.</value>
+  <data name="CrashReportDialog.MailBody" xml:space="preserve">
+    <value>The crash log has been copied to your clipboard. Please paste it into this email (Ctrl+V) and send.</value>
   </data>
 </root>

--- a/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
+++ b/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
@@ -915,7 +915,7 @@
     <value>GitHub で報告する</value>
   </data>
   <data name="CrashReportDialog.CopyButton" xml:space="preserve">
-    <value>ログをコピー</value>
+    <value>メールで報告する</value>
   </data>
   <data name="CrashReportDialog.CloseButton" xml:space="preserve">
     <value>閉じる</value>
@@ -930,7 +930,7 @@
     <value>例外種別:</value>
   </data>
   <data name="CrashReportDialog.SupportNote" xml:space="preserve">
-    <value>GitHubアカウントをお持ちでない場合はログをコピーして photogeoexplorer@outlook.com にお送りください。</value>
+    <value>GitHubアカウントをお持ちでない場合は「メールで報告する」からメールアプリで送信できます。</value>
   </data>
   <data name="CrashReportDialog.OpenFolderLink" xml:space="preserve">
     <value>ログフォルダーを開く</value>
@@ -938,7 +938,7 @@
   <data name="CrashReportDialog.NoLog" xml:space="preserve">
     <value>(ログが見つかりませんでした)</value>
   </data>
-  <data name="CrashReportDialog.CopiedNotification" xml:space="preserve">
-    <value>ログをクリップボードにコピーしました。photogeoexplorer@outlook.com にお送りください。</value>
+  <data name="CrashReportDialog.MailBody" xml:space="preserve">
+    <value>クラッシュログをクリップボードにコピーしました。このメールに貼り付けてお送りください（Ctrl+V）。</value>
   </data>
 </root>

--- a/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
+++ b/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
@@ -905,4 +905,40 @@
   <data name="CrashReportOpenFolderButton.Content" xml:space="preserve">
     <value>クラッシュログフォルダーを開く</value>
   </data>
+  <data name="CrashReportReportButton.Content" xml:space="preserve">
+    <value>報告する</value>
+  </data>
+  <data name="CrashReportDialog.Title" xml:space="preserve">
+    <value>クラッシュレポートの送信</value>
+  </data>
+  <data name="CrashReportDialog.GitHubButton" xml:space="preserve">
+    <value>GitHub で報告する</value>
+  </data>
+  <data name="CrashReportDialog.CopyButton" xml:space="preserve">
+    <value>ログをコピー</value>
+  </data>
+  <data name="CrashReportDialog.CloseButton" xml:space="preserve">
+    <value>閉じる</value>
+  </data>
+  <data name="CrashReportDialog.LabelVersion" xml:space="preserve">
+    <value>バージョン:</value>
+  </data>
+  <data name="CrashReportDialog.LabelTimestamp" xml:space="preserve">
+    <value>発生日時:</value>
+  </data>
+  <data name="CrashReportDialog.LabelException" xml:space="preserve">
+    <value>例外種別:</value>
+  </data>
+  <data name="CrashReportDialog.SupportNote" xml:space="preserve">
+    <value>GitHubアカウントをお持ちでない場合はログをコピーして photogeoexplorer@outlook.com にお送りください。</value>
+  </data>
+  <data name="CrashReportDialog.OpenFolderLink" xml:space="preserve">
+    <value>ログフォルダーを開く</value>
+  </data>
+  <data name="CrashReportDialog.NoLog" xml:space="preserve">
+    <value>(ログが見つかりませんでした)</value>
+  </data>
+  <data name="CrashReportDialog.CopiedNotification" xml:space="preserve">
+    <value>ログをクリップボードにコピーしました。photogeoexplorer@outlook.com にお送りください。</value>
+  </data>
 </root>


### PR DESCRIPTION
## 概要

クラッシュ検出時のバナーに「報告する」ボタンを追加し、送信ダイアログへの導線を整備します。

## 変更内容

### ユーザーフロー

```
クラッシュ検出バナー
  └─ [報告する] ボタン
       └─ クラッシュレポートダイアログ
            ├─ バージョン / 発生日時 / 例外種別 を表示
            ├─ [GitHub で報告する] → Issue 作成ページをブラウザで開く（ログ自動埋め込み）
            ├─ [ログをコピー]      → クリップボードにコピー + photogeoexplorer@outlook.com を案内
            └─ ログフォルダーを開く（リンク）
```

### GitHub アカウントなしの場合
「ログをコピー」後に `photogeoexplorer@outlook.com` へ送付するよう案内します。

### 実装詳細

| ファイル | 変更内容 |
|---------|---------|
| `ICrashReportService.cs` | `GetLatestCrashLogContent()` を追加 |
| `CrashReportService.cs` | 最新クラッシュログを返す実装を追加 |
| `MainWindow.xaml` | InfoBar ActionButton を「報告する」に変更 |
| `MainWindow.xaml.cs` | ダイアログ表示・GitHub URL 生成・クリップボードコピー処理を追加 |
| `Resources.resw` (ja/en) | 新規文字列キー 10 件追加 |

## 検証方法

```powershell
# 1. DevInstall.ps1 でインストール
.\scripts\DevInstall.ps1

# 2. running.lock を手動で作成（クラッシュをシミュレート）
New-Item "$env:LOCALAPPDATA\PhotoGeoExplorer\running.lock" -Force

# 3. アプリを起動 → クラッシュバナーが表示されることを確認
# 4. 「報告する」ボタンをクリック → ダイアログが表示されることを確認
# 5. 「GitHub で報告する」→ ブラウザで Issue 作成ページが開くことを確認
# 6. 「ログをコピー」→ クリップボードにログがコピーされ、通知が表示されることを確認
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)