### PR TITLE
refactor(FileBrowser): FileSystemWatcher を FolderWatcherService へ移動 (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### リファクタリング
+- `FileSystemWatcher` 監視ロジックを `FileBrowserPaneViewModel` から `FolderWatcherService` へ移動 (#132)
+  - `IFolderWatcherService` インターフェースを導入し、ViewModel の `System.IO` 直接依存を排除
+  - デバウンスを `System.Threading.Timer` ベースに変更し WinUI 非依存に
+  - コンストラクタ引数でインターバルを差し替え可能にし、単体テストに対応
+
 ### 追加
 - ファイルブラウザに `FileSystemWatcher` による外部変更検知を追加 (#129)
   - 外部アプリ（エクスプローラー・CLI 等）がフォルダ内のファイルを追加・削除・リネームした場合に自動でリストを更新

--- a/PhotoGeoExplorer.Tests/FolderWatcherServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/FolderWatcherServiceTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using PhotoGeoExplorer.Services;
+
+namespace PhotoGeoExplorer.Tests;
+
+public sealed class FolderWatcherServiceTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public FolderWatcherServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    // =========================================================
+    // Watch / FolderChanged
+    // =========================================================
+
+    [Fact]
+    public async Task Watch_FileCreated_RaisesFolderChanged()
+    {
+        using var service = new FolderWatcherService(
+            debounceInterval: TimeSpan.FromMilliseconds(50));
+
+        var tcs = new TaskCompletionSource<bool>();
+        service.FolderChanged += (_, _) => tcs.TrySetResult(true);
+        service.Watch(_tempDir);
+
+        await File.WriteAllTextAsync(Path.Combine(_tempDir, "new.txt"), "x").ConfigureAwait(true);
+
+        var raised = await Task.WhenAny(tcs.Task, Task.Delay(3000)).ConfigureAwait(true);
+        Assert.Equal(tcs.Task, raised);
+    }
+
+    [Fact]
+    public async Task Watch_FileDeleted_RaisesFolderChanged()
+    {
+        var file = Path.Combine(_tempDir, "del.txt");
+        await File.WriteAllTextAsync(file, "x").ConfigureAwait(true);
+
+        using var service = new FolderWatcherService(
+            debounceInterval: TimeSpan.FromMilliseconds(50));
+
+        var tcs = new TaskCompletionSource<bool>();
+        service.FolderChanged += (_, _) => tcs.TrySetResult(true);
+        service.Watch(_tempDir);
+
+        File.Delete(file);
+
+        var raised = await Task.WhenAny(tcs.Task, Task.Delay(3000)).ConfigureAwait(true);
+        Assert.Equal(tcs.Task, raised);
+    }
+
+    [Fact]
+    public async Task Watch_BurstyEvents_DebouncesToSingleNotification()
+    {
+        using var service = new FolderWatcherService(
+            debounceInterval: TimeSpan.FromMilliseconds(200));
+
+        var count = 0;
+        service.FolderChanged += (_, _) => Interlocked.Increment(ref count);
+        service.Watch(_tempDir);
+
+        for (var i = 0; i < 5; i++)
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(_tempDir, $"burst{i}.txt"), "x").ConfigureAwait(true);
+            await Task.Delay(10).ConfigureAwait(true);
+        }
+
+        await Task.Delay(500).ConfigureAwait(true);
+
+        Assert.Equal(1, count);
+    }
+
+    // =========================================================
+    // Stop / Dispose
+    // =========================================================
+
+    [Fact]
+    public async Task Stop_AfterWatch_NoFurtherNotifications()
+    {
+        using var service = new FolderWatcherService(
+            debounceInterval: TimeSpan.FromMilliseconds(50));
+
+        var count = 0;
+        service.FolderChanged += (_, _) => Interlocked.Increment(ref count);
+        service.Watch(_tempDir);
+        service.Stop();
+
+        await File.WriteAllTextAsync(
+            Path.Combine(_tempDir, "after_stop.txt"), "x").ConfigureAwait(true);
+
+        await Task.Delay(300).ConfigureAwait(true);
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task Dispose_StopsWatching()
+    {
+        var service = new FolderWatcherService(
+            debounceInterval: TimeSpan.FromMilliseconds(50));
+
+        var count = 0;
+        service.FolderChanged += (_, _) => Interlocked.Increment(ref count);
+        service.Watch(_tempDir);
+        service.Dispose();
+
+        await File.WriteAllTextAsync(
+            Path.Combine(_tempDir, "after_dispose.txt"), "x").ConfigureAwait(true);
+
+        await Task.Delay(300).ConfigureAwait(true);
+
+        Assert.Equal(0, count);
+    }
+
+    // =========================================================
+    // Polling fallback
+    // =========================================================
+
+    [Fact]
+    public async Task Watch_PollingFallback_RaisesFolderChangedPeriodically()
+    {
+        // 存在しないパスは FileSystemWatcher が失敗しポーリングにフォールバックする
+        var nonExistentPath = Path.Combine(_tempDir, "does_not_exist");
+
+        using var service = new FolderWatcherService(
+            pollingInterval: TimeSpan.FromMilliseconds(100));
+
+        var count = 0;
+        service.FolderChanged += (_, _) => Interlocked.Increment(ref count);
+        service.Watch(nonExistentPath);
+
+        await Task.Delay(350).ConfigureAwait(true);
+
+        Assert.True(count >= 2, $"Expected at least 2 polling ticks but got {count}");
+    }
+
+    // =========================================================
+    // Watch 再呼び出し（フォルダ切り替え）
+    // =========================================================
+
+    [Fact]
+    public async Task Watch_CalledTwice_WatchesLatestFolder()
+    {
+        var dir2 = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir2);
+        try
+        {
+            using var service = new FolderWatcherService(
+                debounceInterval: TimeSpan.FromMilliseconds(50));
+
+            var tcs = new TaskCompletionSource<bool>();
+            service.FolderChanged += (_, _) => tcs.TrySetResult(true);
+
+            service.Watch(_tempDir);
+            service.Watch(dir2);
+
+            await File.WriteAllTextAsync(
+                Path.Combine(dir2, "new.txt"), "x").ConfigureAwait(true);
+
+            var raised = await Task.WhenAny(tcs.Task, Task.Delay(3000)).ConfigureAwait(true);
+            Assert.Equal(tcs.Task, raised);
+        }
+        finally
+        {
+            try { Directory.Delete(dir2, recursive: true); } catch { }
+        }
+    }
+}

