### PR TITLE
fix(ux): 問題検出バナーの文言をgraceful degradationケースに対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 
 ### 改善
+- 問題検出バナーの文言を修正。graceful degradationで例外をキャッチして正常終了した場合でもバナーが表示されるため、「正常に終了しませんでした」「クラッシュレポート」等の不正確な表現を「前回の実行中に問題が検出されました」「問題レポート」等に変更 (#146)
 - メタデータ解析の部分失敗をgraceful degradationで処理し、アプリのクラッシュを防止 (#144)
   - `ExifService.ReadMetadata` のタグ取得処理全体を `MetadataException` でラップ。将来 `Get*` 系タグが追加された場合も自動的に保護される
   - `MapPaneService.LoadMetadataForItemAsync` に汎用例外キャッチを追加。想定外の例外が発生しても該当ファイルをスキップしてアプリ動作を継続する

--- a/PhotoGeoExplorer/MainWindow.xaml.cs
+++ b/PhotoGeoExplorer/MainWindow.xaml.cs
@@ -526,16 +526,16 @@ public sealed partial class MainWindow : Window, IDisposable
     {
         const string baseUrl = "https://github.com/scottlz0310/PhotoGeoExplorer/issues/new";
         var exType = ParseCrashLogField(logContent, "Exception Type:") ?? "Unknown";
-        var title = Uri.EscapeDataString($"[Crash] {exType}");
+        var title = Uri.EscapeDataString($"[Problem] {exType}");
 
         var truncated = logContent is { Length: > 2000 }
             ? logContent[..2000] + "\n...(truncated)"
             : logContent ?? "(no log)";
 
         var body = Uri.EscapeDataString(
-            "## クラッシュレポート\n\n" +
-            "PhotoGeoExplorer が予期せず終了しました。\n\n" +
-            "<details>\n<summary>クラッシュログ</summary>\n\n```\n" +
+            "## 問題レポート\n\n" +
+            "PhotoGeoExplorer の実行中に問題が検出されました。\n\n" +
+            "<details>\n<summary>診断ログ</summary>\n\n```\n" +
             truncated +
             "\n```\n\n</details>\n\n" +
             "---\n*PhotoGeoExplorer から自動生成されました。*");
@@ -553,7 +553,7 @@ public sealed partial class MainWindow : Window, IDisposable
 
         var version = ParseCrashLogField(logContent, "App Version:") ?? string.Empty;
         var exType = ParseCrashLogField(logContent, "Exception Type:") ?? "Unknown";
-        var subject = Uri.EscapeDataString($"[Crash Report] v{version} {exType}");
+        var subject = Uri.EscapeDataString($"[Problem Report] v{version} {exType}");
         var body = Uri.EscapeDataString(LocalizationService.GetString("CrashReportDialog.MailBody"));
         var mailto = new Uri($"mailto:photogeoexplorer@outlook.com?subject={subject}&body={body}");
         _ = await Windows.System.Launcher.LaunchUriAsync(mailto).AsTask().ConfigureAwait(true);

--- a/PhotoGeoExplorer/Strings/en-US/Resources.resw
+++ b/PhotoGeoExplorer/Strings/en-US/Resources.resw
@@ -900,16 +900,16 @@
     <value>Cancel</value>
   </data>
   <data name="CrashReportBanner.Message" xml:space="preserve">
-    <value>PhotoGeoExplorer did not shut down properly last time. Diagnostic logs have been saved. Attaching logs when reporting an issue helps with investigation.</value>
+    <value>A problem was detected during the last session. Diagnostic logs have been saved. Attaching logs when reporting an issue helps with investigation.</value>
   </data>
   <data name="CrashReportOpenFolderButton.Content" xml:space="preserve">
-    <value>Open Crash Log Folder</value>
+    <value>Open Log Folder</value>
   </data>
   <data name="CrashReportReportButton.Content" xml:space="preserve">
     <value>Report</value>
   </data>
   <data name="CrashReportDialog.Title" xml:space="preserve">
-    <value>Submit Crash Report</value>
+    <value>Submit Problem Report</value>
   </data>
   <data name="CrashReportDialog.GitHubButton" xml:space="preserve">
     <value>Report on GitHub</value>
@@ -939,6 +939,6 @@
     <value>(No log found)</value>
   </data>
   <data name="CrashReportDialog.MailBody" xml:space="preserve">
-    <value>The crash log has been copied to your clipboard. Please paste it into this email (Ctrl+V) and send.</value>
+    <value>The diagnostic log has been copied to your clipboard. Please paste it into this email (Ctrl+V) and send.</value>
   </data>
 </root>

--- a/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
+++ b/PhotoGeoExplorer/Strings/ja-JP/Resources.resw
@@ -900,16 +900,16 @@
     <value>中止</value>
   </data>
   <data name="CrashReportBanner.Message" xml:space="preserve">
-    <value>前回 PhotoGeoExplorer は正常に終了しませんでした。診断用ログが保存されています。問題報告時にログを添付すると原因調査に役立ちます。</value>
+    <value>前回の実行中に問題が検出されました。診断ログが保存されています。問題報告時にログを添付すると原因調査に役立ちます。</value>
   </data>
   <data name="CrashReportOpenFolderButton.Content" xml:space="preserve">
-    <value>クラッシュログフォルダーを開く</value>
+    <value>ログフォルダーを開く</value>
   </data>
   <data name="CrashReportReportButton.Content" xml:space="preserve">
     <value>報告する</value>
   </data>
   <data name="CrashReportDialog.Title" xml:space="preserve">
-    <value>クラッシュレポートの送信</value>
+    <value>問題レポートの送信</value>
   </data>
   <data name="CrashReportDialog.GitHubButton" xml:space="preserve">
     <value>GitHub で報告する</value>
@@ -939,6 +939,6 @@
     <value>(ログが見つかりませんでした)</value>
   </data>
   <data name="CrashReportDialog.MailBody" xml:space="preserve">
-    <value>クラッシュログをクリップボードにコピーしました。このメールに貼り付けてお送りください（Ctrl+V）。</value>
+    <value>診断ログをクリップボードにコピーしました。このメールに貼り付けてお送りください（Ctrl+V）。</value>
   </data>
 </root>


### PR DESCRIPTION
## 概要

PR #145 でgraceful degradationを導入した結果、例外をキャッチして**正常終了**した場合でも次回起動時にバナーが表示されるようになった。しかし既存の文言は「クラッシュ」を前提としており、graceful degradationのケースでは不正確。

## 変更内容

| 変更箇所 | 変更前 | 変更後 |
|---|---|---|
| バナー本文 | 「前回 PhotoGeoExplorer は正常に終了しませんでした」 | 「前回の実行中に問題が検出されました」 |
| ダイアログタイトル | 「クラッシュレポートの送信」 | 「問題レポートの送信」 |
| フォルダーボタン | 「クラッシュログフォルダーを開く」 | 「ログフォルダーを開く」 |
| メール本文 | 「クラッシュログをクリップボードにコピーしました」 | 「診断ログをクリップボードにコピーしました」 |

## 理由

バナーが表示されるシナリオは2つ：
1. **本当のクラッシュ**（`running.lock` が残る）→ 旧文言でも正確
2. **Graceful degradation**（`crash.marker` のみ）→ アプリは正常終了しているのに「正常に終了しませんでした」は不正確

新文言は両シナリオに対して正確。

## 検証

- ビルド: 警告0
- テスト: 510件成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)