### PR TITLE
fix: メタデータ解析の部分失敗をgraceful degradationで処理

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### 改善
+- メタデータ解析の部分失敗をgraceful degradationで処理し、アプリのクラッシュを防止 (#144)
+  - `ExifService.ReadMetadata` のタグ取得処理全体を `MetadataException` でラップ。将来 `Get*` 系タグが追加された場合も自動的に保護される
+  - `MapPaneService.LoadMetadataForItemAsync` に汎用例外キャッチを追加。想定外の例外が発生しても該当ファイルをスキップしてアプリ動作を継続する
+  - `OnUnobservedTaskException` で `WriteCrashLog` を呼ぶよう修正。観測されない Task 例外も次回起動時のクラッシュ報告フローに乗るようになった
+
 ### 修正
 - `Date/Time Original` タグを持たない写真を読み込むと `MetadataExtractor.MetadataException` でクラッシュする問題を修正 (#142)
   - `ExifSubIfdDirectory` は存在するが撮影日時タグがない JPEG（GPS タグのみ付与された写真等）を開いた際に発生

--- a/PhotoGeoExplorer.Core/Services/ExifService.cs
+++ b/PhotoGeoExplorer.Core/Services/ExifService.cs
@@ -85,51 +85,59 @@ internal static class ExifService
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        var gpsDirectory = directories.OfType<GpsDirectory>().FirstOrDefault();
-        GeoLocation? location = null;
-        if (gpsDirectory is not null && gpsDirectory.TryGetGeoLocation(out var geoLocation))
+        try
         {
-            location = geoLocation;
+            var gpsDirectory = directories.OfType<GpsDirectory>().FirstOrDefault();
+            GeoLocation? location = null;
+            if (gpsDirectory is not null && gpsDirectory.TryGetGeoLocation(out var geoLocation))
+            {
+                location = geoLocation;
+            }
+
+            double? latitude = location?.Latitude;
+            double? longitude = location?.Longitude;
+
+            var exifIfd0 = directories.OfType<ExifIfd0Directory>().FirstOrDefault();
+            var cameraMake = exifIfd0?.GetString(ExifDirectoryBase.TagMake);
+            var cameraModel = exifIfd0?.GetString(ExifDirectoryBase.TagModel);
+
+            var subIfd = directories.OfType<ExifSubIfdDirectory>().FirstOrDefault();
+            DateTime? dateTime = null;
+            if (subIfd is not null)
+            {
+                if (subIfd.TryGetDateTime(ExifDirectoryBase.TagDateTimeOriginal, out var dt))
+                    dateTime = dt;
+                else if (subIfd.TryGetDateTime(ExifDirectoryBase.TagDateTimeDigitized, out dt))
+                    dateTime = dt;
+            }
+
+            if (dateTime is null)
+            {
+                var fileMeta = directories.OfType<FileMetadataDirectory>().FirstOrDefault();
+                if (fileMeta is not null && fileMeta.TryGetDateTime(FileMetadataDirectory.TagFileModifiedDate, out var dt))
+                    dateTime = dt;
+            }
+
+            DateTimeOffset? takenAt = null;
+            if (dateTime.HasValue)
+            {
+                var localTime = DateTime.SpecifyKind(dateTime.Value, DateTimeKind.Local);
+                takenAt = new DateTimeOffset(localTime);
+            }
+
+            return new PhotoMetadata(
+                takenAt,
+                cameraMake,
+                cameraModel,
+                latitude,
+                longitude,
+                hasGpsData: gpsDirectory is not null);
         }
-
-        double? latitude = location?.Latitude;
-        double? longitude = location?.Longitude;
-
-        var exifIfd0 = directories.OfType<ExifIfd0Directory>().FirstOrDefault();
-        var cameraMake = exifIfd0?.GetString(ExifDirectoryBase.TagMake);
-        var cameraModel = exifIfd0?.GetString(ExifDirectoryBase.TagModel);
-
-        var subIfd = directories.OfType<ExifSubIfdDirectory>().FirstOrDefault();
-        DateTime? dateTime = null;
-        if (subIfd is not null)
+        catch (MetadataExtractor.MetadataException ex)
         {
-            if (subIfd.TryGetDateTime(ExifDirectoryBase.TagDateTimeOriginal, out var dt))
-                dateTime = dt;
-            else if (subIfd.TryGetDateTime(ExifDirectoryBase.TagDateTimeDigitized, out dt))
-                dateTime = dt;
+            AppLog.Error($"Partial metadata read failure: {filePath}", ex);
+            return null;
         }
-
-        if (dateTime is null)
-        {
-            var fileMeta = directories.OfType<FileMetadataDirectory>().FirstOrDefault();
-            if (fileMeta is not null && fileMeta.TryGetDateTime(FileMetadataDirectory.TagFileModifiedDate, out var dt))
-                dateTime = dt;
-        }
-
-        DateTimeOffset? takenAt = null;
-        if (dateTime.HasValue)
-        {
-            var localTime = DateTime.SpecifyKind(dateTime.Value, DateTimeKind.Local);
-            takenAt = new DateTimeOffset(localTime);
-        }
-
-        return new PhotoMetadata(
-            takenAt,
-            cameraMake,
-            cameraModel,
-            latitude,
-            longitude,
-            hasGpsData: gpsDirectory is not null);
     }
 
     private static bool WriteMetadata(

--- a/PhotoGeoExplorer.Tests/CrashReportServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/CrashReportServiceTests.cs
@@ -196,6 +196,41 @@ public sealed class CrashReportServiceTests : IDisposable
     }
 
     [Fact]
+    public void RecordNormalExit_AfterWriteCrashLog_PreservesLockForNextStartup()
+    {
+        // MapPaneService 等が WriteCrashLog を呼んだ後に正常終了しても
+        // running.lock が残り、次回起動時のバナーが表示されることを保証する
+        var service = new CrashReportService(_tempDir);
+        service.RecordStartup();
+        var lockPath = Path.Combine(_tempDir, "running.lock");
+        Assert.True(File.Exists(lockPath));
+
+        service.WriteCrashLog(new InvalidOperationException("unexpected error in service layer"));
+        service.RecordNormalExit(); // 正常終了パスが実行されてもロックは残るべき
+
+        Assert.True(File.Exists(lockPath));
+
+        // 次回起動時
+        var nextService = new CrashReportService(_tempDir);
+        nextService.RecordStartup();
+        Assert.True(nextService.PreviouslyTerminatedAbnormally);
+    }
+
+    [Fact]
+    public void RecordNormalExit_WithoutWriteCrashLog_DeletesLock()
+    {
+        // クラッシュログがない場合は従来どおりロックを削除する
+        var service = new CrashReportService(_tempDir);
+        service.RecordStartup();
+        var lockPath = Path.Combine(_tempDir, "running.lock");
+        Assert.True(File.Exists(lockPath));
+
+        service.RecordNormalExit();
+
+        Assert.False(File.Exists(lockPath));
+    }
+
+    [Fact]
     public void GetLatestCrashLogContent_ReturnsNull_WhenFileIsLocked()
     {
         var service = new CrashReportService(_tempDir);

--- a/PhotoGeoExplorer.Tests/CrashReportServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/CrashReportServiceTests.cs
@@ -196,24 +196,44 @@ public sealed class CrashReportServiceTests : IDisposable
     }
 
     [Fact]
-    public void RecordNormalExit_AfterWriteCrashLog_PreservesLockForNextStartup()
+    public void RecordNormalExit_AfterWriteCrashLog_SameInstance_PreservesLockForNextStartup()
     {
-        // MapPaneService 等が WriteCrashLog を呼んだ後に正常終了しても
-        // running.lock が残り、次回起動時のバナーが表示されることを保証する
+        // 同一インスタンスで WriteCrashLog → RecordNormalExit → 次回起動のライフサイクルを保証する
         var service = new CrashReportService(_tempDir);
         service.RecordStartup();
         var lockPath = Path.Combine(_tempDir, "running.lock");
         Assert.True(File.Exists(lockPath));
 
-        service.WriteCrashLog(new InvalidOperationException("unexpected error in service layer"));
-        service.RecordNormalExit(); // 正常終了パスが実行されてもロックは残るべき
+        service.WriteCrashLog(new InvalidOperationException("unexpected error"));
+        service.RecordNormalExit();
 
         Assert.True(File.Exists(lockPath));
 
-        // 次回起動時
         var nextService = new CrashReportService(_tempDir);
         nextService.RecordStartup();
         Assert.True(nextService.PreviouslyTerminatedAbnormally);
+    }
+
+    [Fact]
+    public void RecordNormalExit_WhenSeparateInstanceWroteCrashLog_PreservesLockForNextStartup()
+    {
+        // MapPaneService が生成する別インスタンスで WriteCrashLog を呼び、
+        // App インスタンスの RecordNormalExit で running.lock が残ることを保証する
+        var appInstance = new CrashReportService(_tempDir);
+        appInstance.RecordStartup();
+        var lockPath = Path.Combine(_tempDir, "running.lock");
+        Assert.True(File.Exists(lockPath));
+
+        var serviceLayerInstance = new CrashReportService(_tempDir);
+        serviceLayerInstance.WriteCrashLog(new InvalidOperationException("service layer crash"));
+
+        appInstance.RecordNormalExit();
+
+        Assert.True(File.Exists(lockPath));
+
+        var nextInstance = new CrashReportService(_tempDir);
+        nextInstance.RecordStartup();
+        Assert.True(nextInstance.PreviouslyTerminatedAbnormally);
     }
 
     [Fact]

--- a/PhotoGeoExplorer.Tests/MapPaneServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/MapPaneServiceTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using PhotoGeoExplorer.Models;
 using PhotoGeoExplorer.Panes.Map;
+using PhotoGeoExplorer.Services;
 using Xunit;
 
 namespace PhotoGeoExplorer.Tests;
@@ -224,6 +225,60 @@ public class MapPaneServiceTests
         Assert.EndsWith("red_pin.png", path, StringComparison.OrdinalIgnoreCase);
     }
 
