### PR TITLE
chore(release): v1.8.4 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [1.8.4] - 2026-05-28
+
 ### リファクタリング
 - `FileSystemWatcher` 監視ロジックを `FileBrowserPaneViewModel` から `FolderWatcherService` へ移動 (#132)
   - `IFolderWatcherService` インターフェースを導入し、ViewModel の `System.IO` 直接依存を排除

--- a/PhotoGeoExplorer/Assets/propose/listingData-9P0WNR54441B-1152921505701101354.csv
+++ b/PhotoGeoExplorer/Assets/propose/listingData-9P0WNR54441B-1152921505701101354.csv
@@ -4,7 +4,17 @@ This app requires the .NET Desktop Runtime to run. It is automatically provided 
 It targets Windows 10/11 and renders maps using WinUI 3 and Mapsui.","PhotoGeoExplorer は、GPS 情報（ジオタグ）を含む写真を地図上に表示し、撮影場所から写真を整理・探索できる Windows デスクトップアプリです。
 このアプリを実行するには .NET Desktop Runtime が必要です。Microsoft Store からのインストール時に自動的に提供されます。
 Windows 10/11 を対象とし、WinUI 3 と Mapsui で地図を描画します。"
-ReleaseNotes,3,テキスト,,"Release Notes (v1.8.4)&#x0D;&#x0A;- Refactored: FileSystemWatcher logic moved to FolderWatcherService for better testability and WinUI independence&#x0D;&#x0A;- Added: Auto-refresh file list when external apps add/remove/rename files (500ms debounce; polling fallback for network drives)&#x0D;&#x0A;- Fixed: File list not updating after skipping a move/copy conflict&#x0D;&#x0A;- Fixed: Partner Center submission script errors under Set-StrictMode -Version Latest&#x0D;&#x0A;- Fixed: release.yml generating duplicate release notes on re-runs","リリースノート（v1.8.4）&#x0D;&#x0A;- リファクタリング: FileSystemWatcher 監視ロジックを FolderWatcherService へ移動。テスタビリティ向上と WinUI 非依存化。&#x0D;&#x0A;- 追加: 外部アプリがフォルダ内ファイルを追加・削除・リネームした際に自動でリスト更新（500ms デバウンス、ネットワークドライブはポーリングにフォールバック）&#x0D;&#x0A;- 修正: 移動/コピーの競合でスキップした際にファイル一覧が更新されない問題&#x0D;&#x0A;- 修正: Set-StrictMode -Version Latest 環境での Partner Center 提出スクリプトエラー&#x0D;&#x0A;- 修正: release.yml の再実行時にリリースノートが重複する問題"
+ReleaseNotes,3,テキスト,,"Release Notes (v1.8.4)
+- Refactored: FileSystemWatcher logic moved to FolderWatcherService for better testability and WinUI independence
+- Added: Auto-refresh file list when external apps add/remove/rename files (500ms debounce; polling fallback for network drives)
+- Fixed: File list not updating after skipping a move/copy conflict
+- Fixed: Partner Center submission script errors under Set-StrictMode -Version Latest
+- Fixed: release.yml generating duplicate release notes on re-runs","リリースノート（v1.8.4）
+- リファクタリング: FileSystemWatcher 監視ロジックを FolderWatcherService へ移動。テスタビリティ向上と WinUI 非依存化。
+- 追加: 外部アプリがフォルダ内ファイルを追加・削除・リネームした際に自動でリスト更新（500ms デバウンス、ネットワークドライブはポーリングにフォールバック）
+- 修正: 移動/コピーの競合でスキップした際にファイル一覧が更新されない問題
+- 修正: Set-StrictMode -Version Latest 環境での Partner Center 提出スクリプトエラー
+- 修正: release.yml の再実行時にリリースノートが重複する問題"
 Title,4,テキスト,,PhotoGeoExplorer,PhotoGeoExplorer
 ShortTitle,5,テキスト,,Explore Photos on a Map,写真を地図で整理・探索
 SortTitle,6,テキスト,,,

--- a/PhotoGeoExplorer/Assets/propose/listingData-9P0WNR54441B-1152921505701101354.csv
+++ b/PhotoGeoExplorer/Assets/propose/listingData-9P0WNR54441B-1152921505701101354.csv
@@ -4,11 +4,7 @@ This app requires the .NET Desktop Runtime to run. It is automatically provided 
 It targets Windows 10/11 and renders maps using WinUI 3 and Mapsui.","PhotoGeoExplorer は、GPS 情報（ジオタグ）を含む写真を地図上に表示し、撮影場所から写真を整理・探索できる Windows デスクトップアプリです。
 このアプリを実行するには .NET Desktop Runtime が必要です。Microsoft Store からのインストール時に自動的に提供されます。
 Windows 10/11 を対象とし、WinUI 3 と Mapsui で地図を描画します。"
-ReleaseNotes,3,テキスト,,"Release Notes (v1.8.3)
-- Added: Crash report submit dialog — tap ""Report"" on the crash banner to open a dialog; choose ""Report on GitHub"" to open a pre-filled Issue, or ""Report by Email"" to copy the log to clipboard and open the default mail app
-- Added: CI-integrated Partner Center submission — MSIX is now automatically submitted to the Store on tag push","リリースノート（v1.8.3）
-- 追加: クラッシュレポート送信ダイアログ — クラッシュバナーの「報告する」からダイアログを表示。「GitHub で報告する」でログ埋め込み済み Issue 作成ページを開く。「メールで報告する」でログをクリップボードにコピーし標準メールアプリを起動。
-- 追加: CI からの Partner Center 自動提出 — タグプッシュ時に MSIX を Store へ自動提出"
+ReleaseNotes,3,テキスト,,"Release Notes (v1.8.4)&#x0D;&#x0A;- Refactored: FileSystemWatcher logic moved to FolderWatcherService for better testability and WinUI independence&#x0D;&#x0A;- Added: Auto-refresh file list when external apps add/remove/rename files (500ms debounce; polling fallback for network drives)&#x0D;&#x0A;- Fixed: File list not updating after skipping a move/copy conflict&#x0D;&#x0A;- Fixed: Partner Center submission script errors under Set-StrictMode -Version Latest&#x0D;&#x0A;- Fixed: release.yml generating duplicate release notes on re-runs","リリースノート（v1.8.4）&#x0D;&#x0A;- リファクタリング: FileSystemWatcher 監視ロジックを FolderWatcherService へ移動。テスタビリティ向上と WinUI 非依存化。&#x0D;&#x0A;- 追加: 外部アプリがフォルダ内ファイルを追加・削除・リネームした際に自動でリスト更新（500ms デバウンス、ネットワークドライブはポーリングにフォールバック）&#x0D;&#x0A;- 修正: 移動/コピーの競合でスキップした際にファイル一覧が更新されない問題&#x0D;&#x0A;- 修正: Set-StrictMode -Version Latest 環境での Partner Center 提出スクリプトエラー&#x0D;&#x0A;- 修正: release.yml の再実行時にリリースノートが重複する問題"
 Title,4,テキスト,,PhotoGeoExplorer,PhotoGeoExplorer
 ShortTitle,5,テキスト,,Explore Photos on a Map,写真を地図で整理・探索
 SortTitle,6,テキスト,,,

--- a/PhotoGeoExplorer/Package.appxmanifest
+++ b/PhotoGeoExplorer/Package.appxmanifest
@@ -5,7 +5,7 @@
   xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap uap10 rescap">
-  <Identity Name="scottlz0310.PhotoGeoExplorer" Publisher="CN=39FB3D39-1F1A-4B82-B081-47469FD12CA6" Version="1.8.3.0" />
+  <Identity Name="scottlz0310.PhotoGeoExplorer" Publisher="CN=39FB3D39-1F1A-4B82-B081-47469FD12CA6" Version="1.8.4.0" />
   <Properties>
     <DisplayName>PhotoGeoExplorer</DisplayName>
     <PublisherDisplayName>scottlz0310</PublisherDisplayName>

--- a/PhotoGeoExplorer/PhotoGeoExplorer.csproj
+++ b/PhotoGeoExplorer/PhotoGeoExplorer.csproj
@@ -9,10 +9,10 @@
     <WindowsPackageType Condition="'$(WindowsPackageType)'==''">None</WindowsPackageType>
     <Platforms>x64;ARM64</Platforms>
     <RootNamespace>PhotoGeoExplorer</RootNamespace>
-    <Version>1.8.3</Version>
-    <AssemblyVersion>1.8.3.0</AssemblyVersion>
-    <FileVersion>1.8.3.0</FileVersion>
-    <InformationalVersion>1.8.3</InformationalVersion>
+    <Version>1.8.4</Version>
+    <AssemblyVersion>1.8.4.0</AssemblyVersion>
+    <FileVersion>1.8.4.0</FileVersion>
+    <InformationalVersion>1.8.4</InformationalVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <WindowsSdkPackageVersion>10.0.26100.81</WindowsSdkPackageVersion>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>

--- a/docs/MicrosoftStore.md
+++ b/docs/MicrosoftStore.md
@@ -75,8 +75,8 @@ Partner Center から現在の情報をエクスポートし、修正してイ�
 ### 公開状況
 
 - 公開済み: https://apps.microsoft.com/detail/9P0WNR54441B
-- 公開バージョン: v1.8.0
-- 次回リリース: -
+- 公開バージョン: v1.8.3
+- 次回リリース: v1.8.4
 - Store ID: 9P0WNR54441B
 
 ### Partner Center 設定


### PR DESCRIPTION
## 概要

v1.8.4 パッチリリースに向けたバージョン更新・ドキュメント整合作業。

## 変更内容

- `PhotoGeoExplorer.csproj` / `Package.appxmanifest`: バージョンを `1.8.3` → `1.8.4` に更新
- `CHANGELOG.md`: `[Unreleased]` セクションを `[1.8.4] - 2026-05-28` に確定
- `listingData.csv`: `ReleaseNotes` を v1.8.4 内容（英語・日本語）に更新
- `docs/MicrosoftStore.md`: 公開バージョン・次回リリース欄を更新

## マージ後の作業

- [ ] `v1.8.4` タグを作成・push → CI が MSIX Bundle を自動ビルド
- [ ] `.\scripts\DevInstall.ps1` でローカルインストール → `.\scripts\RunWackTests.ps1` で WACK 実行
- [ ] `docs/WACK-TestResults.md` に結果を追記
- [ ] Partner Center への自動提出を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)