### PR TITLE
fix(FileBrowser): ファイル操作のスキップ時にリフレッシュが漏れる問題を修正 (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ## [Unreleased]
 
 ### 修正
+- ファイル移動・コピー操作で競合スキップが発生した際にファイル一覧が自動更新されない問題を修正 (#128)
+  - `ExecuteMoveItemsToFolderAsync` / `ExecuteCopyItemsToFolderAsync` のリフレッシュ条件を `SuccessCount > 0` から `SuccessCount > 0 || SkipCount > 0` に変更
+  - 競合ダイアログで「スキップ」「すべてスキップ」を選んだ後もリストが最新状態に更新されるようになった
 - Partner Center 自動提出スクリプトが `Set-StrictMode -Version Latest` 環境でプロパティ不在エラーになる問題を修正
   - `pendingApplicationSubmission` / `minimumDirectXVersion` / `minimumSystemRam` の存在確認を `PSObject.Properties` 経由に変更
 - `Submit-ToPartnerCenter.ps1`: HTTP レスポンスなし（接続失敗等）の例外処理で `?.StatusCode.value__` が StrictMode エラーになる問題を修正（`?.StatusCode?.value__` に変更）

--- a/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
@@ -940,6 +940,78 @@ public class FileBrowserPaneViewModelTests
         }
     }
 
+    [Fact]
+    public async Task ExecuteMoveItemsToFolderAsync_AllSkip_CallsRefresh()
+    {
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            using var vm = CreateViewModelWithFakes(out var fakePaneService, out var stubOp);
+            stubOp.MoveItemsResult = new FileOperationSummary(0, 3, Array.Empty<FileOperationFailure>());
+            await vm.LoadFolderAsync(tempDir).ConfigureAwait(true);
+            var before = fakePaneService.LoadFolderCallCount;
+
+            var summary = await vm.ExecuteMoveItemsToFolderAsync(new List<PhotoListItem>(), Path.GetTempPath());
+
+            Assert.Equal(0, summary.SuccessCount);
+            Assert.Equal(3, summary.SkipCount);
+            Assert.Equal(before + 1, fakePaneService.LoadFolderCallCount);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteMoveItemsToFolderAsync_WithConflictCallback_AllSkip_CallsRefresh()
+    {
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            using var vm = CreateViewModelWithFakes(out var fakePaneService, out var stubOp);
+            stubOp.MoveItemsResult = new FileOperationSummary(0, 2, Array.Empty<FileOperationFailure>());
+            await vm.LoadFolderAsync(tempDir).ConfigureAwait(true);
+            var before = fakePaneService.LoadFolderCallCount;
+
+            var summary = await vm.ExecuteMoveItemsToFolderAsync(
+                new List<PhotoListItem>(),
+                Path.GetTempPath(),
+                (_, _) => Task.FromResult(ConflictResolution.Skip));
+
+            Assert.Equal(0, summary.SuccessCount);
+            Assert.Equal(2, summary.SkipCount);
+            Assert.Equal(before + 1, fakePaneService.LoadFolderCallCount);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteCopyItemsToFolderAsync_AllSkip_CallsRefresh()
+    {
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            using var vm = CreateViewModelWithFakes(out var fakePaneService, out var stubOp);
+            stubOp.CopyItemsResult = new FileOperationSummary(0, 2, Array.Empty<FileOperationFailure>());
+            await vm.LoadFolderAsync(tempDir).ConfigureAwait(true);
+            var before = fakePaneService.LoadFolderCallCount;
+
+            var summary = await vm.ExecuteCopyItemsToFolderAsync(new List<PhotoListItem>(), Path.GetTempPath());
+
+            Assert.Equal(0, summary.SuccessCount);
+            Assert.Equal(2, summary.SkipCount);
+            Assert.Equal(before + 1, fakePaneService.LoadFolderCallCount);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
     // =========================================================
     // ExecuteDeleteItemsAsync
     // =========================================================

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -693,7 +693,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         if (resolveConflictAsync is null)
         {
             var summary = _fileOperationService.MoveItems(items, destinationFolder);
-            if (summary.SuccessCount > 0)
+            if (summary.SuccessCount > 0 || summary.SkipCount > 0)
             {
                 await RefreshAsync().ConfigureAwait(false);
             }
@@ -735,7 +735,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
             _moveCts = null;
         }
 
-        if (result.SuccessCount > 0)
+        if (result.SuccessCount > 0 || result.SkipCount > 0)
         {
             await RefreshAsync().ConfigureAwait(false);
         }
@@ -778,7 +778,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         if (resolveConflictAsync is null)
         {
             var summary = _fileOperationService.CopyItems(items, destinationFolder);
-            if (summary.SuccessCount > 0)
+            if (summary.SuccessCount > 0 || summary.SkipCount > 0)
             {
                 await RefreshAsync().ConfigureAwait(false);
             }
@@ -818,7 +818,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
             _copyCts = null;
         }
 
-        if (result.SuccessCount > 0)
+        if (result.SuccessCount > 0 || result.SkipCount > 0)
         {
             await RefreshAsync().ConfigureAwait(false);
         }


### PR DESCRIPTION
## 概要

移動・コピー操作で競合ダイアログが表示され「スキップ」「すべてスキップ」を選択した場合（`SuccessCount=0, SkipCount>0`）に、ファイル一覧が自動更新されないバグを修正する。

Closes #128

## 変更内容

`ExecuteMoveItemsToFolderAsync` / `ExecuteCopyItemsToFolderAsync` のリフレッシュ条件を変更。

```csharp
// Before
if (result.SuccessCount > 0)
{
    await RefreshAsync().ConfigureAwait(false);
}

// After
if (result.SuccessCount > 0 || result.SkipCount > 0)
{
    await RefreshAsync().ConfigureAwait(false);
}
```

対象: コールバックなし（同期）・コールバックあり（非同期）の両パス × Move / Copy = 計4箇所。

**リフレッシュしない（変更なし）ケース:**
- 全件失敗（`SuccessCount=0, SkipCount=0`）: ファイルシステムに変化なし
- 全件同一フォルダスキップ（カウントなし）: 変化なし
- 全件キャンセル（`Cancelled`エラー）: 変化なし

## テスト

以下のテストを追加:
- `ExecuteMoveItemsToFolderAsync_AllSkip_CallsRefresh`
- `ExecuteMoveItemsToFolderAsync_WithConflictCallback_AllSkip_CallsRefresh`
- `ExecuteCopyItemsToFolderAsync_AllSkip_CallsRefresh`

## 検証方法

1. 同名ファイルが存在するフォルダへ移動操作を実行
2. 競合ダイアログで「すべてスキップ」を選択
3. 操作完了後にファイル一覧がリフレッシュされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)