+    // =========================================================
+    // ICrashReportService DI / ライフサイクル
+    // =========================================================
+
+    [Fact]
+    public void Constructor_WithCrashReportService_DoesNotThrow()
+    {
+        var cacheRoot = CreateTempCacheRoot();
+        try
+        {
+            var fakeCrashReporter = new FakeCrashReportService();
+            var ex = Record.Exception(() => new MapPaneService(cacheRoot, fakeCrashReporter));
+            Assert.Null(ex);
+        }
+        finally
+        {
+            DeleteTempCacheRoot(cacheRoot);
+        }
+    }
+
+    [Fact]
+    public void Constructor_WithNullCrashReportService_ThrowsArgumentNullException()
+    {
+        var cacheRoot = CreateTempCacheRoot();
+        try
+        {
+            Assert.Throws<ArgumentNullException>(() => new MapPaneService(cacheRoot, null!));
+        }
+        finally
+        {
+            DeleteTempCacheRoot(cacheRoot);
+        }
+    }
+
+    [Fact]
+    public async Task LoadPhotoMetadataAsync_EmptyItems_DoesNotCallWriteCrashLog()
+    {
+        var cacheRoot = CreateTempCacheRoot();
+        try
+        {
+            var fakeCrashReporter = new FakeCrashReportService();
+            var service = new MapPaneService(cacheRoot, fakeCrashReporter);
+            var items = Array.Empty<PhotoGeoExplorer.ViewModels.PhotoListItem>();
+
+            await service.LoadPhotoMetadataAsync(items, CancellationToken.None).ConfigureAwait(true);
+
+            Assert.Equal(0, fakeCrashReporter.WriteCallCount);
+        }
+        finally
+        {
+            DeleteTempCacheRoot(cacheRoot);
+        }
+    }
+
     private static string CreateTempCacheRoot()
     {
         var path = Path.Combine(Path.GetTempPath(), "PhotoGeoExplorer.Tests", Guid.NewGuid().ToString("N"));
@@ -237,5 +292,17 @@ public class MapPaneServiceTests
         {
             Directory.Delete(path, recursive: true);
         }
+    }
+
+    private sealed class FakeCrashReportService : ICrashReportService
+    {
+        public bool PreviouslyTerminatedAbnormally => false;
+        public string CrashReportsDirectoryPath => string.Empty;
+        public int WriteCallCount { get; private set; }
+
+        public void RecordStartup() { }
+        public void RecordNormalExit() { }
+        public void WriteCrashLog(Exception? exception) => WriteCallCount++;
+        public string? GetLatestCrashLogContent() => null;
     }
 }