--- a/PhotoGeoExplorer.Tests/FolderWatcherServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/FolderWatcherServiceTests.cs
@@ -18,7 +18,7 @@ public sealed class FolderWatcherServiceTests : IDisposable
 
     public void Dispose()
     {
-        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+        try { Directory.Delete(_tempDir, recursive: true); } catch (IOException) { } catch (UnauthorizedAccessException) { }
     }
 
     // =========================================================
@@ -174,7 +174,7 @@ public sealed class FolderWatcherServiceTests : IDisposable
         }
         finally
         {
-            try { Directory.Delete(dir2, recursive: true); } catch { }
+            try { Directory.Delete(dir2, recursive: true); } catch (IOException) { } catch (UnauthorizedAccessException) { }
         }
     }
 }

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -25,8 +25,6 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 {
     private const int ThumbnailGenerationConcurrency = 3;
     private const int ThumbnailUpdateBatchIntervalMs = 300;
-    private const int FileSystemWatcherDebounceMs = 500;
-    private const int FolderPollingIntervalMs = 60_000;
 
     private readonly IFileBrowserPaneService _service;
     private readonly IFileOperationService _fileOperationService;
@@ -97,9 +95,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     private DispatcherQueueTimer? _copyProgressTimer;
     private IReadOnlyList<PhotoListItem> _clipboardItems = Array.Empty<PhotoListItem>();
     private ClipboardOperation _clipboardOperation = ClipboardOperation.None;
-    private System.IO.FileSystemWatcher? _fileSystemWatcher;
-    private DispatcherQueueTimer? _fileSystemWatcherDebounceTimer;
-    private DispatcherQueueTimer? _folderPollingTimer;
+    private readonly IFolderWatcherService _folderWatcherService;
 
     public FileBrowserPaneViewModel()
         : this(new FileBrowserPaneService(), new WorkspaceState())
@@ -111,7 +107,8 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         WorkspaceState workspaceState,
         IExifEditorService? exifEditorService = null,
         IDialogService? dialogService = null,
-        IFileOperationService? fileOperationService = null)
+        IFileOperationService? fileOperationService = null,
+        IFolderWatcherService? folderWatcherService = null)
     {
         ArgumentNullException.ThrowIfNull(service);
         ArgumentNullException.ThrowIfNull(workspaceState);
@@ -121,6 +118,8 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         _workspaceState = workspaceState;
         _exifEditorService = exifEditorService;
         _dialogService = dialogService;
+        _folderWatcherService = folderWatcherService ?? new FolderWatcherService();
+        _folderWatcherService.FolderChanged += OnFolderWatcherChanged;
         _dispatcherQueue = TryGetDispatcherQueue();
 
         // WorkspaceState にナビゲーションコールバックを設定
@@ -1010,7 +1009,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
                 // 注意: StartBackgroundThumbnailGeneration 内部で DispatcherQueue を使用してタイマーを構成しているため、
                 //       ここでは明示的に UI スレッド上から呼び出している（UI 更新と意図を揃えるため）
                 StartBackgroundThumbnailGeneration();
-                StartFolderWatcher(folderPath);
+                _folderWatcherService.Watch(folderPath);
             }).ConfigureAwait(false);
 
             AppLog.Info($"LoadFolderAsync: Folder '{folderPath}' loaded successfully. Item count: {Items.Count}");
