### PR TITLE
chore(release): v1.8.3 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ## [Unreleased]
 
+## [1.8.3] - 2026-05-27
+
 ### 追加
-- クラッシュレポート送信ダイアログを追加
+- クラッシュレポート送信ダイアログを追加（#123）
   - バナーの「フォルダを開く」を「報告する」ボタンに変更。クリックでダイアログを表示。
   - 「GitHub で報告する」: クラッシュログを埋め込んだ Issue 作成ページをブラウザで開く。
-  - 「ログをコピー」: ログ全文をクリップボードにコピーし、サポートメールアドレス（photogeoexplorer@outlook.com）を案内するトースト通知を表示。
+  - 「メールで報告する」: ログ全文をクリップボードにコピーし、標準メールアプリを `mailto:photogeoexplorer@outlook.com` で起動（件名・本文案内付き）。
   - ダイアログ内に「ログフォルダーを開く」リンクを設置。
 - Partner Center へのストア提出を CI から自動化（#121）
   - `scripts/Submit-ToPartnerCenter.ps1`: MSIX/appxupload API（`manage.devcenter.microsoft.com/v1.0/my/`）を使いリリースビルドを自動提出。

--- a/PhotoGeoExplorer/Assets/propose/listingData-9P0WNR54441B-1152921505701101354.csv
+++ b/PhotoGeoExplorer/Assets/propose/listingData-9P0WNR54441B-1152921505701101354.csv
@@ -5,7 +5,7 @@ It targets Windows 10/11 and renders maps using WinUI 3 and Mapsui.","PhotoGeoEx
 このアプリを実行するには .NET Desktop Runtime が必要です。Microsoft Store からのインストール時に自動的に提供されます。
 Windows 10/11 を対象とし、WinUI 3 と Mapsui で地図を描画します。"
 ReleaseNotes,3,テキスト,,"Release Notes (v1.8.3)
-- Added: Crash report submit dialog — tap ""Report"" on the crash banner to open a dialog; choose ""Report on GitHub"" to open a pre-filled Issue, or ""Send by Email"" to copy the log to clipboard and open the default mail app
+- Added: Crash report submit dialog — tap ""Report"" on the crash banner to open a dialog; choose ""Report on GitHub"" to open a pre-filled Issue, or ""Report by Email"" to copy the log to clipboard and open the default mail app
 - Added: CI-integrated Partner Center submission — MSIX is now automatically submitted to the Store on tag push","リリースノート（v1.8.3）
 - 追加: クラッシュレポート送信ダイアログ — クラッシュバナーの「報告する」からダイアログを表示。「GitHub で報告する」でログ埋め込み済み Issue 作成ページを開く。「メールで報告する」でログをクリップボードにコピーし標準メールアプリを起動。
 - 追加: CI からの Partner Center 自動提出 — タグプッシュ時に MSIX を Store へ自動提出"

--- a/PhotoGeoExplorer/Assets/propose/listingData-9P0WNR54441B-1152921505701101354.csv
+++ b/PhotoGeoExplorer/Assets/propose/listingData-9P0WNR54441B-1152921505701101354.csv
@@ -4,13 +4,11 @@ This app requires the .NET Desktop Runtime to run. It is automatically provided 
 It targets Windows 10/11 and renders maps using WinUI 3 and Mapsui.","PhotoGeoExplorer は、GPS 情報（ジオタグ）を含む写真を地図上に表示し、撮影場所から写真を整理・探索できる Windows デスクトップアプリです。
 このアプリを実行するには .NET Desktop Runtime が必要です。Microsoft Store からのインストール時に自動的に提供されます。
 Windows 10/11 を対象とし、WinUI 3 と Mapsui で地図を描画します。"