--- a/PhotoGeoExplorer/App.xaml.cs
+++ b/PhotoGeoExplorer/App.xaml.cs
@@ -130,6 +130,7 @@ public partial class App : Application
     {
         var exceptionInfo = $"Type: {e.Exception?.GetType().FullName ?? "Unknown"}, InnerExceptions: {e.Exception?.InnerExceptions.Count ?? 0}";
         AppLog.Error($"Unobserved task exception. {exceptionInfo}", e.Exception);
+        _crashDetected = true;
         CrashReporter.WriteCrashLog(e.Exception);
     }
 

--- a/PhotoGeoExplorer/App.xaml.cs
+++ b/PhotoGeoExplorer/App.xaml.cs
@@ -130,6 +130,7 @@ public partial class App : Application
     {
         var exceptionInfo = $"Type: {e.Exception?.GetType().FullName ?? "Unknown"}, InnerExceptions: {e.Exception?.InnerExceptions.Count ?? 0}";
         AppLog.Error($"Unobserved task exception. {exceptionInfo}", e.Exception);
+        CrashReporter.WriteCrashLog(e.Exception);
     }
 
     private void OnProcessExit(object? sender, EventArgs e)

--- a/PhotoGeoExplorer/Panes/Map/MapPaneService.cs
+++ b/PhotoGeoExplorer/Panes/Map/MapPaneService.cs
@@ -178,6 +178,14 @@ internal sealed class MapPaneService : IMapPaneService
             AppLog.Error($"Failed to load metadata for {item.Item.FilePath}", ex);
             return (item, null);
         }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex)
