### PR TITLE
refactor: FileBrowser の UI スレッドディスパッチ処理を共通サービスに抽出

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+### リファクタリング
+- UI スレッドディスパッチ処理を `FileBrowserPaneViewModel` から共通サービス `UiDispatcher` へ抽出 (#152)
+  - `IUiDispatcher` / `IUiDispatcherTimer` インターフェースを `Services/` に新設し、`RunAsync` / `EnqueueAsync<T>` / `TryEnqueue` / `CreateTimer` を提供
+  - `DispatcherQueue` が取得できないテスト環境では従来どおり同期実行にフォールバック
+  - ViewModel はコンストラクタ DI で `IUiDispatcher` を受け取り、`DispatcherQueue` への直接依存を排除
+  - `SetDispatcherQueue` 経路を廃止。ViewModel は `MainWindow` の DI 構築（UI スレッド上）で生成されるため、View の `OnLoaded` / `OnDataContextChanged` からの再設定は不要と確認
+
 ### 修正
 - Release ビルドで `HarfBuzzSharp` などのネイティブ依存の PDB を処理しようとして `mspdbcmf.exe` パス構築バグ (MSB6011) が発生し CI が失敗する問題を修正
   - `AppxSymbolPackageEnabled=false` を Release 構成に追加してシンボルパッケージ生成を無効化

--- a/PhotoGeoExplorer.Tests/UiDispatcherTests.cs
+++ b/PhotoGeoExplorer.Tests/UiDispatcherTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Threading.Tasks;
+using PhotoGeoExplorer.Services;
+using Xunit;
+
+namespace PhotoGeoExplorer.Tests;
+
+/// <summary>
+/// UiDispatcher のテスト
+/// テスト環境では DispatcherQueue が取得できないため、フォールバック動作を検証する
+/// </summary>
+public class UiDispatcherTests
+{
+    [Fact]
+    public void IsAvailableReturnsFalseWithoutDispatcherQueue()
+    {
+        // Arrange
+        var dispatcher = new UiDispatcher();
+
+        // Assert
+        Assert.False(dispatcher.IsAvailable);
+    }
+
+    [Fact]
+    public async Task RunAsyncExecutesSynchronouslyWithoutDispatcherQueue()
+    {
+        // Arrange
+        var dispatcher = new UiDispatcher();
+        var executed = false;
+
+        // Act
+        await dispatcher.RunAsync(() => executed = true);
+
+        // Assert
+        Assert.True(executed);
+    }
+
+    [Fact]
+    public async Task RunAsyncPropagatesExceptionWithoutDispatcherQueue()
+    {
+        // Arrange
+        var dispatcher = new UiDispatcher();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => dispatcher.RunAsync(() => throw new InvalidOperationException("test")));
+    }
+
+    [Fact]
+    public async Task EnqueueAsyncExecutesDirectlyWithoutDispatcherQueue()
+    {
+        // Arrange
+        var dispatcher = new UiDispatcher();
+
+        // Act
+        var result = await dispatcher.EnqueueAsync(() => Task.FromResult(42));
+
+        // Assert
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void TryEnqueueReturnsFalseWithoutDispatcherQueue()
+    {
+        // Arrange
+        var dispatcher = new UiDispatcher();
+        var executed = false;
+
+        // Act
+        var enqueued = dispatcher.TryEnqueue(() => executed = true);
+
+        // Assert
+        Assert.False(enqueued);
+        Assert.False(executed);
+    }
+
+    [Fact]
+    public void CreateTimerReturnsNullWithoutDispatcherQueue()
+    {
+        // Arrange
+        var dispatcher = new UiDispatcher();
+
+        // Assert
+        Assert.Null(dispatcher.CreateTimer());
+    }
+}

--- a/PhotoGeoExplorer/MainWindow.xaml.cs
+++ b/PhotoGeoExplorer/MainWindow.xaml.cs
@@ -54,11 +54,14 @@ public sealed partial class MainWindow : Window, IDisposable
             new ExifMetadataService(),
             MapPaneControl,
             (message, severity) => _viewModel.ShowNotificationMessage(message, severity));
