### PR TITLE
fix(ci): Release ビルドで MSB6011 が発生し CI が失敗する問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### 修正
+- Release ビルドで `HarfBuzzSharp` などのネイティブ依存の PDB を処理しようとして `mspdbcmf.exe` パス構築バグ (MSB6011) が発生し CI が失敗する問題を修正
+  - `AppxSymbolPackageEnabled=false` を Release 構成に追加してシンボルパッケージ生成を無効化
+
 ## [1.8.5] - 2026-06-09
 
 ### 改善

--- a/PhotoGeoExplorer/PhotoGeoExplorer.csproj
+++ b/PhotoGeoExplorer/PhotoGeoExplorer.csproj
@@ -39,6 +39,8 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <DebugType>none</DebugType>
     <DebugSymbols>false</DebugSymbols>
+    <!-- mspdbcmf.exe パス構築バグ (MSB6011/HarfBuzzSharp) 回避: DebugType=none でシンボルパッケージ不要 -->
+    <AppxSymbolPackageEnabled>false</AppxSymbolPackageEnabled>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- `AppxSymbolPackageEnabled=false` を Release 構成に追加してシンボルパッケージ生成を無効化

## 原因

Mapsui 5.1.0 の推移的依存として `HarfBuzzSharp.NativeAssets.Win32` が加わり、ネイティブ PDB ファイル (`win-arm64/native/libHarfBuzzSharp.pdb`) が追加された。  
これにより `microsoft.windows.sdk.buildtools.msix` の `WinAppSdkCheckFastlinkPdb` タスクが起動し、`mspdbcmf.exe` のパス構築バグ（二重バックスラッシュ）に当たって `MSB6011` エラーが発生。  
プロジェクトはすでに `DebugType=none` を設定済みのため、Store 提出に必要な成果物（`msixupload`）は正しく生成されていたが exit code 1 で CI が失敗していた。

## 対処

`AppxSymbolPackageEnabled=false` により、line 3088 の条件ブロック（`WinAppSdkGenerateAppxSymbolPackage` 呼び出し）が丸ごとスキップされる。  
`DebugType=none` / `DebugSymbols=false` と組み合わせてシンボルパッケージ生成を完全に無効化する。

## 検証方法

- `dotnet build` がローカルで成功することを確認（pre-commit hook 通過）
- CI リリースワークフローの再実行で `MSB6011` が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)