+        {
+            // MetadataExtractor 等、想定外の例外でクラッシュする代わりに当該ファイルをスキップする
+            AppLog.Error($"Unexpected exception loading metadata for {item.Item.FilePath}", ex);
+            return (item, null);
+        }
+#pragma warning restore CA1031
         finally
         {
             if (acquired)

--- a/PhotoGeoExplorer/Panes/Map/MapPaneService.cs
+++ b/PhotoGeoExplorer/Panes/Map/MapPaneService.cs
@@ -21,13 +21,19 @@ internal sealed class MapPaneService : IMapPaneService
 {
     private const int MetadataLoadMaxConcurrency = 4;
     private readonly string _tileCacheRootDirectory;
+    private readonly ICrashReportService _crashReportService;
 
     public MapPaneService()
-        : this(GetDefaultTileCacheRootDirectory())
+        : this(GetDefaultTileCacheRootDirectory(), new CrashReportService())
     {
     }
 
     internal MapPaneService(string tileCacheRootDirectory)
+        : this(tileCacheRootDirectory, new CrashReportService())
+    {
+    }
+
+    internal MapPaneService(string tileCacheRootDirectory, ICrashReportService crashReportService)
     {
         if (string.IsNullOrWhiteSpace(tileCacheRootDirectory))
         {
@@ -35,6 +41,7 @@ internal sealed class MapPaneService : IMapPaneService
         }
 
         _tileCacheRootDirectory = tileCacheRootDirectory;
+        _crashReportService = crashReportService ?? throw new ArgumentNullException(nameof(crashReportService));
     }
 
     /// <inheritdoc/>
@@ -150,7 +157,7 @@ internal sealed class MapPaneService : IMapPaneService
         }
     }
 