+        // MainWindow のコンストラクタは UI スレッドで実行されるため、
+        // ここで生成した UiDispatcher が UI スレッドの DispatcherQueue を捕捉する
         _fileBrowserPaneViewModel = new FileBrowserPaneViewModel(
             new FileBrowserPaneService(),
             _viewModel.WorkspaceState,
             exifEditorService,
-            dialogService);
+            dialogService,
+            uiDispatcher: new UiDispatcher());
         _startupCoordinator = new StartupCoordinator(_fileBrowserPaneViewModel);
         _previewPaneViewModel = new PreviewPaneViewModel(new PreviewPaneService(), _viewModel.WorkspaceState);
         _mapPaneViewModel = new MapPaneViewModel(new MapPaneService(), _viewModel.WorkspaceState);

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
@@ -69,12 +69,6 @@ internal sealed partial class FileBrowserPaneView : UserControl
 
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
-        // DispatcherQueue は Loaded 時に確実に利用可能なため、ここで設定
-        if (ViewModel is not null && DispatcherQueue is not null)
-        {
-            ViewModel.SetDispatcherQueue(DispatcherQueue);
-        }
-
         if (!_fileListInputHandlersRegistered)
         {
             // WinUI 3 の ListView/GridView は Ctrl+C 等を内部でハンドルして e.Handled=true にするため
@@ -97,13 +91,6 @@ internal sealed partial class FileBrowserPaneView : UserControl
 
     private void OnDataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
     {
-        // DataContext 変更時にも設定を試みる（ViewModel が後から設定される場合に備える）
-        // SetDispatcherQueue 内で null チェックがあるため、DispatcherQueue が null でも安全
-        if (ViewModel is not null && DispatcherQueue is not null)
-        {
-            ViewModel.SetDispatcherQueue(DispatcherQueue);
-        }
-
         // 旧 ViewModel の購読を解除（メモリリーク防止）
         if (_previousViewModel is not null)
         {

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -2,11 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
@@ -30,7 +28,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     private readonly IFileOperationService _fileOperationService;
     private readonly IExifEditorService? _exifEditorService;
     private readonly IDialogService? _dialogService;
-    private DispatcherQueue? _dispatcherQueue;
+    private readonly IUiDispatcher _uiDispatcher;
     private readonly WorkspaceState _workspaceState;
     private readonly SemaphoreSlim _thumbnailGenerationSemaphore = new(ThumbnailGenerationConcurrency, ThumbnailGenerationConcurrency);
     private readonly HashSet<string> _thumbnailsInProgress = new();
@@ -80,7 +78,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     private readonly object _activeThumbnailTasksLock = new();
     // テストからタイムアウト値を差し替え可能にするための internal フィールド
     internal TimeSpan ThumbnailDisposeTimeout = TimeSpan.FromSeconds(30);
-    private DispatcherQueueTimer? _thumbnailUpdateTimer;
+    private IUiDispatcherTimer? _thumbnailUpdateTimer;
     private Func<Task>? _openFolderAction;
     private Func<Task>? _createFolderAction;
     private Func<Task>? _renameSelectionAction;
@@ -91,12 +89,12 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     private int _moveTotal;
     private int _moveCompleted;
     private bool _isMoveInProgress;
-    private DispatcherQueueTimer? _moveProgressTimer;
+    private IUiDispatcherTimer? _moveProgressTimer;
     private CancellationTokenSource? _copyCts;
     private int _copyTotal;
     private int _copyCompleted;
     private bool _isCopyInProgress;
-    private DispatcherQueueTimer? _copyProgressTimer;
+    private IUiDispatcherTimer? _copyProgressTimer;
     private IReadOnlyList<PhotoListItem> _clipboardItems = Array.Empty<PhotoListItem>();
     private ClipboardOperation _clipboardOperation = ClipboardOperation.None;
     private readonly IFolderWatcherService _folderWatcherService;
@@ -112,7 +110,8 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         IExifEditorService? exifEditorService = null,
         IDialogService? dialogService = null,
         IFileOperationService? fileOperationService = null,
-        IFolderWatcherService? folderWatcherService = null)
+        IFolderWatcherService? folderWatcherService = null,
+        IUiDispatcher? uiDispatcher = null)
     {
         ArgumentNullException.ThrowIfNull(service);
         ArgumentNullException.ThrowIfNull(workspaceState);
@@ -124,7 +123,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         _dialogService = dialogService;
         _folderWatcherService = folderWatcherService ?? new FolderWatcherService();
         _folderWatcherService.FolderChanged += OnFolderWatcherChanged;
-        _dispatcherQueue = TryGetDispatcherQueue();
+        _uiDispatcher = uiDispatcher ?? new UiDispatcher();
 
         // WorkspaceState にナビゲーションコールバックを設定
         _workspaceState.SelectNextAction = SelectNext;
@@ -720,7 +719,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         // ファイル操作はバックグラウンドスレッドで実行し UI スレッドをブロックしない。
         // 競合ダイアログは UI スレッドへ marshal してから表示する。
         Func<string, bool, Task<ConflictResolution>> marshalledCallback = async (name, isFolder) =>
-            await EnqueueOnUIThreadAsync(() => resolveConflictAsync(name, isFolder)).ConfigureAwait(false);
+            await _uiDispatcher.EnqueueAsync(() => resolveConflictAsync(name, isFolder)).ConfigureAwait(false);
 
         FileOperationSummary result;
         try
@@ -737,9 +736,9 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         finally
         {
             // ConfigureAwait(false) により finally はバックグラウンドスレッドで実行される。
-            // DispatcherQueueTimer.Stop()、PropertyChanged 発火、CTS の Dispose/null 化は
+            // 進捗タイマーの Stop()、PropertyChanged 発火、CTS の Dispose/null 化は
             // すべて UI スレッドで行い、CancelMoveCommand との race を防ぐ（#137）。
-            await RunOnUIThreadAsync(() =>
+            await _uiDispatcher.RunAsync(() =>
             {
                 StopMoveProgressTimer();
                 IsMoveInProgress = false;
@@ -756,16 +755,17 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 
         var doneText = LocalizationService.Format(
             "Message.MoveDone", result.SuccessCount, result.SkipCount, result.FailureCount);
-        await RunOnUIThreadAsync(() => StatusBarText = doneText).ConfigureAwait(false);
+        await _uiDispatcher.RunAsync(() => StatusBarText = doneText).ConfigureAwait(false);
 
         return result;
     }
 
     private void StartMoveProgressTimer()
     {
-        if (_dispatcherQueue is null) return;
+        var timer = _uiDispatcher.CreateTimer();
+        if (timer is null) return;
 
-        _moveProgressTimer = _dispatcherQueue.CreateTimer();
+        _moveProgressTimer = timer;
         _moveProgressTimer.Interval = TimeSpan.FromMilliseconds(300);
         _moveProgressTimer.Tick += OnMoveProgressTick;
         _moveProgressTimer.Start();
@@ -777,7 +777,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         _moveProgressTimer = null;
     }
 
-    private void OnMoveProgressTick(DispatcherQueueTimer sender, object args)
+    private void OnMoveProgressTick(object? sender, EventArgs e)
     {
         var completed = Volatile.Read(ref _moveCompleted);
         StatusBarText = LocalizationService.Format(
@@ -809,7 +809,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         StartCopyProgressTimer();
 
         Func<string, bool, Task<ConflictResolution>> marshalledCallback = async (name, isFolder) =>
-            await EnqueueOnUIThreadAsync(() => resolveConflictAsync(name, isFolder)).ConfigureAwait(false);
+            await _uiDispatcher.EnqueueAsync(() => resolveConflictAsync(name, isFolder)).ConfigureAwait(false);
 
         FileOperationSummary result;
         try
@@ -826,9 +826,9 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         finally
         {
             // ConfigureAwait(false) により finally はバックグラウンドスレッドで実行される。
-            // DispatcherQueueTimer.Stop()、PropertyChanged 発火、CTS の Dispose/null 化は
+            // 進捗タイマーの Stop()、PropertyChanged 発火、CTS の Dispose/null 化は
             // すべて UI スレッドで行い、CancelCopyCommand との race を防ぐ（#137）。
-            await RunOnUIThreadAsync(() =>
+            await _uiDispatcher.RunAsync(() =>
             {
                 StopCopyProgressTimer();
                 IsCopyInProgress = false;
@@ -845,16 +845,17 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 
         var doneText = LocalizationService.Format(
             "Message.CopyDone", result.SuccessCount, result.SkipCount, result.FailureCount);
-        await RunOnUIThreadAsync(() => StatusBarText = doneText).ConfigureAwait(false);
+        await _uiDispatcher.RunAsync(() => StatusBarText = doneText).ConfigureAwait(false);
 
         return result;
     }
 
     private void StartCopyProgressTimer()
     {
-        if (_dispatcherQueue is null) return;
+        var timer = _uiDispatcher.CreateTimer();
+        if (timer is null) return;
 
-        _copyProgressTimer = _dispatcherQueue.CreateTimer();
+        _copyProgressTimer = timer;
         _copyProgressTimer.Interval = TimeSpan.FromMilliseconds(300);
         _copyProgressTimer.Tick += OnCopyProgressTick;
         _copyProgressTimer.Start();
@@ -866,7 +867,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         _copyProgressTimer = null;
     }
 
-    private void OnCopyProgressTick(DispatcherQueueTimer sender, object args)
+    private void OnCopyProgressTick(object? sender, EventArgs e)
     {
         var completed = Volatile.Read(ref _copyCompleted);
         StatusBarText = LocalizationService.Format(
@@ -954,7 +955,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     {
         if (string.IsNullOrWhiteSpace(folderPath))
         {
-            await RunOnUIThreadAsync(() =>
+            await _uiDispatcher.RunAsync(() =>
             {
                 SetStatus(LocalizationService.GetString("Message.FolderPathEmpty"), InfoBarSeverity.Error);
             }).ConfigureAwait(false);
@@ -963,7 +964,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 
         if (!_fileOperationService.FolderExistsAtPath(folderPath))
         {
-            await RunOnUIThreadAsync(() =>
+            await _uiDispatcher.RunAsync(() =>
             {
                 SetStatus(LocalizationService.GetString("Message.FolderNotFound"), InfoBarSeverity.Error);
             }).ConfigureAwait(false);
@@ -984,7 +985,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         try
         {
             var previousPath = CurrentFolderPath;
-            await RunOnUIThreadAsync(() =>
+            await _uiDispatcher.RunAsync(() =>
             {
                 CurrentFolderPath = folderPath;
                 UpdateBreadcrumbs(folderPath);
@@ -1000,7 +1001,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 
             var sorted = _service.ApplySort(items, SortColumn, SortDirection);
 
-            await RunOnUIThreadAsync(() =>
+            await _uiDispatcher.RunAsync(() =>
             {
                 Items.Clear();
                 foreach (var item in sorted)
@@ -1022,7 +1023,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
                 UpdateStatusBar();
 
                 // バックグラウンドでサムネイル生成を開始
-                // 注意: StartBackgroundThumbnailGeneration 内部で DispatcherQueue を使用してタイマーを構成しているため、
+                // 注意: StartBackgroundThumbnailGeneration 内部で UI スレッドタイマーを構成しているため、
                 //       ここでは明示的に UI スレッド上から呼び出している（UI 更新と意図を揃えるため）
                 StartBackgroundThumbnailGeneration();
                 _folderWatcherService.Watch(folderPath);
@@ -1038,7 +1039,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         catch (UnauthorizedAccessException ex)
         {
             AppLog.Error($"Failed to access folder: {folderPath}", ex);
-            await RunOnUIThreadAsync(() =>
+            await _uiDispatcher.RunAsync(() =>
             {
                 SetStatus(LocalizationService.GetString("Message.AccessDeniedSeeLog"), InfoBarSeverity.Error);
             }).ConfigureAwait(false);
@@ -1046,7 +1047,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         catch (DirectoryNotFoundException ex)
         {
             AppLog.Error($"Folder not found: {folderPath}", ex);
-            await RunOnUIThreadAsync(() =>
+            await _uiDispatcher.RunAsync(() =>
             {
                 SetStatus(LocalizationService.GetString("Message.FolderNotFoundSeeLog"), InfoBarSeverity.Error);
             }).ConfigureAwait(false);
@@ -1054,7 +1055,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         catch (IOException ex)
         {
             AppLog.Error($"Failed to read folder: {folderPath}", ex);
-            await RunOnUIThreadAsync(() =>
+            await _uiDispatcher.RunAsync(() =>
             {
                 SetStatus(LocalizationService.GetString("Message.FailedReadFolderSeeLog"), InfoBarSeverity.Error);
             }).ConfigureAwait(false);
@@ -1064,7 +1065,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 #pragma warning restore CA1031
         {
             AppLog.Error($"LoadFolderAsync: Unexpected exception for '{folderPath}'", ex);
-            await RunOnUIThreadAsync(() =>
+            await _uiDispatcher.RunAsync(() =>
             {
                 Items.Clear();
                 SetStatus(LocalizationService.GetString("Message.FailedReadFolderSeeLog"), InfoBarSeverity.Error);
@@ -1077,7 +1078,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         var homePath = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
         if (string.IsNullOrWhiteSpace(homePath) || !_fileOperationService.FolderExistsAtPath(homePath))
         {
-            await RunOnUIThreadAsync(() =>
+            await _uiDispatcher.RunAsync(() =>
             {
                 SetStatus(LocalizationService.GetString("Message.PicturesFolderNotFound"), InfoBarSeverity.Error);
             }).ConfigureAwait(false);
@@ -1098,7 +1099,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         if (previousPath is not null)
         {
             await LoadFolderAsync(previousPath, updateHistory: false).ConfigureAwait(false);
-            await RunOnUIThreadAsync(UpdateNavigationCommands).ConfigureAwait(false);
+            await _uiDispatcher.RunAsync(UpdateNavigationCommands).ConfigureAwait(false);
         }
     }
 
@@ -1113,7 +1114,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         if (nextPath is not null)
         {
             await LoadFolderAsync(nextPath, updateHistory: false).ConfigureAwait(false);
-            await RunOnUIThreadAsync(UpdateNavigationCommands).ConfigureAwait(false);
+            await _uiDispatcher.RunAsync(UpdateNavigationCommands).ConfigureAwait(false);
         }
     }
 
@@ -1609,12 +1610,12 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         if (item is null || item.IsFolder)
         {
             _selectedMetadata = null;
-            await RunOnUIThreadAsync(UpdateStatusBarLocation).ConfigureAwait(false);
+            await _uiDispatcher.RunAsync(UpdateStatusBarLocation).ConfigureAwait(false);
             return;
         }
 
         _selectedMetadata = null;
-        await RunOnUIThreadAsync(UpdateStatusBarLocation).ConfigureAwait(false);
+        await _uiDispatcher.RunAsync(UpdateStatusBarLocation).ConfigureAwait(false);
 
         var cts = new CancellationTokenSource();
         _metadataCts = cts;
@@ -1628,7 +1629,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
             }
 
             _selectedMetadata = metadata;
-            await RunOnUIThreadAsync(UpdateStatusBarLocation).ConfigureAwait(false);
+            await _uiDispatcher.RunAsync(UpdateStatusBarLocation).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -1681,7 +1682,8 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         CancelThumbnailGeneration();
 
         // テスト環境またはUIスレッドがない場合はスキップ
-        if (_dispatcherQueue is null)
+        var thumbnailUpdateTimer = _uiDispatcher.CreateTimer();
+        if (thumbnailUpdateTimer is null)
         {
             return;
         }
@@ -1701,7 +1703,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         _thumbnailGenerationCompleted = 0;
 
         // 更新タイマーの初期化
-        _thumbnailUpdateTimer = _dispatcherQueue.CreateTimer();
+        _thumbnailUpdateTimer = thumbnailUpdateTimer;
         _thumbnailUpdateTimer.Interval = TimeSpan.FromMilliseconds(ThumbnailUpdateBatchIntervalMs);
         _thumbnailUpdateTimer.Tick += OnThumbnailUpdateTimerTick;
         _thumbnailUpdateTimer.Start();
@@ -1855,7 +1857,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         }
     }
 
-    private void OnThumbnailUpdateTimerTick(DispatcherQueueTimer sender, object args)
+    private void OnThumbnailUpdateTimerTick(object? sender, EventArgs e)
     {
         ApplyPendingThumbnailUpdates();
     }
@@ -1922,7 +1924,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 
     private void OnFolderWatcherChanged(object? sender, EventArgs e)
     {
-        _dispatcherQueue?.TryEnqueue(async () =>
+        _uiDispatcher.TryEnqueue(async () =>
         {
             if (_isMoveInProgress || _isCopyInProgress)
             {
@@ -2000,90 +2002,4 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         }
     }
 
-    private static DispatcherQueue? TryGetDispatcherQueue()
-    {
-        try
-        {
-            return DispatcherQueue.GetForCurrentThread();
-        }
-        catch (COMException ex)
-        {
-            AppLog.Info($"DispatcherQueue is unavailable in this environment: {ex.Message}");
-            return null;
-        }
-        catch (TypeInitializationException ex)
-        {
-            AppLog.Info($"DispatcherQueue initialization failed: {ex.Message}");
-            return null;
-        }
-    }
-
-    internal void SetDispatcherQueue(DispatcherQueue? dispatcherQueue)
-    {
-        if (dispatcherQueue is null)
-        {
-            return;
-        }
-
-        _dispatcherQueue = dispatcherQueue;
-    }
-
-    private Task RunOnUIThreadAsync(Action action)
-    {
-        if (_dispatcherQueue is null)
-        {
-            action();
-            return Task.CompletedTask;
-        }
-
-        var tcs = new TaskCompletionSource<bool>();
-        if (!_dispatcherQueue.TryEnqueue(() =>
-            {
-                try
-                {
-                    action();
-                    tcs.SetResult(true);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    throw;
-                }
-            }))
-        {
-            var ex = new InvalidOperationException("DispatcherQueue へのエンキューに失敗しました。");
-            AppLog.Error("RunOnUIThreadAsync: DispatcherQueue.TryEnqueue が false を返しました。", ex);
-            tcs.SetException(ex);
-        }
-        return tcs.Task;
-    }
-
-    private Task<T> EnqueueOnUIThreadAsync<T>(Func<Task<T>> asyncFunc)
-    {
-        if (_dispatcherQueue is null)
-        {
-            return asyncFunc();
-        }
-
-        var tcs = new TaskCompletionSource<T>();
-        if (!_dispatcherQueue.TryEnqueue(async () =>
-            {
-                try
-                {
-                    var result = await asyncFunc().ConfigureAwait(false);
-                    tcs.SetResult(result);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                    throw;
-                }
-            }))
-        {
-            var ex = new InvalidOperationException("DispatcherQueue へのエンキューに失敗しました。");
-            AppLog.Error("EnqueueOnUIThreadAsync: DispatcherQueue.TryEnqueue が false を返しました。", ex);
-            tcs.SetException(ex);
-        }
-        return tcs.Task;
-    }
 }

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -1682,8 +1682,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         CancelThumbnailGeneration();
 
         // テスト環境またはUIスレッドがない場合はスキップ
-        var thumbnailUpdateTimer = _uiDispatcher.CreateTimer();
-        if (thumbnailUpdateTimer is null)
+        if (!_uiDispatcher.IsAvailable)
         {
             return;
         }
@@ -1702,7 +1701,13 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         _thumbnailGenerationTotal = itemsNeedingThumbnails.Count;
         _thumbnailGenerationCompleted = 0;
 
-        // 更新タイマーの初期化
+        // 更新タイマーの初期化（IsAvailable 確認済みのため CreateTimer は非 null を返す）
+        var thumbnailUpdateTimer = _uiDispatcher.CreateTimer();
+        if (thumbnailUpdateTimer is null)
+        {
+            return;
+        }
+
         _thumbnailUpdateTimer = thumbnailUpdateTimer;
         _thumbnailUpdateTimer.Interval = TimeSpan.FromMilliseconds(ThumbnailUpdateBatchIntervalMs);
         _thumbnailUpdateTimer.Tick += OnThumbnailUpdateTimerTick;

--- a/PhotoGeoExplorer/Services/IUiDispatcher.cs
+++ b/PhotoGeoExplorer/Services/IUiDispatcher.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading.Tasks;
+
+namespace PhotoGeoExplorer.Services;
+
+/// <summary>
+/// UI スレッドへのディスパッチを抽象化するサービス。
+/// DispatcherQueue が取得できない環境（単体テスト等）では同期実行にフォールバックする。
+/// </summary>
+internal interface IUiDispatcher
+{
+    /// <summary>
+    /// UI スレッドディスパッチが利用可能かどうか。
+    /// false の場合、各メソッドはフォールバック動作（同期実行・no-op）になる。
+    /// </summary>
+    bool IsAvailable { get; }
+
+    /// <summary>
+    /// アクションを UI スレッドで実行し、完了を待機する。
+    /// 利用不可の場合は呼び出し元スレッドで同期実行する。
+    /// </summary>
+    Task RunAsync(Action action);
+
+    /// <summary>
+    /// 非同期関数を UI スレッドで開始し、その完了結果を返す。
+    /// 利用不可の場合は呼び出し元スレッドでそのまま実行する。
+    /// </summary>
+    Task<T> EnqueueAsync<T>(Func<Task<T>> asyncFunc);
+
+    /// <summary>
+    /// アクションを UI スレッドへエンキューする（完了は待機しない）。
+    /// 利用不可の場合は何もせず false を返す。
+    /// </summary>
+    bool TryEnqueue(Action action);
+
+    /// <summary>
+    /// UI スレッド上で Tick する繰り返しタイマーを作成する。
+    /// 利用不可の場合は null を返す。
+    /// </summary>
+    IUiDispatcherTimer? CreateTimer();
+}
+
+/// <summary>
+/// UI スレッド上で Tick する繰り返しタイマーの抽象。
+/// </summary>
+internal interface IUiDispatcherTimer
+{
+    TimeSpan Interval { get; set; }
+
+    event EventHandler? Tick;
+
+    void Start();
+
+    void Stop();
+}

--- a/PhotoGeoExplorer/Services/UiDispatcher.cs
+++ b/PhotoGeoExplorer/Services/UiDispatcher.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Microsoft.UI.Dispatching;
+
+namespace PhotoGeoExplorer.Services;
+
+/// <summary>
+/// DispatcherQueue ベースの <see cref="IUiDispatcher"/> 実装。
+/// 生成したスレッド（UI スレッド上での DI 構築を想定）の DispatcherQueue を捕捉する。
+/// DispatcherQueue が取得できない環境（単体テスト等）では同期実行にフォールバックする。
+/// </summary>
+internal sealed class UiDispatcher : IUiDispatcher
+{
+    private readonly DispatcherQueue? _dispatcherQueue;
+
+    public UiDispatcher()
+    {
+        _dispatcherQueue = TryGetDispatcherQueue();
+    }
+
+    public bool IsAvailable => _dispatcherQueue is not null;
+
+    public Task RunAsync(Action action)
+    {
+        if (_dispatcherQueue is null)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        var tcs = new TaskCompletionSource<bool>();
+        if (!_dispatcherQueue.TryEnqueue(() =>
+            {
+                try
+                {
+                    action();
+                    tcs.SetResult(true);
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                    throw;
+                }
+            }))
+        {
+            var ex = new InvalidOperationException("DispatcherQueue へのエンキューに失敗しました。");
+            AppLog.Error("UiDispatcher.RunAsync: DispatcherQueue.TryEnqueue が false を返しました。", ex);
+            tcs.SetException(ex);
+        }
+
+        return tcs.Task;
+    }
+
+    public Task<T> EnqueueAsync<T>(Func<Task<T>> asyncFunc)
+    {
+        if (_dispatcherQueue is null)
+        {
+            return asyncFunc();
+        }
+
+        var tcs = new TaskCompletionSource<T>();
+        if (!_dispatcherQueue.TryEnqueue(async () =>
+            {
+                try
+                {
+                    var result = await asyncFunc().ConfigureAwait(false);
+                    tcs.SetResult(result);
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                    throw;
+                }
+            }))
+        {
+            var ex = new InvalidOperationException("DispatcherQueue へのエンキューに失敗しました。");
+            AppLog.Error("UiDispatcher.EnqueueAsync: DispatcherQueue.TryEnqueue が false を返しました。", ex);
+            tcs.SetException(ex);
+        }
+
+        return tcs.Task;
+    }
+
+    public bool TryEnqueue(Action action)
+    {
+        return _dispatcherQueue?.TryEnqueue(() => action()) ?? false;
+    }
+
+    public IUiDispatcherTimer? CreateTimer()
+    {
+        return _dispatcherQueue is null
+            ? null
+            : new DispatcherQueueTimerAdapter(_dispatcherQueue.CreateTimer());
+    }
+
+    private static DispatcherQueue? TryGetDispatcherQueue()
+    {
+        try
+        {
+            return DispatcherQueue.GetForCurrentThread();
+        }
+        catch (COMException ex)
+        {
+            AppLog.Info($"DispatcherQueue is unavailable in this environment: {ex.Message}");
+            return null;
+        }
+        catch (TypeInitializationException ex)
+        {
+            AppLog.Info($"DispatcherQueue initialization failed: {ex.Message}");
+            return null;
+        }
+    }
+
+    private sealed class DispatcherQueueTimerAdapter : IUiDispatcherTimer
+    {
+        private readonly DispatcherQueueTimer _timer;
+
+        public DispatcherQueueTimerAdapter(DispatcherQueueTimer timer)
+        {
+            _timer = timer;
+            _timer.Tick += OnTimerTick;
+        }
+
+        public TimeSpan Interval
+        {
+            get => _timer.Interval;
+            set => _timer.Interval = value;
+        }
+
+        public event EventHandler? Tick;
+
+        public void Start() => _timer.Start();
+
+        public void Stop() => _timer.Stop();
+
+        private void OnTimerTick(DispatcherQueueTimer sender, object args)
+            => Tick?.Invoke(this, EventArgs.Empty);
+    }
+}


### PR DESCRIPTION
## 概要

Closes #152

#150 Phase 1（`FileBrowserPaneViewModel` 分割）の第1弾として、VM が private 実装として抱えていた UI スレッドブリッジ（`RunOnUIThreadAsync` / `EnqueueOnUIThreadAsync<T>` / `TryGetDispatcherQueue` / `SetDispatcherQueue` / `DispatcherQueue.CreateTimer()` 直接利用）を共通サービス `UiDispatcher` へ抽出しました。後続の切り出し（サムネイル生成 Coordinator・ファイル操作 Coordinator・ステータス表示子VM）はこの基盤を利用します。

## 変更内容

- `Services/IUiDispatcher.cs` を新設: `IsAvailable` / `RunAsync(Action)` / `EnqueueAsync<T>(Func<Task<T>>)` / `TryEnqueue(Action)` / `CreateTimer()` と、タイマー抽象 `IUiDispatcherTimer` を定義
- `Services/UiDispatcher.cs` を新設: `DispatcherQueue` ベースの実装。既存の private 実装をそのまま移植し、`DispatcherQueue` が取得できないテスト環境では従来どおり同期実行（`RunAsync`）・直接実行（`EnqueueAsync`）・no-op（`TryEnqueue` / `CreateTimer`）にフォールバック
- `FileBrowserPaneViewModel` はコンストラクタ DI で `IUiDispatcher` を受け取り（省略時は `new UiDispatcher()`）、`DispatcherQueue` への直接アクセスを排除。Move/Copy 進捗タイマー・サムネイル更新タイマーも `IUiDispatcherTimer` 経由に変更
- `MainWindow` の DI 構築で `UiDispatcher` を明示注入

## `SetDispatcherQueue` 経路の廃止検証（Issue の設計方針に対する回答）

**廃止可能と判断し、削除しました。**

- VM は `MainWindow` のコンストラクタ（UI スレッド上の DI 構築）でのみ生成されるため、その時点で `UiDispatcher` が `DispatcherQueue.GetForCurrentThread()` により UI スレッドの DispatcherQueue を捕捉できます
- `SetDispatcherQueue` とコンストラクタでの `TryGetDispatcherQueue()` は PR #88 で同時に導入されたもので、View の `OnLoaded` / `OnDataContextChanged` からの再設定は同じ DispatcherQueue を再代入するだけの冗長な保険でした
- テストコードからの `SetDispatcherQueue` 利用はありません

## 検証

- `dotnet build PhotoGeoExplorer.sln -c Release -p:Platform=x64`: 成功（警告 0）
- `dotnet test PhotoGeoExplorer.sln -c Release -p:Platform=x64`: 518 件すべて合格（新規 `UiDispatcherTests` 6 件含む）
- `dotnet format --verify-no-changes`: 差分なし

## 受け入れ条件の確認

- [x] `FileBrowserPaneViewModel` 内に `DispatcherQueue` への直接アクセスが残っていない（注入された `IUiDispatcher` 経由になっている）
- [x] 既存の `FileBrowserPaneViewModelTests` がすべてパスする
- [x] `dotnet build` / `dotnet test`（Release, x64）が成功する

🤖 Generated with [Claude Code](https://claude.com/claude-code)