@@ -1299,7 +1298,8 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     {
         _workspaceState.PhotoFocusRequested -= OnWorkspacePhotoFocusRequested;
         ConfigureUiActionHandlers(null, null, null, null, null, null);
-        StopFolderWatcher();
+        _folderWatcherService.FolderChanged -= OnFolderWatcherChanged;
+        _folderWatcherService.Dispose();
         CancelThumbnailGeneration();
         CancelMetadataLoad();
         CancelFolderLoad();
@@ -1861,135 +1861,17 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         }
     }
 
-    private void StartFolderWatcher(string folderPath)
+    private void OnFolderWatcherChanged(object? sender, EventArgs e)
     {
-        StopFolderWatcher();
-
-        if (_dispatcherQueue is null)
-        {
-            return;
-        }
-
-        var watcherStarted = false;
-        try
-        {
-            var watcher = new System.IO.FileSystemWatcher(folderPath)
-            {
-                NotifyFilter = System.IO.NotifyFilters.FileName
-                    | System.IO.NotifyFilters.DirectoryName
-                    | System.IO.NotifyFilters.LastWrite,
-                IncludeSubdirectories = false,
-            };
-            watcher.Created += OnFileSystemChanged;
-            watcher.Deleted += OnFileSystemChanged;
-            watcher.Changed += OnFileSystemChanged;
-            watcher.Renamed += OnFileSystemChanged;
-            watcher.Error += OnFileSystemWatcherError;
-            watcher.EnableRaisingEvents = true;
-            _fileSystemWatcher = watcher;
-            watcherStarted = true;
-            AppLog.Info($"StartFolderWatcher: Watching '{folderPath}'");
-        }
-        catch (Exception ex) when (ex is ArgumentException or System.IO.IOException or UnauthorizedAccessException)
-        {
-            AppLog.Info($"StartFolderWatcher: FileSystemWatcher unavailable for '{folderPath}', falling back to polling. {ex.Message}");
-        }
-
-        if (!watcherStarted)
-        {
-            _folderPollingTimer = _dispatcherQueue.CreateTimer();
-            _folderPollingTimer.Interval = TimeSpan.FromMilliseconds(FolderPollingIntervalMs);
-            _folderPollingTimer.Tick += OnFolderPollingTimerTick;
-            _folderPollingTimer.Start();
-        }
-    }
-
-    private void StopFolderWatcher()
-    {
-        if (_fileSystemWatcher is not null)
-        {
-            _fileSystemWatcher.EnableRaisingEvents = false;
-            _fileSystemWatcher.Created -= OnFileSystemChanged;
-            _fileSystemWatcher.Deleted -= OnFileSystemChanged;
-            _fileSystemWatcher.Changed -= OnFileSystemChanged;
-            _fileSystemWatcher.Renamed -= OnFileSystemChanged;
-            _fileSystemWatcher.Error -= OnFileSystemWatcherError;
-            _fileSystemWatcher.Dispose();
-            _fileSystemWatcher = null;
-        }
-
-        if (_fileSystemWatcherDebounceTimer is not null)
-        {
-            _fileSystemWatcherDebounceTimer.Stop();
-            _fileSystemWatcherDebounceTimer.Tick -= OnFileSystemWatcherDebounceTimerTick;
-            _fileSystemWatcherDebounceTimer = null;
-        }
-
-        if (_folderPollingTimer is not null)
-        {
-            _folderPollingTimer.Stop();
-            _folderPollingTimer.Tick -= OnFolderPollingTimerTick;
-            _folderPollingTimer = null;
-        }
-    }
-
-    private void OnFileSystemChanged(object sender, System.IO.FileSystemEventArgs e)
-    {
-        _dispatcherQueue?.TryEnqueue(ResetFileSystemWatcherDebounceTimer);
-    }
-
-    private void ResetFileSystemWatcherDebounceTimer()
-    {
-        if (_dispatcherQueue is null)
-        {
-            return;
-        }
-
-        if (_fileSystemWatcherDebounceTimer is null)
-        {
-            _fileSystemWatcherDebounceTimer = _dispatcherQueue.CreateTimer();
-            _fileSystemWatcherDebounceTimer.Interval = TimeSpan.FromMilliseconds(FileSystemWatcherDebounceMs);
-            _fileSystemWatcherDebounceTimer.IsRepeating = false;
-            _fileSystemWatcherDebounceTimer.Tick += OnFileSystemWatcherDebounceTimerTick;
-        }
-
-        _fileSystemWatcherDebounceTimer.Stop();
-        _fileSystemWatcherDebounceTimer.Start();
-    }
-
-    private async void OnFileSystemWatcherDebounceTimerTick(DispatcherQueueTimer sender, object args)
-    {
-        if (_isMoveInProgress || _isCopyInProgress)
-        {
-            return;
-        }
-
-        await RefreshAsync().ConfigureAwait(false);
-    }
-
-    private void OnFileSystemWatcherError(object sender, System.IO.ErrorEventArgs e)
-    {
-        AppLog.Error("FileSystemWatcher error, restarting watcher.", e.GetException());
-
         _dispatcherQueue?.TryEnqueue(async () =>
         {
-            var folderPath = CurrentFolderPath;
-            if (!string.IsNullOrWhiteSpace(folderPath))
+            if (_isMoveInProgress || _isCopyInProgress)
             {
-                StartFolderWatcher(folderPath);
-                await RefreshAsync().ConfigureAwait(false);
+                return;
             }
+
+            await RefreshAsync().ConfigureAwait(false);
         });
-    }
-
-    private async void OnFolderPollingTimerTick(DispatcherQueueTimer sender, object args)
-    {
-        if (_isMoveInProgress || _isCopyInProgress)
-        {
-            return;
-        }
-
-        await RefreshAsync().ConfigureAwait(false);
     }
 
     private void CancelThumbnailGeneration()

