### PR TITLE
fix(ci): StrictMode でのプロパティ不在エラーを修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### 修正
+- Partner Center 自動提出スクリプトが `Set-StrictMode -Version Latest` 環境でプロパティ不在エラーになる問題を修正
+  - `pendingApplicationSubmission` / `minimumDirectXVersion` / `minimumSystemRam` の存在確認を `PSObject.Properties` 経由に変更
+
 ## [1.8.3] - 2026-05-27
 
 ### 追加

--- a/scripts/Submit-ToPartnerCenter.ps1
+++ b/scripts/Submit-ToPartnerCenter.ps1
@@ -136,7 +136,7 @@ function Get-Application([string]$AppId) {
 # ── 3. pending 申請の確認・処理 ──────────────────────────────────────────────
 function Resolve-PendingSubmission {
     param([object]$App, [string]$AppId, [bool]$ShouldDelete)
-    $pending = $App.pendingApplicationSubmission
+    $pending = if ($App.PSObject.Properties['pendingApplicationSubmission']) { $App.pendingApplicationSubmission } else { $null }
     if (-not $pending) {
         Write-Ok 'pending submission なし'
         return
@@ -247,8 +247,8 @@ function Update-Packages {
     $newPkg = [PSCustomObject]@{
         fileName              = $fileName
         fileStatus            = 'PendingUpload'
-        minimumDirectXVersion = if ($refPkg -and $refPkg.minimumDirectXVersion) { $refPkg.minimumDirectXVersion } else { 'None' }
-        minimumSystemRam      = if ($refPkg -and $refPkg.minimumSystemRam)      { $refPkg.minimumSystemRam }      else { 'None' }
+        minimumDirectXVersion = if ($refPkg -and $refPkg.PSObject.Properties['minimumDirectXVersion']) { $refPkg.minimumDirectXVersion } else { 'None' }
+        minimumSystemRam      = if ($refPkg -and $refPkg.PSObject.Properties['minimumSystemRam'])      { $refPkg.minimumSystemRam }      else { 'None' }
     }
     $Submission.applicationPackages = $existing + $newPkg
     Write-Ok "PendingUpload : $fileName"


### PR DESCRIPTION
## 概要

`Submit-ToPartnerCenter.ps1` が `Set-StrictMode -Version Latest` 環境で、API レスポンスに存在しないプロパティへ直接アクセスして例外になる問題を修正します。

## 原因

```
The property 'pendingApplicationSubmission' cannot be found on this object.
```

`Set-StrictMode -Version Latest` が有効なため、PSCustomObject に存在しないプロパティへの直接アクセスが例外をスローする。

## 修正内容

| 箇所 | 変更 |
|------|------|
| `Resolve-PendingSubmission` | `$App.pendingApplicationSubmission` → `PSObject.Properties` で存在確認してから参照 |
| `Update-Packages` | `$refPkg.minimumDirectXVersion` / `minimumSystemRam` → 同様に `PSObject.Properties` 経由 |

## 検証方法

v1.8.3 タグで Release ワークフローを再実行して `Submit to Partner Center` ステップが通過することを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)