-ReleaseNotes,3,テキスト,,"Release Notes (v1.8.2)
-- Fixed: App crashed on startup due to x:Uid naming conflict in crash report banner (introduced in v1.8.2)
-- Added: Crash report detection — on startup after an abnormal exit, a warning banner with a link to the crash log folder is shown
-- Fixed: Buttons using async commands are now protected against double-execution","リリースノート（v1.8.2）
-- 修正: クラッシュレポートバナーの x:Uid 命名衝突により起動時にクラッシュする問題
-- 追加: 異常終了検知 — 前回クラッシュ時の次回起動時に警告バナーとクラッシュログフォルダーへのリンクを表示
-- 修正: 非同期コマンドボタンの二重実行を防止"
+ReleaseNotes,3,テキスト,,"Release Notes (v1.8.3)
+- Added: Crash report submit dialog — tap ""Report"" on the crash banner to open a dialog; choose ""Report on GitHub"" to open a pre-filled Issue, or ""Send by Email"" to copy the log to clipboard and open the default mail app
+- Added: CI-integrated Partner Center submission — MSIX is now automatically submitted to the Store on tag push","リリースノート（v1.8.3）
+- 追加: クラッシュレポート送信ダイアログ — クラッシュバナーの「報告する」からダイアログを表示。「GitHub で報告する」でログ埋め込み済み Issue 作成ページを開く。「メールで報告する」でログをクリップボードにコピーし標準メールアプリを起動。
+- 追加: CI からの Partner Center 自動提出 — タグプッシュ時に MSIX を Store へ自動提出"
 Title,4,テキスト,,PhotoGeoExplorer,PhotoGeoExplorer
 ShortTitle,5,テキスト,,Explore Photos on a Map,写真を地図で整理・探索
 SortTitle,6,テキスト,,,

--- a/PhotoGeoExplorer/Package.appxmanifest
+++ b/PhotoGeoExplorer/Package.appxmanifest
@@ -5,7 +5,7 @@
   xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap uap10 rescap">
-  <Identity Name="scottlz0310.PhotoGeoExplorer" Publisher="CN=39FB3D39-1F1A-4B82-B081-47469FD12CA6" Version="1.8.2.0" />
+  <Identity Name="scottlz0310.PhotoGeoExplorer" Publisher="CN=39FB3D39-1F1A-4B82-B081-47469FD12CA6" Version="1.8.3.0" />
   <Properties>
     <DisplayName>PhotoGeoExplorer</DisplayName>
     <PublisherDisplayName>scottlz0310</PublisherDisplayName>

--- a/PhotoGeoExplorer/PhotoGeoExplorer.csproj
+++ b/PhotoGeoExplorer/PhotoGeoExplorer.csproj
@@ -9,10 +9,10 @@
     <WindowsPackageType Condition="'$(WindowsPackageType)'==''">None</WindowsPackageType>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PhotoGeoExplorer</RootNamespace>
-    <Version>1.8.2</Version>
-    <AssemblyVersion>1.8.2.0</AssemblyVersion>
-    <FileVersion>1.8.2.0</FileVersion>
-    <InformationalVersion>1.8.2</InformationalVersion>
+    <Version>1.8.3</Version>
+    <AssemblyVersion>1.8.3.0</AssemblyVersion>
+    <FileVersion>1.8.3.0</FileVersion>
+    <InformationalVersion>1.8.3</InformationalVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <WindowsSdkPackageVersion>10.0.26100.81</WindowsSdkPackageVersion>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>


### PR DESCRIPTION
## 概要

v1.8.3 リリース準備のバージョンバンプとドキュメント更新です。

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `PhotoGeoExplorer.csproj` | Version / AssemblyVersion / FileVersion / InformationalVersion: 1.8.2 → 1.8.3 |
| `Package.appxmanifest` | Identity Version: 1.8.2.0 → 1.8.3.0 |
| `CHANGELOG.md` | [Unreleased] を [1.8.3] - 2026-05-27 に昇格、[Unreleased] セクションを空で再設置 |
| `listingData-*.csv` | ReleaseNotes を v1.8.3 内容（クラッシュ送信ダイアログ・CI 自動提出）に更新 |

## v1.8.3 の主な変更点

- クラッシュレポート送信ダイアログを追加（#123）
- Partner Center への CI 自動提出を実装（#121）

## 検証方法

```powershell
dotnet build PhotoGeoExplorer.sln -c Release -p:Platform=x64
```

ビルド成功・バージョン番号 1.8.3 であることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)