--- a/PhotoGeoExplorer/Services/FolderWatcherService.cs
+++ b/PhotoGeoExplorer/Services/FolderWatcherService.cs
@@ -1,0 +1,138 @@
+using System;
+using System.IO;
+using System.Threading;
+using PhotoGeoExplorer.Logging;
+
+namespace PhotoGeoExplorer.Services;
+
+internal sealed class FolderWatcherService : IFolderWatcherService
+{
+    private readonly TimeSpan _debounceInterval;
+    private readonly TimeSpan _pollingInterval;
+
+    private FileSystemWatcher? _watcher;
+    private Timer? _debounceTimer;
+    private Timer? _pollingTimer;
+    private string? _currentFolderPath;
+    private bool _disposed;
+
+    public event EventHandler? FolderChanged;
+
+    public FolderWatcherService(
+        TimeSpan? debounceInterval = null,
+        TimeSpan? pollingInterval = null)
+    {
+        _debounceInterval = debounceInterval ?? TimeSpan.FromMilliseconds(500);
+        _pollingInterval = pollingInterval ?? TimeSpan.FromSeconds(60);
+    }
+
+    public void Watch(string folderPath)
+    {
+        Stop();
+        _currentFolderPath = folderPath;
+
+        var watcherStarted = false;
+        try
+        {
+            var watcher = new FileSystemWatcher(folderPath)
+            {
+                NotifyFilter = NotifyFilters.FileName
+                    | NotifyFilters.DirectoryName
+                    | NotifyFilters.LastWrite,
+                IncludeSubdirectories = false,
+            };
+            watcher.Created += OnFileSystemEvent;
+            watcher.Deleted += OnFileSystemEvent;
+            watcher.Changed += OnFileSystemEvent;
+            watcher.Renamed += OnFileSystemEvent;
+            watcher.Error += OnWatcherError;
+            watcher.EnableRaisingEvents = true;
+            _watcher = watcher;
+            watcherStarted = true;
+            AppLog.Info($"FolderWatcherService: Watching '{folderPath}'");
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or UnauthorizedAccessException)
+        {
+            AppLog.Info($"FolderWatcherService: FileSystemWatcher unavailable for '{folderPath}', falling back to polling. {ex.Message}");
+        }
+
+        if (!watcherStarted)
+        {
+            _pollingTimer = new Timer(
+                _ => RaiseFolderChanged(),
+                null,
+                _pollingInterval,
+                _pollingInterval);
+        }
+    }
+
+    public void Stop()
+    {
+        if (_watcher is not null)
+        {
+            _watcher.EnableRaisingEvents = false;
+            _watcher.Created -= OnFileSystemEvent;
+            _watcher.Deleted -= OnFileSystemEvent;
+            _watcher.Changed -= OnFileSystemEvent;
+            _watcher.Renamed -= OnFileSystemEvent;
+            _watcher.Error -= OnWatcherError;
+            _watcher.Dispose();
+            _watcher = null;
+        }
+
+        _debounceTimer?.Dispose();
+        _debounceTimer = null;
+
+        _pollingTimer?.Dispose();
+        _pollingTimer = null;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        Stop();
+    }
+
+    private void OnFileSystemEvent(object sender, FileSystemEventArgs e)
+    {
+        ResetDebounceTimer();
+    }
+
+    private void ResetDebounceTimer()
+    {
+        if (_debounceTimer is null)
+        {
+            _debounceTimer = new Timer(
+                _ => RaiseFolderChanged(),
+                null,
+                _debounceInterval,
+                Timeout.InfiniteTimeSpan);
+        }
+        else
+        {
+            _debounceTimer.Change(_debounceInterval, Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    private void OnWatcherError(object sender, ErrorEventArgs e)
+    {
+        AppLog.Error("FolderWatcherService: FileSystemWatcher error, restarting watcher.", e.GetException());
+
+        var folderPath = _currentFolderPath;
+        if (!string.IsNullOrWhiteSpace(folderPath))
+        {
+            Watch(folderPath);
+            RaiseFolderChanged();
+        }
+    }
+
+    private void RaiseFolderChanged()
+    {
+        FolderChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/PhotoGeoExplorer/Services/FolderWatcherService.cs
+++ b/PhotoGeoExplorer/Services/FolderWatcherService.cs
@@ -132,6 +132,12 @@ internal sealed class FolderWatcherService : IFolderWatcherService
 
     private void OnWatcherError(object sender, ErrorEventArgs e)
     {
+        // フォルダ切り替え中に古い watcher のエラーが遅延発火した場合は無視する
+        if (!ReferenceEquals(sender, _watcher))
+        {
+            return;
+        }
+
         AppLog.Error("FolderWatcherService: FileSystemWatcher error, restarting watcher.", e.GetException());
 
         var folderPath = _currentFolderPath;

--- a/PhotoGeoExplorer/Services/FolderWatcherService.cs
+++ b/PhotoGeoExplorer/Services/FolderWatcherService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Threading;
-using PhotoGeoExplorer.Logging;
 
 namespace PhotoGeoExplorer.Services;
 

--- a/PhotoGeoExplorer/Services/FolderWatcherService.cs
+++ b/PhotoGeoExplorer/Services/FolderWatcherService.cs
@@ -9,6 +9,7 @@ internal sealed class FolderWatcherService : IFolderWatcherService
     private readonly TimeSpan _debounceInterval;
     private readonly TimeSpan _pollingInterval;
 
+    private readonly object _timerLock = new();
     private FileSystemWatcher? _watcher;
     private Timer? _debounceTimer;
     private Timer? _pollingTimer;
@@ -79,8 +80,11 @@ internal sealed class FolderWatcherService : IFolderWatcherService
             _watcher = null;
         }
 
-        _debounceTimer?.Dispose();
-        _debounceTimer = null;
+        lock (_timerLock)
+        {
+            _debounceTimer?.Dispose();
+            _debounceTimer = null;
+        }
 
         _pollingTimer?.Dispose();
         _pollingTimer = null;
@@ -104,17 +108,25 @@ internal sealed class FolderWatcherService : IFolderWatcherService
 
     private void ResetDebounceTimer()
     {
-        if (_debounceTimer is null)
+        lock (_timerLock)
         {
-            _debounceTimer = new Timer(
-                _ => RaiseFolderChanged(),
-                null,
-                _debounceInterval,
-                Timeout.InfiniteTimeSpan);
-        }
-        else
-        {
-            _debounceTimer.Change(_debounceInterval, Timeout.InfiniteTimeSpan);
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (_debounceTimer is null)
+            {
+                _debounceTimer = new Timer(
+                    _ => RaiseFolderChanged(),
+                    null,
+                    _debounceInterval,
+                    Timeout.InfiniteTimeSpan);
+            }
+            else
+            {
+                _debounceTimer.Change(_debounceInterval, Timeout.InfiniteTimeSpan);
+            }
         }
     }
 
@@ -132,6 +144,11 @@ internal sealed class FolderWatcherService : IFolderWatcherService
 
     private void RaiseFolderChanged()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         FolderChanged?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/PhotoGeoExplorer/Services/IFolderWatcherService.cs
+++ b/PhotoGeoExplorer/Services/IFolderWatcherService.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace PhotoGeoExplorer.Services;
+
+internal interface IFolderWatcherService : IDisposable
+{
+    event EventHandler? FolderChanged;
+
+    void Watch(string folderPath);
+
+    void Stop();
+}


### PR DESCRIPTION
## 概要

- `IFolderWatcherService` インターフェースと `FolderWatcherService` 実装を新規作成
- `FileBrowserPaneViewModel` から `System.IO.FileSystemWatcher` 直接生成・管理を排除
- デバウンスを `DispatcherQueueTimer`（WinUI 依存）から `System.Threading.Timer` に変更
- ViewModel はイベント購読のみ行い、UI スレッドへのマーシャリングは `_dispatcherQueue.TryEnqueue` で吸収

## 変更理由

PR #131 の Codex レビュー（P1）および `AGENTS.md` のガイドライン（ViewModel に `System.IO` 直接アクセス不可）への対応。

## 主な変更点

| ファイル | 変更内容 |
|---------|---------|
| `Services/IFolderWatcherService.cs` | 新規作成 |
| `Services/FolderWatcherService.cs` | 新規作成（FSW + ポーリング + デバウンス） |
| `FileBrowserPaneViewModel.cs` | 旧 watcher 関連 ~90 行削除、service DI 追加 |
| `FolderWatcherServiceTests.cs` | 新規作成（6 テスト） |
| `CHANGELOG.md` | Unreleased セクションに追記 |

## テスト

```
- FolderWatcherServiceTests.Watch_FileCreated_RaisesFolderChanged
- FolderWatcherServiceTests.Watch_FileDeleted_RaisesFolderChanged
- FolderWatcherServiceTests.Watch_BurstyEvents_DebouncesToSingleNotification
- FolderWatcherServiceTests.Stop_AfterWatch_NoFurtherNotifications
- FolderWatcherServiceTests.Dispose_StopsWatching
- FolderWatcherServiceTests.Watch_PollingFallback_RaisesFolderChangedPeriodically
- FolderWatcherServiceTests.Watch_CalledTwice_WatchesLatestFolder
```

Closes #132