-    private static async Task<(PhotoListItem Item, PhotoMetadata? Metadata)> LoadMetadataForItemAsync(
+    private async Task<(PhotoListItem Item, PhotoMetadata? Metadata)> LoadMetadataForItemAsync(
         PhotoListItem item,
         SemaphoreSlim semaphore,
         CancellationToken cancellationToken)
@@ -181,8 +188,10 @@ internal sealed class MapPaneService : IMapPaneService
 #pragma warning disable CA1031 // Do not catch general exception types
         catch (Exception ex)
         {
-            // MetadataExtractor 等、想定外の例外でクラッシュする代わりに当該ファイルをスキップする
+            // MetadataExtractor 等、想定外の例外でクラッシュする代わりに当該ファイルをスキップする。
+            // WriteCrashLog で running.lock を維持し、次回起動時の報告フローへ情報を引き渡す。
             AppLog.Error($"Unexpected exception loading metadata for {item.Item.FilePath}", ex);
+            _crashReportService.WriteCrashLog(ex);
             return (item, null);
         }
 #pragma warning restore CA1031

--- a/PhotoGeoExplorer/Services/CrashReportService.cs
+++ b/PhotoGeoExplorer/Services/CrashReportService.cs
@@ -18,6 +18,7 @@ internal sealed class CrashReportService : ICrashReportService
     private readonly string _appDataDirectory;
     private readonly string _lockFilePath;
     private readonly string _crashReportsDir;
+    private volatile bool _crashLogWritten;
 
     public CrashReportService()
         : this(DefaultAppDataDirectory)
@@ -43,11 +44,18 @@ internal sealed class CrashReportService : ICrashReportService
 
     public void RecordNormalExit()
     {
+        // WriteCrashLog が呼ばれていた場合は running.lock を残し、次回起動時のバナーを保証する
+        if (_crashLogWritten)
+        {
+            return;
+        }
+
         TryDeleteFile(_lockFilePath);
     }
 
     public void WriteCrashLog(Exception? exception)
     {
+        _crashLogWritten = true;
         try
         {
             Directory.CreateDirectory(_crashReportsDir);

--- a/PhotoGeoExplorer/Services/CrashReportService.cs
+++ b/PhotoGeoExplorer/Services/CrashReportService.cs
@@ -18,7 +18,7 @@ internal sealed class CrashReportService : ICrashReportService
     private readonly string _appDataDirectory;
     private readonly string _lockFilePath;
     private readonly string _crashReportsDir;
-    private volatile bool _crashLogWritten;
+    private readonly string _crashMarkerPath;
 
     public CrashReportService()
         : this(DefaultAppDataDirectory)
@@ -30,6 +30,7 @@ internal sealed class CrashReportService : ICrashReportService
         _appDataDirectory = appDataDirectory ?? throw new ArgumentNullException(nameof(appDataDirectory));
         _lockFilePath = Path.Combine(_appDataDirectory, "running.lock");
         _crashReportsDir = Path.Combine(_appDataDirectory, "CrashReports");
+        _crashMarkerPath = Path.Combine(_appDataDirectory, "crash.marker");
     }
 
     public bool PreviouslyTerminatedAbnormally { get; private set; }
@@ -38,14 +39,17 @@ internal sealed class CrashReportService : ICrashReportService
 
     public void RecordStartup()
     {
-        PreviouslyTerminatedAbnormally = File.Exists(_lockFilePath);
+        PreviouslyTerminatedAbnormally = File.Exists(_lockFilePath) || File.Exists(_crashMarkerPath);
+        TryDeleteFile(_crashMarkerPath);
         TryCreateLockFile();
     }
 
     public void RecordNormalExit()
     {
-        // WriteCrashLog が呼ばれていた場合は running.lock を残し、次回起動時のバナーを保証する
-        if (_crashLogWritten)
+        // crash.marker が存在する場合は running.lock を残し、次回起動時のバナーを保証する。
+        // crash.marker はファイルシステムで永続化されるため、WriteCrashLog を呼んだインスタンスと
+        // RecordNormalExit を呼ぶインスタンスが異なっていても確実に機能する。
+        if (File.Exists(_crashMarkerPath))
         {
             return;
         }
@@ -55,7 +59,7 @@ internal sealed class CrashReportService : ICrashReportService
 
     public void WriteCrashLog(Exception? exception)
     {
-        _crashLogWritten = true;
+        TryWriteMarkerFile();
         try
         {
             Directory.CreateDirectory(_crashReportsDir);
@@ -157,6 +161,19 @@ internal sealed class CrashReportService : ICrashReportService
         {
             Directory.CreateDirectory(_appDataDirectory);
             File.WriteAllText(_lockFilePath, DateTimeOffset.Now.ToString("O"));
+        }
+        catch (UnauthorizedAccessException) { }
+        catch (IOException) { }
+        catch (ArgumentException) { }
+        catch (NotSupportedException) { }
+    }
+
+    private void TryWriteMarkerFile()
+    {
+        try
+        {
+            Directory.CreateDirectory(_appDataDirectory);
+            File.WriteAllText(_crashMarkerPath, DateTimeOffset.Now.ToString("O"));
         }
         catch (UnauthorizedAccessException) { }
         catch (IOException) { }


### PR DESCRIPTION
## 概要

Issue #142のクラッシュを個別修正したPR #143の根本対応。クラッシュのたびに1件ずつ直す構造を改め、3か所で例外ハンドリングを強化した。

Closes #144

## 変更内容

### 1. `ExifService.ReadMetadata` — タグ取得処理を `MetadataException` でラップ

ファイル読み込み後のタグ取得処理全体（GPS・Make/Model・DateTime）を `MetadataException` でキャッチ。将来 `Get*` 系タグが追加された場合も個別修正なしに保護される。

### 2. `MapPaneService.LoadMetadataForItemAsync` — 汎用例外キャッチを追加

既存の `IOException / UnauthorizedAccessException / InvalidOperationException` の後に汎用 `Exception` キャッチを追加（`#pragma warning disable CA1031`）。想定外の例外が発生しても当該ファイルをスキップしてアプリ動作を継続する。

### 3. `App.OnUnobservedTaskException` — `WriteCrashLog` を追加

これまでログ出力のみだった観測されない Task 例外にも `WriteCrashLog` を追加。`running.lock` + 次回起動時ダイアログの報告フローに乗るようになった。

## 検証方法

```
dotnet test PhotoGeoExplorer.Tests/PhotoGeoExplorer.Tests.csproj -c Release -p:Platform=x64
```

全504テスト通過、ビルド警告ゼロ。