### PR TITLE
fix(ci): リリースワークフローの2つの不具合を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,11 +113,10 @@ jobs:
           $escaped  = [regex]::Escape($version)
           $pattern  = "(?ms)^## \[$escaped\][^\n]*\n(.*?)(?=^## \[|\z)"
           $m        = [regex]::Match($content, $pattern)
-          $notes    = if ($m.Success) { $m.Groups[1].Value.Trim() } else { '' }
+          $notes    = if ($m.Success) { $m.Groups[1].Value.Trim().Replace("`r`n", "`n").Replace("`r", "`n") } else { '' }
           $delim    = "GHDELIM$(Get-Random)"
-          "NOTES<<$delim"  | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
-          $notes           | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
-          $delim           | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
+          $nl       = "`n"
+          [IO.File]::AppendAllText($env:GITHUB_OUTPUT, "NOTES<<$delim$nl$notes$nl$delim$nl", [System.Text.Encoding]::UTF8)
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,13 +104,29 @@ jobs:
           name: installer
           path: artifacts/
 
+      - name: Extract release notes from CHANGELOG
+        id: changelog
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart("v")
+          $content  = Get-Content -Path "CHANGELOG.md" -Raw
+          $escaped  = [regex]::Escape($version)
+          $pattern  = "(?ms)^## \[$escaped\][^\n]*\n(.*?)(?=^## \[|\z)"
+          $m        = [regex]::Match($content, $pattern)
+          $notes    = if ($m.Success) { $m.Groups[1].Value.Trim() } else { '' }
+          $delim    = "GHDELIM$(Get-Random)"
+          "NOTES<<$delim"  | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
+          $notes           | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
+          $delim           | Add-Content -Path $env:GITHUB_OUTPUT -Encoding utf8
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           files: artifacts/*
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
-          generate_release_notes: true
+          body: ${{ steps.changelog.outputs.NOTES }}
+          append_body: false
 
       - name: Submit to Partner Center
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - `Submit-ToPartnerCenter.ps1`: HTTP レスポンスなし（接続失敗等）の例外処理で `?.StatusCode.value__` が StrictMode エラーになる問題を修正（`?.StatusCode?.value__` に変更）
 - `release.yml`: `generate_release_notes: true` が既存リリースへの再実行時にノートを重複付加する問題を修正
   - `CHANGELOG.md` の該当バージョンセクションをリリースノートとして使用するよう変更し、再実行しても重複しない設計に変更
+- `release.yml`: CHANGELOG 抽出ステップで `Add-Content` が Windows 上で CRLF を付加し `GITHUB_OUTPUT` のパースが不安定になる問題を修正
+  - `[IO.File]::AppendAllText` + 明示的 LF に切り替え、`$notes` 内の CRLF を LF へ正規化
 
 ## [1.8.3] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### 修正
 - Partner Center 自動提出スクリプトが `Set-StrictMode -Version Latest` 環境でプロパティ不在エラーになる問題を修正
   - `pendingApplicationSubmission` / `minimumDirectXVersion` / `minimumSystemRam` の存在確認を `PSObject.Properties` 経由に変更
+- `Submit-ToPartnerCenter.ps1`: HTTP レスポンスなし（接続失敗等）の例外処理で `?.StatusCode.value__` が StrictMode エラーになる問題を修正（`?.StatusCode?.value__` に変更）
+- `release.yml`: `generate_release_notes: true` が既存リリースへの再実行時にノートを重複付加する問題を修正
+  - `CHANGELOG.md` の該当バージョンセクションをリリースノートとして使用するよう変更し、再実行しても重複しない設計に変更
 
 ## [1.8.3] - 2026-05-27
 

--- a/scripts/Submit-ToPartnerCenter.ps1
+++ b/scripts/Submit-ToPartnerCenter.ps1
@@ -94,7 +94,7 @@ function Invoke-StoreApi {
         return $null
     }
     catch {
-        $sc   = $_.Exception.Response?.StatusCode.value__ ?? '?'
+        $sc   = $_.Exception.Response?.StatusCode?.value__ ?? '?'
         $corr = $_.Exception.Response?.Headers?['MS-CV'] ?? '—'
         $body = $null
         try { $body = $_.Exception.Response.GetResponseStream() | ForEach-Object { [System.IO.StreamReader]::new($_).ReadToEnd() } } catch {}


### PR DESCRIPTION
- Submit-ToPartnerCenter.ps1: `?.StatusCode.value__` を `?.StatusCode?.value__` に変更し
  HTTP レスポンスなしの例外処理で StrictMode エラーが発生する問題を修正
- release.yml: `generate_release_notes: true` を廃止し CHANGELOG.md から
  該当バージョンのノートを抽出して使用するよう変更。
  ワークフロー再実行時にリリースノートが重複付加される問題を解消。

https://claude.ai/code/session_01CaA3ZE2ARFfkSPAuET2rPD