### PR TITLE
fix(filebrowser): 移動・コピー完了時の RPC_E_WRONG_THREAD クラッシュを修正 (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+### 修正
+- ファイル移動・コピー操作完了時に `RPC_E_WRONG_THREAD (0x8001010E)` でクラッシュする問題を修正 (#137)
+  - `ExecuteMoveItemsToFolderAsync` / `ExecuteCopyItemsToFolderAsync` の `finally` ブロックが `ConfigureAwait(false)` によりバックグラウンドスレッドで実行され、`IsMoveInProgress` / `IsCopyInProgress` の `PropertyChanged` が UI スレッド外から発火していた
+  - UI 状態の更新（プロパティ変更・`RaiseCanExecuteChanged`）を `RunOnUIThreadAsync` でラップし、UI スレッドへ marshal するよう修正
+
 ## [1.8.4] - 2026-05-28
 
 ### リファクタリング

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -732,15 +732,16 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         }
         finally
         {
-            StopMoveProgressTimer();
-            _moveCts.Dispose();
-            _moveCts = null;
-            // ConfigureAwait(false) により finally はバックグラウンドスレッドで実行されるため、
-            // PropertyChanged を発火するプロパティ更新は UI スレッドへ marshal する（#137）。
+            // ConfigureAwait(false) により finally はバックグラウンドスレッドで実行される。
+            // DispatcherQueueTimer.Stop()、PropertyChanged 発火、CTS の Dispose/null 化は
+            // すべて UI スレッドで行い、CancelMoveCommand との race を防ぐ（#137）。
             await RunOnUIThreadAsync(() =>
             {
+                StopMoveProgressTimer();
                 IsMoveInProgress = false;
                 ((RelayCommand)CancelMoveCommand).RaiseCanExecuteChanged();
+                _moveCts?.Dispose();
+                _moveCts = null;
             }).ConfigureAwait(false);
         }
 
@@ -820,15 +821,16 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         }
         finally
         {
-            StopCopyProgressTimer();
-            _copyCts.Dispose();
-            _copyCts = null;
-            // ConfigureAwait(false) により finally はバックグラウンドスレッドで実行されるため、
-            // PropertyChanged を発火するプロパティ更新は UI スレッドへ marshal する（#137 と同様）。
+            // ConfigureAwait(false) により finally はバックグラウンドスレッドで実行される。
+            // DispatcherQueueTimer.Stop()、PropertyChanged 発火、CTS の Dispose/null 化は
+            // すべて UI スレッドで行い、CancelCopyCommand との race を防ぐ（#137）。
             await RunOnUIThreadAsync(() =>
             {
+                StopCopyProgressTimer();
                 IsCopyInProgress = false;
                 ((RelayCommand)CancelCopyCommand).RaiseCanExecuteChanged();
+                _copyCts?.Dispose();
+                _copyCts = null;
             }).ConfigureAwait(false);
         }
 

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -733,10 +733,15 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         finally
         {
             StopMoveProgressTimer();
-            IsMoveInProgress = false;
-            ((RelayCommand)CancelMoveCommand).RaiseCanExecuteChanged();
             _moveCts.Dispose();
             _moveCts = null;
+            // ConfigureAwait(false) により finally はバックグラウンドスレッドで実行されるため、
+            // PropertyChanged を発火するプロパティ更新は UI スレッドへ marshal する（#137）。
+            await RunOnUIThreadAsync(() =>
+            {
+                IsMoveInProgress = false;
+                ((RelayCommand)CancelMoveCommand).RaiseCanExecuteChanged();
+            }).ConfigureAwait(false);
         }
 
         if (result.SuccessCount > 0 || result.SkipCount > 0)
@@ -816,10 +821,15 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         finally
         {
             StopCopyProgressTimer();
-            IsCopyInProgress = false;
-            ((RelayCommand)CancelCopyCommand).RaiseCanExecuteChanged();
             _copyCts.Dispose();
             _copyCts = null;
+            // ConfigureAwait(false) により finally はバックグラウンドスレッドで実行されるため、
+            // PropertyChanged を発火するプロパティ更新は UI スレッドへ marshal する（#137 と同様）。
+            await RunOnUIThreadAsync(() =>
+            {
+                IsCopyInProgress = false;
+                ((RelayCommand)CancelCopyCommand).RaiseCanExecuteChanged();
+            }).ConfigureAwait(false);
         }
 
         if (result.SuccessCount > 0 || result.SkipCount > 0)


### PR DESCRIPTION
## 概要

- ファイル移動・コピー操作完了時に `System.Runtime.InteropServices.COMException (0x8001010E)` でクラッシュする問題を修正

## 原因

`ExecuteMoveItemsToFolderAsync` / `ExecuteCopyItemsToFolderAsync` で `await Task.Run(...).ConfigureAwait(false)` を使用しているため、`finally` ブロックがバックグラウンドスレッドで実行される。このスレッドから `IsMoveInProgress = false` が呼ばれると `PropertyChanged` イベントが UI スレッド外から発火し、WinUI 3 の COM マーシャリングが `RPC_E_WRONG_THREAD` を返してクラッシュしていた。

## 修正内容

`finally` ブロック内の UI 状態更新（`IsMoveInProgress` / `IsCopyInProgress` プロパティ変更および `RaiseCanExecuteChanged`）を `RunOnUIThreadAsync` でラップし、UI スレッドへ marshal するよう修正した。

**変更ファイル**: `PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs`（2箇所）

## 検証

- `dotnet build` → 警告 0、エラー 0
- `dotnet test` → 503件合格、0件失敗

## 関連

Closes #137