### PR TITLE
refactor: FileBrowserPaneViewModel からサムネイル生成処理を ThumbnailGenerationCoordinator に分離

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ## [Unreleased]
 
 ### リファクタリング
+- サムネイル生成処理を `FileBrowserPaneViewModel` から `ThumbnailGenerationCoordinator` へ分離 (#153)
+  - SemaphoreSlim による並列数制限・UI スレッドタイマーによるバッチ更新・CancellationTokenSource 管理を `Panes/FileBrowser/ThumbnailGenerationCoordinator.cs`（internal sealed, IDisposable）へ移動。ViewModel は `StartGeneration` / `Dispose` を呼ぶだけになった
+  - #147 / #137 で入れた並行処理対策（Task.Run 前のトークンキャプチャ、Dispose 時の全タスク完了待ち、ObjectDisposedException の安全網）は移動先でも維持
+  - #147 の回帰テスト 2 件をリフレクションによる private フィールドアクセスから Coordinator の公開 API（コンストラクタ注入・internal メンバー）経由のテストへ書き換え、`ThumbnailGenerationCoordinatorTests` に移設。生成対象フィルタ・並列数制限・バッチ更新・キャンセルの単体テストも追加
 - UI スレッドディスパッチ処理を `FileBrowserPaneViewModel` から共通サービス `UiDispatcher` へ抽出 (#152)
   - `IUiDispatcher` / `IUiDispatcherTimer` インターフェースを `Services/` に新設し、`RunAsync` / `EnqueueAsync<T>` / `TryEnqueue` / `CreateTimer` を提供
   - `DispatcherQueue` が取得できないテスト環境では従来どおり同期実行にフォールバック

--- a/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
@@ -523,115 +522,6 @@ public class FileBrowserPaneViewModelTests
         // Act & Assert (Should not throw)
         viewModel.Dispose();
         viewModel.Dispose();
-    }
-
-    /// <summary>
-    /// 回帰テスト(タスク上書き): フォルダ切り替えで旧タスクが _activeThumbnailTasks から
-    /// 上書きされず、Dispose() が両タスクの完了を待ってからセマフォを破棄することを検証する。
-    /// </summary>
-    [Fact]
-    public async Task DisposeWhileMultipleThumbnailTasksRunning_WaitsForAllAndDoesNotThrow()
-    {
-        // Arrange
-        var service = new FileBrowserPaneService();
-        var workspaceState = new WorkspaceState();
-        var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
-
-        var flags = BindingFlags.NonPublic | BindingFlags.Instance;
-        var semaphoreField = typeof(FileBrowserPaneViewModel).GetField("_thumbnailGenerationSemaphore", flags)!;
-        var tasksField = typeof(FileBrowserPaneViewModel).GetField("_activeThumbnailTasks", flags)!;
-        var tasksLockField = typeof(FileBrowserPaneViewModel).GetField("_activeThumbnailTasksLock", flags)!;
-        var semaphore = (SemaphoreSlim)semaphoreField.GetValue(viewModel)!;
-        var activeTasks = (HashSet<Task>)tasksField.GetValue(viewModel)!;
-        var tasksLock = tasksLockField.GetValue(viewModel)!;
-
-        // セマフォを取得して 2 つの「バッチ実行中タスク」を模擬（フォルダ切り替えシナリオ）
-        await semaphore.WaitAsync().ConfigureAwait(true);
-        await semaphore.WaitAsync().ConfigureAwait(true); // 2スロット占有
-
-        Task task1 = null!;
-        Task task2 = null!;
-
-        task1 = Task.Run(() =>
-        {
-            Thread.Sleep(40);
-            try { semaphore.Release(); }
-            catch (ObjectDisposedException) { }
-        });
-        task2 = Task.Run(() =>
-        {
-            Thread.Sleep(20);
-            try { semaphore.Release(); }
-            catch (ObjectDisposedException) { }
-        });
-
-        lock (tasksLock)
-        {
-            activeTasks.Add(task1);
-            activeTasks.Add(task2);
-        }
-
-        // Act: 2 タスクが実行中に Dispose
-        viewModel.Dispose();
-
-        // 両タスクが完了していることを確認（Dispose が Wait で待ったはず）
-        await Task.WhenAll(task1, task2).ConfigureAwait(true);
-        Assert.True(task1.IsCompleted);
-        Assert.True(task2.IsCompleted);
-    }
-
-    /// <summary>
-    /// 回帰テスト(タイムアウト): Dispose のタイムアウトを短くして待機を超過させても
-    /// GenerateThumbnailAsync が ObjectDisposedException を捕捉し クラッシュしないことを検証する。
-    /// </summary>
-    [Fact]
-    public async Task DisposeWithTimeoutExceeded_TaskCatchesObjectDisposedExceptionAndDoesNotCrash()
-    {
-        // Arrange
-        var service = new FileBrowserPaneService();
-        var workspaceState = new WorkspaceState();
-        var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
-
-        // タイムアウトを極端に短くする（テスト専用フィールド）
-        viewModel.ThumbnailDisposeTimeout = TimeSpan.FromMilliseconds(10);
-
-        var flags = BindingFlags.NonPublic | BindingFlags.Instance;
-        var semaphoreField = typeof(FileBrowserPaneViewModel).GetField("_thumbnailGenerationSemaphore", flags)!;
-        var tasksField = typeof(FileBrowserPaneViewModel).GetField("_activeThumbnailTasks", flags)!;
-        var tasksLockField = typeof(FileBrowserPaneViewModel).GetField("_activeThumbnailTasksLock", flags)!;
-        var semaphore = (SemaphoreSlim)semaphoreField.GetValue(viewModel)!;
-        var activeTasks = (HashSet<Task>)tasksField.GetValue(viewModel)!;
-        var tasksLock = tasksLockField.GetValue(viewModel)!;
-
-        await semaphore.WaitAsync().ConfigureAwait(true);
-
-        var releaseException = (Exception?)null;
-        Task slowTask = null!;
-        slowTask = Task.Run(() =>
-        {
-            Thread.Sleep(200); // タイムアウト（10ms）を超過する処理
-            try { semaphore.Release(); }
-            catch (ObjectDisposedException ex) { releaseException = ex; }
-        });
-
-        lock (tasksLock)
-        {
-            activeTasks.Add(slowTask);
-        }
-
-        // Act: タイムアウト前に Dispose が戻る
-        viewModel.Dispose();
-
-        // slowTask の完了を待つ（Release が ODE を投げるか否かを確認）
-        await slowTask.ConfigureAwait(true);
-
-        // タイムアウト後にセマフォが破棄されているため ODE は発生しうるが、
-        // それが捕捉されてクラッシュに至らないことを確認する
-        if (releaseException is not null)
-        {
-            Assert.IsType<ObjectDisposedException>(releaseException);
-            // ODE が捕捉されていることを確認（アプリがクラッシュしていない）
-        }
     }
 
     [Fact]

--- a/PhotoGeoExplorer.Tests/ThumbnailGenerationCoordinatorTests.cs
+++ b/PhotoGeoExplorer.Tests/ThumbnailGenerationCoordinatorTests.cs
@@ -1,0 +1,402 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using PhotoGeoExplorer.Models;
+using PhotoGeoExplorer.Panes.FileBrowser;
+using PhotoGeoExplorer.Services;
+using PhotoGeoExplorer.ViewModels;
+using Xunit;
+
+namespace PhotoGeoExplorer.Tests;
+
+/// <summary>
+/// ThumbnailGenerationCoordinator のテスト。
+/// 生成パイプライン・並列制御・バッチ更新・キャンセル・Dispose 時の安全性を
+/// 公開 API（コンストラクタ注入・internal メンバー）経由で検証する。
+/// </summary>
+public sealed class ThumbnailGenerationCoordinatorTests
+{
+    private const int WaitTimeoutMs = 5000;
+
+    [Fact]
+    public async Task StartGenerationGeneratesThumbnailsOnlyForItemsNeedingThem()
+    {
+        // Arrange
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            var targetPath = CreateTempFile(tempDir, "target.jpg");
+            var noKeyPath = CreateTempFile(tempDir, "no-key.jpg");
+
+            var generatedPaths = new List<string>();
+            var generatedPathsLock = new object();
+            var dispatcher = new FakeUiDispatcher();
+            using var coordinator = CreateCoordinator(dispatcher, (path, _) =>
+            {
+                lock (generatedPathsLock)
+                {
+                    generatedPaths.Add(path);
+                }
+
+                return (null, null, null);
+            });
+
+            var items = new List<PhotoListItem>
+            {
+                CreateListItem(targetPath, thumbnailKey: "key-target"),
+                CreateListItem(noKeyPath, thumbnailKey: null),
+                CreateFolderListItem(tempDir),
+            };
+
+            // Act
+            coordinator.StartGeneration(items);
+            await Task.WhenAll(coordinator.GetActiveTasksSnapshot()).ConfigureAwait(true);
+
+            // Assert: ThumbnailKey を持つ非フォルダのアイテムのみ生成対象になる
+            lock (generatedPathsLock)
+            {
+                var generated = Assert.Single(generatedPaths);
+                Assert.Equal(targetPath, generated);
+            }
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public async Task StartGenerationLimitsConcurrencyWithSemaphore()
+    {
+        // Arrange
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            var items = new List<PhotoListItem>();
+            for (var i = 0; i < 8; i++)
+            {
+                var path = CreateTempFile(tempDir, $"photo{i}.jpg");
+                items.Add(CreateListItem(path, thumbnailKey: $"key{i}"));
+            }
+
+            var running = 0;
+            var maxObserved = 0;
+            var dispatcher = new FakeUiDispatcher();
+            using var coordinator = CreateCoordinator(dispatcher, (_, _) =>
+            {
+                var current = Interlocked.Increment(ref running);
+                int snapshot;
+                while (current > (snapshot = Volatile.Read(ref maxObserved)))
+                {
+                    Interlocked.CompareExchange(ref maxObserved, current, snapshot);
+                }
+
+                Thread.Sleep(30);
+                Interlocked.Decrement(ref running);
+                return (null, null, null);
+            });
+
+            // Act
+            coordinator.StartGeneration(items);
+            await Task.WhenAll(coordinator.GetActiveTasksSnapshot()).ConfigureAwait(true);
+
+            // Assert: 同時実行数がセマフォの上限（3）を超えない
+            Assert.InRange(Volatile.Read(ref maxObserved), 1, 3);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public async Task TimerTickAppliesPendingUpdatesAndStopsTimerWhenCompleted()
+    {
+        // Arrange
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            var photoPath = CreateTempFile(tempDir, "photo.jpg");
+            var takenAt = new DateTimeOffset(2026, 6, 1, 12, 0, 0, TimeSpan.Zero);
+            var dispatcher = new FakeUiDispatcher();
+            using var coordinator = CreateCoordinator(
+                dispatcher,
+                (_, _) => (Path.Combine(tempDir, "thumb.png"), 200, 100),
+                isJpegFile: _ => true,
+                getMetadataAsync: (_, _) => Task.FromResult<PhotoMetadata?>(
+                    new PhotoMetadata(takenAt, null, null, 35.0, 139.0, hasGpsData: true)));
+
+            var item = CreateListItem(photoPath, thumbnailKey: "key1");
+
+            // Act
+            coordinator.StartGeneration(new List<PhotoListItem> { item });
+            await Task.WhenAll(coordinator.GetActiveTasksSnapshot()).ConfigureAwait(true);
+
+            var timer = dispatcher.LastTimer;
+            Assert.NotNull(timer);
+            Assert.True(timer.IsRunning);
+            timer.FireTick();
+
+            // Assert: 保留中の更新がアイテムへ適用される（createThumbnailImage は null を
+            // 返すテストシームのため、解像度とメタデータの反映を検証する）
+            Assert.Equal("200 x 100", item.ResolutionText);
+            Assert.Equal(takenAt, item.TakenAt);
+            Assert.True(item.HasLocation);
+
+            // Assert: 全タスク完了かつキューが空になったためタイマーが停止する
+            Assert.False(timer.IsRunning);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public async Task CancelStopsTimerAndDiscardsInFlightResults()
+    {
+        // Arrange
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            var photoPath = CreateTempFile(tempDir, "photo.jpg");
+            using var generationStarted = new ManualResetEventSlim(initialState: false);
+            using var releaseGeneration = new ManualResetEventSlim(initialState: false);
+            var dispatcher = new FakeUiDispatcher();
+            using var coordinator = CreateCoordinator(dispatcher, (_, _) =>
+            {
+                generationStarted.Set();
+                releaseGeneration.Wait(WaitTimeoutMs);
+                return (Path.Combine(tempDir, "thumb.png"), 200, 100);
+            });
+
+            var item = CreateListItem(photoPath, thumbnailKey: "key1");
+            coordinator.StartGeneration(new List<PhotoListItem> { item });
+            Assert.True(generationStarted.Wait(WaitTimeoutMs));
+            var timer = dispatcher.LastTimer;
+            Assert.NotNull(timer);
+            var pendingTasks = coordinator.GetActiveTasksSnapshot();
+
+            // Act: 生成処理の実行中にキャンセル
+            coordinator.Cancel();
+            releaseGeneration.Set();
+            await Task.WhenAll(pendingTasks).ConfigureAwait(true);
+
+            // Assert: タイマーが停止し、生成済みの結果はアイテムへ適用されない
+            Assert.False(timer.IsRunning);
+            timer.FireTick();
+            Assert.Equal(string.Empty, item.ResolutionText);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    /// <summary>
+    /// 回帰テスト(タスク上書き): フォルダ切り替えで生成バッチが複数作られても旧タスクが
+    /// 失われず、Dispose() が全タスクの完了を待ってからセマフォを破棄することを検証する。
+    /// </summary>
+    [Fact]
+    public void DisposeWhileMultipleThumbnailTasksRunning_WaitsForAllAndDoesNotThrow()
+    {
+        // Arrange
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            var photo1 = CreateTempFile(tempDir, "photo1.jpg");
+            var photo2 = CreateTempFile(tempDir, "photo2.jpg");
+
+            var started = 0;
+            var completed = 0;
+            var dispatcher = new FakeUiDispatcher();
+            var coordinator = CreateCoordinator(dispatcher, (_, _) =>
+            {
+                Interlocked.Increment(ref started);
+                Thread.Sleep(40);
+                Interlocked.Increment(ref completed);
+                return (null, null, null);
+            });
+
+            // フォルダ切り替えを模擬: 1 つ目のバッチ実行中に 2 つ目のバッチを開始する
+            coordinator.StartGeneration(new List<PhotoListItem> { CreateListItem(photo1, thumbnailKey: "key1") });
+            Assert.True(SpinWait.SpinUntil(() => Volatile.Read(ref started) >= 1, WaitTimeoutMs));
+            coordinator.StartGeneration(new List<PhotoListItem> { CreateListItem(photo2, thumbnailKey: "key2") });
+            Assert.True(SpinWait.SpinUntil(() => Volatile.Read(ref started) >= 2, WaitTimeoutMs));
+
+            // Act: 2 つのバッチタスクが実行中に Dispose
+            coordinator.Dispose();
+
+            // Assert: Dispose が両バッチの生成処理の完了を待っている
+            Assert.Equal(2, Volatile.Read(ref completed));
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    /// <summary>
+    /// 回帰テスト(タイムアウト): Dispose のタイムアウトを短くして待機を超過させても
+    /// GenerateThumbnailAsync が ObjectDisposedException を捕捉し クラッシュしないことを検証する。
+    /// </summary>
+    [Fact]
+    public async Task DisposeWithTimeoutExceeded_TaskCatchesObjectDisposedExceptionAndDoesNotCrash()
+    {
+        // Arrange
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            var photoPath = CreateTempFile(tempDir, "photo.jpg");
+            var started = 0;
+            var dispatcher = new FakeUiDispatcher();
+            var coordinator = CreateCoordinator(dispatcher, (_, _) =>
+            {
+                Interlocked.Increment(ref started);
+                Thread.Sleep(200); // タイムアウト（10ms）を超過する処理
+                return (null, null, null);
+            });
+
+            // タイムアウトを極端に短くする（テスト専用フィールド）
+            coordinator.DisposeTimeout = TimeSpan.FromMilliseconds(10);
+
+            coordinator.StartGeneration(new List<PhotoListItem> { CreateListItem(photoPath, thumbnailKey: "key1") });
+            Assert.True(SpinWait.SpinUntil(() => Volatile.Read(ref started) >= 1, WaitTimeoutMs));
+            var pendingTasks = coordinator.GetActiveTasksSnapshot();
+            Assert.NotEmpty(pendingTasks);
+
+            // Act: タイムアウト前に Dispose が戻り、セマフォが先に破棄される
+            coordinator.Dispose();
+
+            // Assert: 破棄済みセマフォへの Release() で発生する ObjectDisposedException が
+            // 捕捉され、タスクが例外なく完了する（アプリがクラッシュしない）
+            await Task.WhenAll(pendingTasks).ConfigureAwait(true);
+            Assert.All(pendingTasks, task => Assert.True(task.IsCompletedSuccessfully));
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    private static ThumbnailGenerationCoordinator CreateCoordinator(
+        FakeUiDispatcher dispatcher,
+        Func<string, DateTime, (string? ThumbnailPath, int? Width, int? Height)> generateThumbnail,
+        Func<string, bool>? isJpegFile = null,
+        Func<string, CancellationToken, Task<PhotoMetadata?>>? getMetadataAsync = null)
+    {
+        return new ThumbnailGenerationCoordinator(
+            dispatcher,
+            isJpegFile ?? (_ => false),
+            generateThumbnail,
+            getMetadataAsync ?? ((_, _) => Task.FromResult<PhotoMetadata?>(null)),
+            createThumbnailImage: _ => null);
+    }
+
+    private static PhotoListItem CreateListItem(string filePath, string? thumbnailKey)
+    {
+        var photoItem = new PhotoItem(
+            filePath: filePath,
+            sizeBytes: 1000,
+            modifiedAt: DateTimeOffset.UtcNow,
+            isFolder: false);
+
+        return new PhotoListItem(photoItem, thumbnail: null, toolTipText: null, thumbnailKey: thumbnailKey);
+    }
+
+    private static PhotoListItem CreateFolderListItem(string folderPath)
+    {
+        var photoItem = new PhotoItem(
+            filePath: folderPath,
+            sizeBytes: 0,
+            modifiedAt: DateTimeOffset.UtcNow,
+            isFolder: true);
+
+        return new PhotoListItem(photoItem, thumbnail: null, toolTipText: null, thumbnailKey: "folder-key");
+    }
+
+    private static string CreateTempFile(string directory, string fileName)
+    {
+        var path = Path.Combine(directory, fileName);
+        File.WriteAllBytes(path, new byte[] { 0xFF, 0xD8, 0xFF });
+        return path;
+    }
+
+    private static string CreateTempTestDirectory()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"test-thumbnailcoordinator-{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDir);
+        return tempDir;
+    }
+
+    private static void CleanupTempDirectory(string directory)
+    {
+        if (Directory.Exists(directory))
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // ベストエフォート
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // ベストエフォート
+            }
+            catch (PathTooLongException)
+            {
+                // ベストエフォート
+            }
+            catch (IOException)
+            {
+                // ベストエフォート
+            }
+        }
+    }
+
+    private sealed class FakeUiDispatcher : IUiDispatcher
+    {
+        public FakeUiDispatcherTimer? LastTimer { get; private set; }
+
+        public bool IsAvailable => true;
+
+        public Task RunAsync(Action action)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task<T> EnqueueAsync<T>(Func<Task<T>> asyncFunc) => asyncFunc();
+
+        public bool TryEnqueue(Action action)
+        {
+            action();
+            return true;
+        }
+
+        public IUiDispatcherTimer? CreateTimer()
+        {
+            LastTimer = new FakeUiDispatcherTimer();
+            return LastTimer;
+        }
+    }
+
+    private sealed class FakeUiDispatcherTimer : IUiDispatcherTimer
+    {
+        public TimeSpan Interval { get; set; }
+
+        public bool IsRunning { get; private set; }
+
+        public event EventHandler? Tick;
+
+        public void Start() => IsRunning = true;
+
+        public void Stop() => IsRunning = false;
+
+        public void FireTick() => Tick?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media.Imaging;
 using PhotoGeoExplorer.Models;
 using PhotoGeoExplorer.Services;
 using PhotoGeoExplorer.State;
@@ -21,20 +20,13 @@ namespace PhotoGeoExplorer.Panes.FileBrowser;
 /// </summary>
 internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 {
-    private const int ThumbnailGenerationConcurrency = 3;
-    private const int ThumbnailUpdateBatchIntervalMs = 300;
-
     private readonly IFileBrowserPaneService _service;
     private readonly IFileOperationService _fileOperationService;
     private readonly IExifEditorService? _exifEditorService;
     private readonly IDialogService? _dialogService;
     private readonly IUiDispatcher _uiDispatcher;
     private readonly WorkspaceState _workspaceState;
-    private readonly SemaphoreSlim _thumbnailGenerationSemaphore = new(ThumbnailGenerationConcurrency, ThumbnailGenerationConcurrency);
-    private readonly HashSet<string> _thumbnailsInProgress = new();
-    private readonly object _thumbnailsInProgressLock = new();
-    private readonly List<(PhotoListItem Item, string? ThumbnailPath, string? Key, int Generation, int? Width, int? Height, DateTimeOffset? TakenAt, bool? HasLocation, bool IsLocationFixFailed)> _pendingThumbnailUpdates = new();
-    private readonly object _pendingThumbnailUpdatesLock = new();
+    private readonly ThumbnailGenerationCoordinator _thumbnailCoordinator;
 
     private string? _currentFolderPath;
     private string? _statusMessage;
@@ -71,14 +63,6 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     private Symbol _statusBarLocationSymbol = Symbol.Map;
     private Visibility _statusBarLocationVisibility = Visibility.Collapsed;
     private string? _statusBarLocationTooltip;
-    private int _thumbnailGenerationTotal;
-    private int _thumbnailGenerationCompleted;
-    private CancellationTokenSource? _thumbnailGenerationCts;
-    private readonly HashSet<Task> _activeThumbnailTasks = new();
-    private readonly object _activeThumbnailTasksLock = new();
-    // テストからタイムアウト値を差し替え可能にするための internal フィールド
-    internal TimeSpan ThumbnailDisposeTimeout = TimeSpan.FromSeconds(30);
-    private IUiDispatcherTimer? _thumbnailUpdateTimer;
     private Func<Task>? _openFolderAction;
     private Func<Task>? _createFolderAction;
     private Func<Task>? _renameSelectionAction;
@@ -124,6 +108,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         _folderWatcherService = folderWatcherService ?? new FolderWatcherService();
         _folderWatcherService.FolderChanged += OnFolderWatcherChanged;
         _uiDispatcher = uiDispatcher ?? new UiDispatcher();
+        _thumbnailCoordinator = new ThumbnailGenerationCoordinator(_uiDispatcher, _fileOperationService.IsJpegFile);
 
         // WorkspaceState にナビゲーションコールバックを設定
         _workspaceState.SelectNextAction = SelectNext;
@@ -1023,9 +1008,9 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
                 UpdateStatusBar();
 
                 // バックグラウンドでサムネイル生成を開始
-                // 注意: StartBackgroundThumbnailGeneration 内部で UI スレッドタイマーを構成しているため、
+                // 注意: StartGeneration 内部で UI スレッドタイマーを構成しているため、
                 //       ここでは明示的に UI スレッド上から呼び出している（UI 更新と意図を揃えるため）
-                StartBackgroundThumbnailGeneration();
+                _thumbnailCoordinator.StartGeneration(Items);
                 _folderWatcherService.Watch(folderPath);
             }).ConfigureAwait(false);
 
@@ -1317,18 +1302,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         ConfigureUiActionHandlers(null, null, null, null, null, null);
         _folderWatcherService.FolderChanged -= OnFolderWatcherChanged;
         _folderWatcherService.Dispose();
-        CancelThumbnailGeneration();
-        // フォルダ切り替えで生成バッチが複数回作られた場合も含め、全アクティブタスクの
-        // 完了を待ってからセマフォを破棄する。タイムアウト時は後続の Release() が
-        // ObjectDisposedException になりうるが、GenerateThumbnailAsync 内で捕捉される。
-        Task[] pendingTasks;
-        lock (_activeThumbnailTasksLock)
-        {
-            pendingTasks = [.. _activeThumbnailTasks];
-        }
-
-        try { Task.WhenAll(pendingTasks).Wait(ThumbnailDisposeTimeout); }
-        catch (AggregateException) { }
+        _thumbnailCoordinator.Dispose();
         CancelMetadataLoad();
         CancelFolderLoad();
         StopMoveProgressTimer();
@@ -1337,7 +1311,6 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         StopCopyProgressTimer();
         _copyCts?.Cancel();
         _copyCts?.Dispose();
-        _thumbnailGenerationSemaphore.Dispose();
     }
 
     private void OnWorkspacePhotoFocusRequested(object? sender, WorkspacePhotoFocusRequestedEventArgs e)
@@ -1676,257 +1649,6 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         }
     }
 
-    private void StartBackgroundThumbnailGeneration()
-    {
-        // 既存の生成処理をキャンセル
-        CancelThumbnailGeneration();
-
-        // テスト環境またはUIスレッドがない場合はスキップ
-        if (!_uiDispatcher.IsAvailable)
-        {
-            return;
-        }
-
-        // サムネイルが未生成のアイテムを収集
-        var itemsNeedingThumbnails = Items
-            .Where(item => !item.IsFolder && item.Thumbnail is null && item.ThumbnailKey is not null)
-            .ToList();
-
-        if (itemsNeedingThumbnails.Count == 0)
-        {
-            return;
-        }
-
-        // カウンターを初期化
-        _thumbnailGenerationTotal = itemsNeedingThumbnails.Count;
-        _thumbnailGenerationCompleted = 0;
-
-        // 更新タイマーの初期化（IsAvailable 確認済みのため CreateTimer は非 null を返す）
-        var thumbnailUpdateTimer = _uiDispatcher.CreateTimer();
-        if (thumbnailUpdateTimer is null)
-        {
-            return;
-        }
-
-        _thumbnailUpdateTimer = thumbnailUpdateTimer;
-        _thumbnailUpdateTimer.Interval = TimeSpan.FromMilliseconds(ThumbnailUpdateBatchIntervalMs);
-        _thumbnailUpdateTimer.Tick += OnThumbnailUpdateTimerTick;
-        _thumbnailUpdateTimer.Start();
-
-        // 新しいキャンセルトークンを作成
-        var cts = new CancellationTokenSource();
-        _thumbnailGenerationCts = cts;
-        // cts が後で破棄されても Token プロパティへのアクセスで ObjectDisposedException が
-        // 発生しないよう、Task.Run 前にトークン値をキャプチャする（Select は lazy なので
-        // Task.WhenAll 反復時点で cts が破棄済みになりうる）
-        var token = cts.Token;
-
-        AppLog.Info($"StartBackgroundThumbnailGeneration: Starting generation for {itemsNeedingThumbnails.Count} items");
-
-        // バックグラウンドで並列生成開始
-        // フォルダ切り替えで旧バッチがキャンセルされても ThumbnailService.GenerateThumbnail（同期・非キャンセル）
-        // が実行中の場合は完了まで継続する。Dispose() でセマフォを破棄する前に全タスクの完了を保証するため
-        // _activeThumbnailTasks に登録し、完了時に自己削除する。
-        var task = Task.Run(async () =>
-        {
-            try
-            {
-                var tasks = itemsNeedingThumbnails.Select(listItem => GenerateThumbnailAsync(listItem, token));
-                await Task.WhenAll(tasks).ConfigureAwait(false);
-                AppLog.Info("StartBackgroundThumbnailGeneration: Completed");
-            }
-            catch (OperationCanceledException)
-            {
-                // キャンセル済み - 正常終了
-            }
-        }, token);
-
-        lock (_activeThumbnailTasksLock)
-        {
-            _activeThumbnailTasks.Add(task);
-        }
-
-        _ = task.ContinueWith(_ =>
-        {
-            lock (_activeThumbnailTasksLock)
-            {
-                _activeThumbnailTasks.Remove(task);
-            }
-        }, TaskScheduler.Default);
-    }
-
-    private async Task GenerateThumbnailAsync(PhotoListItem listItem, CancellationToken cancellationToken)
-    {
-        if (cancellationToken.IsCancellationRequested)
-        {
-            return;
-        }
-
-        var key = listItem.ThumbnailKey;
-        if (key is null)
-        {
-            return;
-        }
-
-        // 重複生成を防止
-        lock (_thumbnailsInProgressLock)
-        {
-            if (_thumbnailsInProgress.Contains(key))
-            {
-                return;
-            }
-
-            _thumbnailsInProgress.Add(key);
-        }
-
-        try
-        {
-            // セマフォで並列数を制限
-            await _thumbnailGenerationSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-            try
-            {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    return;
-                }
-
-                // サムネイル生成（バックグラウンドスレッド）
-                var fileInfo = new FileInfo(listItem.FilePath);
-                if (!fileInfo.Exists)
-                {
-                    return;
-                }
-
-                var result = ThumbnailService.GenerateThumbnail(listItem.FilePath, fileInfo.LastWriteTimeUtc);
-                if (result.ThumbnailPath is null || cancellationToken.IsCancellationRequested)
-                {
-                    return;
-                }
-
-                DateTimeOffset? takenAt = null;
-                bool? hasLocation = null;
-                var isLocationFixFailed = false;
-                if (IsJpegFile(listItem))
-                {
-                    var metadata = await ExifService.GetMetadataAsync(listItem.FilePath, cancellationToken).ConfigureAwait(false);
-                    if (metadata is not null)
-                    {
-                        takenAt = metadata.TakenAt;
-                        hasLocation = metadata.HasValidLocation;
-                        isLocationFixFailed = metadata.IsLikelyLocationFixFailed;
-                    }
-                }
-
-                // UIスレッドで BitmapImage を作成して更新をキューに追加
-                lock (_pendingThumbnailUpdatesLock)
-                {
-                    _pendingThumbnailUpdates.Add((listItem, result.ThumbnailPath, key, listItem.Generation, result.Width, result.Height, takenAt, hasLocation, isLocationFixFailed));
-                }
-            }
-            finally
-            {
-                // タイムアウト時に Dispose() がセマフォを先に破棄した場合の安全網
-                try { _thumbnailGenerationSemaphore.Release(); }
-                catch (ObjectDisposedException) { }
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            // キャンセルは正常
-        }
-        catch (ObjectDisposedException)
-        {
-            // WaitAsync 待機中に Dispose() でセマフォが破棄された場合
-        }
-        catch (UnauthorizedAccessException ex)
-        {
-            AppLog.Error($"GenerateThumbnailAsync: Access denied for {listItem.FileName}", ex);
-        }
-        catch (IOException ex)
-        {
-            AppLog.Error($"GenerateThumbnailAsync: IO error for {listItem.FileName}", ex);
-        }
-        catch (NotSupportedException ex)
-        {
-            AppLog.Error($"GenerateThumbnailAsync: Unsupported operation for {listItem.FileName}", ex);
-        }
-        finally
-        {
-            lock (_thumbnailsInProgressLock)
-            {
-                _thumbnailsInProgress.Remove(key);
-            }
-
-            // 完了カウントをインクリメント
-            Interlocked.Increment(ref _thumbnailGenerationCompleted);
-        }
-    }
-
-    private void OnThumbnailUpdateTimerTick(object? sender, EventArgs e)
-    {
-        ApplyPendingThumbnailUpdates();
-    }
-
-    private void ApplyPendingThumbnailUpdates()
-    {
-        // まず、生成完了チェックを実行（キューの有無に関わらず）
-        var shouldStopTimer = Volatile.Read(ref _thumbnailGenerationCompleted) >= _thumbnailGenerationTotal;
-
-        List<(PhotoListItem Item, string? ThumbnailPath, string? Key, int Generation, int? Width, int? Height, DateTimeOffset? TakenAt, bool? HasLocation, bool IsLocationFixFailed)> updates;
-
-        lock (_pendingThumbnailUpdatesLock)
-        {
-            // キューが空の場合、完了チェックのみ実行
-            if (_pendingThumbnailUpdates.Count == 0)
-            {
-                if (shouldStopTimer && _thumbnailUpdateTimer is not null)
-                {
-                    _thumbnailUpdateTimer.Stop();
-                    AppLog.Info("ApplyPendingThumbnailUpdates: All thumbnail generation tasks finished, stopping timer (queue empty)");
-                }
-                return;
-            }
-
-            updates = new List<(PhotoListItem, string?, string?, int, int?, int?, DateTimeOffset?, bool?, bool)>(_pendingThumbnailUpdates);
-            _pendingThumbnailUpdates.Clear();
-        }
-
-        var successCount = 0;
-        var metadataUpdatedCount = 0;
-        foreach (var (item, thumbnailPath, key, generation, width, height, takenAt, hasLocation, isLocationFixFailed) in updates)
-        {
-            // UIスレッドでBitmapImageを作成
-            var thumbnail = CreateThumbnailImage(thumbnailPath);
-            if (item.UpdateThumbnail(thumbnail, key, generation, width, height))
-            {
-                successCount++;
-            }
-
-            if (item.UpdateMetadata(takenAt, hasLocation, isLocationFixFailed))
-            {
-                metadataUpdatedCount++;
-            }
-        }
-
-        if (successCount > 0 || metadataUpdatedCount > 0)
-        {
-            AppLog.Info($"ApplyPendingThumbnailUpdates: Applied {successCount} thumbnail updates and {metadataUpdatedCount} metadata updates");
-        }
-
-        // 生成完了チェック後、キューも確認してタイマーを停止
-        if (shouldStopTimer)
-        {
-            lock (_pendingThumbnailUpdatesLock)
-            {
-                if (_pendingThumbnailUpdates.Count == 0 && _thumbnailUpdateTimer is not null)
-                {
-                    _thumbnailUpdateTimer.Stop();
-                    AppLog.Info("ApplyPendingThumbnailUpdates: All thumbnail generation tasks finished, stopping timer");
-                }
-            }
-        }
-    }
-
     private void OnFolderWatcherChanged(object? sender, EventArgs e)
     {
         _uiDispatcher.TryEnqueue(async () =>
@@ -1938,73 +1660,6 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 
             await RefreshAsync().ConfigureAwait(false);
         });
-    }
-
-    private void CancelThumbnailGeneration()
-    {
-        // タイマーを停止
-        if (_thumbnailUpdateTimer is not null)
-        {
-            _thumbnailUpdateTimer.Stop();
-            _thumbnailUpdateTimer.Tick -= OnThumbnailUpdateTimerTick;
-            _thumbnailUpdateTimer = null;
-        }
-
-        // 保留中の更新をクリア
-        lock (_pendingThumbnailUpdatesLock)
-        {
-            _pendingThumbnailUpdates.Clear();
-        }
-
-        // 生成中リストをクリア
-        lock (_thumbnailsInProgressLock)
-        {
-            _thumbnailsInProgress.Clear();
-        }
-
-        // キャンセルトークンをキャンセル
-        var previousCts = _thumbnailGenerationCts;
-        _thumbnailGenerationCts = null;
-        if (previousCts is not null)
-        {
-            try
-            {
-                previousCts.Cancel();
-                previousCts.Dispose();
-            }
-            catch (ObjectDisposedException)
-            {
-                // 既に破棄済み
-            }
-        }
-    }
-
-    private static BitmapImage? CreateThumbnailImage(string? thumbnailPath)
-    {
-        if (string.IsNullOrWhiteSpace(thumbnailPath))
-        {
-            return null;
-        }
-
-        try
-        {
-            return new BitmapImage(new Uri(thumbnailPath));
-        }
-        catch (ArgumentException ex)
-        {
-            AppLog.Error($"Failed to load thumbnail image. Path: '{thumbnailPath}'", ex);
-            return null;
-        }
-        catch (IOException ex)
-        {
-            AppLog.Error($"Failed to load thumbnail image. Path: '{thumbnailPath}'", ex);
-            return null;
-        }
-        catch (UriFormatException ex)
-        {
-            AppLog.Error($"Failed to load thumbnail image. Path: '{thumbnailPath}'", ex);
-            return null;
-        }
     }
 
 }

--- a/PhotoGeoExplorer/Panes/FileBrowser/ThumbnailGenerationCoordinator.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/ThumbnailGenerationCoordinator.cs
@@ -1,0 +1,425 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Media.Imaging;
+using PhotoGeoExplorer.Models;
+using PhotoGeoExplorer.Services;
+using PhotoGeoExplorer.ViewModels;
+
+namespace PhotoGeoExplorer.Panes.FileBrowser;
+
+/// <summary>
+/// サムネイル生成サブシステムのコーディネーター。
+/// SemaphoreSlim による並列数制限、UI スレッドタイマーによるバッチ UI 更新、
+/// CancellationTokenSource のライフサイクル管理を担う。
+/// </summary>
+internal sealed class ThumbnailGenerationCoordinator : IDisposable
+{
+    private const int ThumbnailGenerationConcurrency = 3;
+    private const int ThumbnailUpdateBatchIntervalMs = 300;
+
+    private readonly IUiDispatcher _uiDispatcher;
+    private readonly Func<string, bool> _isJpegFile;
+    private readonly Func<string, DateTime, (string? ThumbnailPath, int? Width, int? Height)> _generateThumbnail;
+    private readonly Func<string, CancellationToken, Task<PhotoMetadata?>> _getMetadataAsync;
+    private readonly Func<string?, BitmapImage?> _createThumbnailImage;
+
+    private readonly SemaphoreSlim _thumbnailGenerationSemaphore = new(ThumbnailGenerationConcurrency, ThumbnailGenerationConcurrency);
+    private readonly HashSet<string> _thumbnailsInProgress = new();
+    private readonly object _thumbnailsInProgressLock = new();
+    private readonly List<(PhotoListItem Item, string? ThumbnailPath, string? Key, int Generation, int? Width, int? Height, DateTimeOffset? TakenAt, bool? HasLocation, bool IsLocationFixFailed)> _pendingThumbnailUpdates = new();
+    private readonly object _pendingThumbnailUpdatesLock = new();
+    private readonly HashSet<Task> _activeThumbnailTasks = new();
+    private readonly object _activeThumbnailTasksLock = new();
+    private int _thumbnailGenerationTotal;
+    private int _thumbnailGenerationCompleted;
+    private CancellationTokenSource? _thumbnailGenerationCts;
+    private IUiDispatcherTimer? _thumbnailUpdateTimer;
+
+    // テストからタイムアウト値を差し替え可能にするための internal フィールド
+    internal TimeSpan DisposeTimeout = TimeSpan.FromSeconds(30);
+
+    /// <param name="uiDispatcher">バッチ更新タイマーの構成に使う UI スレッドディスパッチャ。</param>
+    /// <param name="isJpegFile">EXIF メタデータ取得対象（JPEG）かどうかの判定。</param>
+    /// <param name="generateThumbnail">サムネイル生成処理。null の場合は <see cref="ThumbnailService.GenerateThumbnail"/>（テスト用シーム）。</param>
+    /// <param name="getMetadataAsync">EXIF メタデータ取得処理。null の場合は <see cref="ExifService.GetMetadataAsync"/>（テスト用シーム）。</param>
+    /// <param name="createThumbnailImage">サムネイル画像の生成処理。null の場合は BitmapImage を生成する既定実装（テスト用シーム）。</param>
+    public ThumbnailGenerationCoordinator(
+        IUiDispatcher uiDispatcher,
+        Func<string, bool> isJpegFile,
+        Func<string, DateTime, (string? ThumbnailPath, int? Width, int? Height)>? generateThumbnail = null,
+        Func<string, CancellationToken, Task<PhotoMetadata?>>? getMetadataAsync = null,
+        Func<string?, BitmapImage?>? createThumbnailImage = null)
+    {
+        ArgumentNullException.ThrowIfNull(uiDispatcher);
+        ArgumentNullException.ThrowIfNull(isJpegFile);
+
+        _uiDispatcher = uiDispatcher;
+        _isJpegFile = isJpegFile;
+        _generateThumbnail = generateThumbnail ?? ThumbnailService.GenerateThumbnail;
+        _getMetadataAsync = getMetadataAsync ?? ExifService.GetMetadataAsync;
+        _createThumbnailImage = createThumbnailImage ?? CreateThumbnailImage;
+    }
+
+    /// <summary>
+    /// サムネイル未生成のアイテムに対してバックグラウンド生成を開始する。
+    /// 進行中の生成バッチがあればキャンセルしてから開始する。
+    /// UI スレッドタイマーを構成するため、UI スレッド上から呼び出すこと。
+    /// </summary>
+    public void StartGeneration(IReadOnlyList<PhotoListItem> items)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+
+        // 既存の生成処理をキャンセル
+        Cancel();
+
+        // テスト環境またはUIスレッドがない場合はスキップ
+        if (!_uiDispatcher.IsAvailable)
+        {
+            return;
+        }
+
+        // サムネイルが未生成のアイテムを収集
+        var itemsNeedingThumbnails = items
+            .Where(item => !item.IsFolder && item.Thumbnail is null && item.ThumbnailKey is not null)
+            .ToList();
+
+        if (itemsNeedingThumbnails.Count == 0)
+        {
+            return;
+        }
+
+        // カウンターを初期化
+        _thumbnailGenerationTotal = itemsNeedingThumbnails.Count;
+        _thumbnailGenerationCompleted = 0;
+
+        // 更新タイマーの初期化（IsAvailable 確認済みのため CreateTimer は非 null を返す）
+        var thumbnailUpdateTimer = _uiDispatcher.CreateTimer();
+        if (thumbnailUpdateTimer is null)
+        {
+            return;
+        }
+
+        _thumbnailUpdateTimer = thumbnailUpdateTimer;
+        _thumbnailUpdateTimer.Interval = TimeSpan.FromMilliseconds(ThumbnailUpdateBatchIntervalMs);
+        _thumbnailUpdateTimer.Tick += OnThumbnailUpdateTimerTick;
+        _thumbnailUpdateTimer.Start();
+
+        // 新しいキャンセルトークンを作成
+        var cts = new CancellationTokenSource();
+        _thumbnailGenerationCts = cts;
+        // cts が後で破棄されても Token プロパティへのアクセスで ObjectDisposedException が
+        // 発生しないよう、Task.Run 前にトークン値をキャプチャする（Select は lazy なので
+        // Task.WhenAll 反復時点で cts が破棄済みになりうる）
+        var token = cts.Token;
+
+        AppLog.Info($"ThumbnailGenerationCoordinator.StartGeneration: Starting generation for {itemsNeedingThumbnails.Count} items");
+
+        // バックグラウンドで並列生成開始
+        // フォルダ切り替えで旧バッチがキャンセルされても生成処理（同期・非キャンセル）
+        // が実行中の場合は完了まで継続する。Dispose() でセマフォを破棄する前に全タスクの完了を保証するため
+        // _activeThumbnailTasks に登録し、完了時に自己削除する。
+        var task = Task.Run(async () =>
+        {
+            try
+            {
+                var tasks = itemsNeedingThumbnails.Select(listItem => GenerateThumbnailAsync(listItem, token));
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+                AppLog.Info("ThumbnailGenerationCoordinator.StartGeneration: Completed");
+            }
+            catch (OperationCanceledException)
+            {
+                // キャンセル済み - 正常終了
+            }
+        }, token);
+
+        lock (_activeThumbnailTasksLock)
+        {
+            _activeThumbnailTasks.Add(task);
+        }
+
+        _ = task.ContinueWith(_ =>
+        {
+            lock (_activeThumbnailTasksLock)
+            {
+                _activeThumbnailTasks.Remove(task);
+            }
+        }, TaskScheduler.Default);
+    }
+
+    /// <summary>
+    /// 進行中の生成バッチをキャンセルし、タイマー・保留中更新・生成中リストをクリアする。
+    /// </summary>
+    public void Cancel()
+    {
+        // タイマーを停止
+        if (_thumbnailUpdateTimer is not null)
+        {
+            _thumbnailUpdateTimer.Stop();
+            _thumbnailUpdateTimer.Tick -= OnThumbnailUpdateTimerTick;
+            _thumbnailUpdateTimer = null;
+        }
+
+        // 保留中の更新をクリア
+        lock (_pendingThumbnailUpdatesLock)
+        {
+            _pendingThumbnailUpdates.Clear();
+        }
+
+        // 生成中リストをクリア
+        lock (_thumbnailsInProgressLock)
+        {
+            _thumbnailsInProgress.Clear();
+        }
+
+        // キャンセルトークンをキャンセル
+        var previousCts = _thumbnailGenerationCts;
+        _thumbnailGenerationCts = null;
+        if (previousCts is not null)
+        {
+            try
+            {
+                previousCts.Cancel();
+                previousCts.Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+                // 既に破棄済み
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        Cancel();
+        // フォルダ切り替えで生成バッチが複数回作られた場合も含め、全アクティブタスクの
+        // 完了を待ってからセマフォを破棄する。タイムアウト時は後続の Release() が
+        // ObjectDisposedException になりうるが、GenerateThumbnailAsync 内で捕捉される。
+        Task[] pendingTasks;
+        lock (_activeThumbnailTasksLock)
+        {
+            pendingTasks = [.. _activeThumbnailTasks];
+        }
+
+        try { Task.WhenAll(pendingTasks).Wait(DisposeTimeout); }
+        catch (AggregateException) { }
+        _thumbnailGenerationSemaphore.Dispose();
+    }
+
+    /// <summary>
+    /// テスト用: アクティブな生成タスクのスナップショットを返す。
+    /// Dispose のタイムアウト超過後にタスクが安全に完了することを検証するために使う。
+    /// </summary>
+    internal Task[] GetActiveTasksSnapshot()
+    {
+        lock (_activeThumbnailTasksLock)
+        {
+            return [.. _activeThumbnailTasks];
+        }
+    }
+
+    private async Task GenerateThumbnailAsync(PhotoListItem listItem, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        var key = listItem.ThumbnailKey;
+        if (key is null)
+        {
+            return;
+        }
+
+        // 重複生成を防止
+        lock (_thumbnailsInProgressLock)
+        {
+            if (_thumbnailsInProgress.Contains(key))
+            {
+                return;
+            }
+
+            _thumbnailsInProgress.Add(key);
+        }
+
+        try
+        {
+            // セマフォで並列数を制限
+            await _thumbnailGenerationSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                // サムネイル生成（バックグラウンドスレッド）
+                var fileInfo = new FileInfo(listItem.FilePath);
+                if (!fileInfo.Exists)
+                {
+                    return;
+                }
+
+                var result = _generateThumbnail(listItem.FilePath, fileInfo.LastWriteTimeUtc);
+                if (result.ThumbnailPath is null || cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                DateTimeOffset? takenAt = null;
+                bool? hasLocation = null;
+                var isLocationFixFailed = false;
+                if (IsJpegFile(listItem))
+                {
+                    var metadata = await _getMetadataAsync(listItem.FilePath, cancellationToken).ConfigureAwait(false);
+                    if (metadata is not null)
+                    {
+                        takenAt = metadata.TakenAt;
+                        hasLocation = metadata.HasValidLocation;
+                        isLocationFixFailed = metadata.IsLikelyLocationFixFailed;
+                    }
+                }
+
+                // UIスレッドで BitmapImage を作成して更新をキューに追加
+                lock (_pendingThumbnailUpdatesLock)
+                {
+                    _pendingThumbnailUpdates.Add((listItem, result.ThumbnailPath, key, listItem.Generation, result.Width, result.Height, takenAt, hasLocation, isLocationFixFailed));
+                }
+            }
+            finally
+            {
+                // タイムアウト時に Dispose() がセマフォを先に破棄した場合の安全網
+                try { _thumbnailGenerationSemaphore.Release(); }
+                catch (ObjectDisposedException) { }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // キャンセルは正常
+        }
+        catch (ObjectDisposedException)
+        {
+            // WaitAsync 待機中に Dispose() でセマフォが破棄された場合
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            AppLog.Error($"GenerateThumbnailAsync: Access denied for {listItem.FileName}", ex);
+        }
+        catch (IOException ex)
+        {
+            AppLog.Error($"GenerateThumbnailAsync: IO error for {listItem.FileName}", ex);
+        }
+        catch (NotSupportedException ex)
+        {
+            AppLog.Error($"GenerateThumbnailAsync: Unsupported operation for {listItem.FileName}", ex);
+        }
+        finally
+        {
+            lock (_thumbnailsInProgressLock)
+            {
+                _thumbnailsInProgress.Remove(key);
+            }
+
+            // 完了カウントをインクリメント
+            Interlocked.Increment(ref _thumbnailGenerationCompleted);
+        }
+    }
+
+    private bool IsJpegFile(PhotoListItem item)
+        => !item.IsFolder && _isJpegFile(item.FilePath);
+
+    private void OnThumbnailUpdateTimerTick(object? sender, EventArgs e)
+    {
+        ApplyPendingThumbnailUpdates();
+    }
+
+    private void ApplyPendingThumbnailUpdates()
+    {
+        // まず、生成完了チェックを実行（キューの有無に関わらず）
+        var shouldStopTimer = Volatile.Read(ref _thumbnailGenerationCompleted) >= _thumbnailGenerationTotal;
+
+        List<(PhotoListItem Item, string? ThumbnailPath, string? Key, int Generation, int? Width, int? Height, DateTimeOffset? TakenAt, bool? HasLocation, bool IsLocationFixFailed)> updates;
+
+        lock (_pendingThumbnailUpdatesLock)
+        {
+            // キューが空の場合、完了チェックのみ実行
+            if (_pendingThumbnailUpdates.Count == 0)
+            {
+                if (shouldStopTimer && _thumbnailUpdateTimer is not null)
+                {
+                    _thumbnailUpdateTimer.Stop();
+                    AppLog.Info("ApplyPendingThumbnailUpdates: All thumbnail generation tasks finished, stopping timer (queue empty)");
+                }
+                return;
+            }
+
+            updates = new List<(PhotoListItem, string?, string?, int, int?, int?, DateTimeOffset?, bool?, bool)>(_pendingThumbnailUpdates);
+            _pendingThumbnailUpdates.Clear();
+        }
+
+        var successCount = 0;
+        var metadataUpdatedCount = 0;
+        foreach (var (item, thumbnailPath, key, generation, width, height, takenAt, hasLocation, isLocationFixFailed) in updates)
+        {
+            // UIスレッドでBitmapImageを作成
+            var thumbnail = _createThumbnailImage(thumbnailPath);
+            if (item.UpdateThumbnail(thumbnail, key, generation, width, height))
+            {
+                successCount++;
+            }
+
+            if (item.UpdateMetadata(takenAt, hasLocation, isLocationFixFailed))
+            {
+                metadataUpdatedCount++;
+            }
+        }
+
+        if (successCount > 0 || metadataUpdatedCount > 0)
+        {
+            AppLog.Info($"ApplyPendingThumbnailUpdates: Applied {successCount} thumbnail updates and {metadataUpdatedCount} metadata updates");
+        }
+
+        // 生成完了チェック後、キューも確認してタイマーを停止
+        if (shouldStopTimer)
+        {
+            lock (_pendingThumbnailUpdatesLock)
+            {
+                if (_pendingThumbnailUpdates.Count == 0 && _thumbnailUpdateTimer is not null)
+                {
+                    _thumbnailUpdateTimer.Stop();
+                    AppLog.Info("ApplyPendingThumbnailUpdates: All thumbnail generation tasks finished, stopping timer");
+                }
+            }
+        }
+    }
+
+    private static BitmapImage? CreateThumbnailImage(string? thumbnailPath)
+    {
+        if (string.IsNullOrWhiteSpace(thumbnailPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            return new BitmapImage(new Uri(thumbnailPath));
+        }
+        catch (ArgumentException ex)
+        {
+            AppLog.Error($"Failed to load thumbnail image. Path: '{thumbnailPath}'", ex);
+            return null;
+        }
+        catch (IOException ex)
+        {
+            AppLog.Error($"Failed to load thumbnail image. Path: '{thumbnailPath}'", ex);
+            return null;
+        }
+        catch (UriFormatException ex)
+        {
+            AppLog.Error($"Failed to load thumbnail image. Path: '{thumbnailPath}'", ex);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## 要約

#150 Phase 1 の第 2 弾（#153）。`FileBrowserPaneViewModel` 内で最大の独立した責務だったサムネイル生成サブシステム（約 350 行 + フィールド群）を `Panes/FileBrowser/ThumbnailGenerationCoordinator.cs`（internal sealed, IDisposable）へ分離しました。

## 変更内容

### 実装
- `ThumbnailGenerationCoordinator` を新設し、以下を VM から移動
  - メソッド: `StartBackgroundThumbnailGeneration`（→ `StartGeneration`）/ `GenerateThumbnailAsync` / `OnThumbnailUpdateTimerTick` / `ApplyPendingThumbnailUpdates` / `CancelThumbnailGeneration`（→ `Cancel`）/ `CreateThumbnailImage`
  - フィールド: `_thumbnailGenerationSemaphore` / `_thumbnailsInProgress` / `_pendingThumbnailUpdates` / `_activeThumbnailTasks` / `_thumbnailGenerationCts` / `_thumbnailUpdateTimer` / 進捗カウンタ / `ThumbnailDisposeTimeout`（→ `DisposeTimeout`）と各 lock オブジェクト
  - 定数: `ThumbnailGenerationConcurrency` / `ThumbnailUpdateBatchIntervalMs`
- VM は `StartGeneration(Items)` / `Dispose()` を呼ぶだけに簡素化（#152 で導入した `IUiDispatcher` 経由でタイマー・UI 更新）
- **#147 / #137 の並行処理対策を維持**: Task.Run 前のトークンキャプチャ、`_activeThumbnailTasks` による Dispose 時の完了待ち、`ObjectDisposedException` の安全網と既存コメントをそのまま移設
- テスト用シームとして `isJpegFile` / `generateThumbnail` / `getMetadataAsync` / `createThumbnailImage` をコンストラクタ注入可能に（既定は従来どおり `ThumbnailService` / `ExifService` の静的呼び出し）

### テスト
- #147 回帰テスト 2 件（`DisposeWhileMultipleThumbnailTasksRunning_WaitsForAllAndDoesNotThrow` / `DisposeWithTimeoutExceeded_TaskCatchesObjectDisposedExceptionAndDoesNotCrash`）を `BindingFlags.NonPublic` リフレクションから Coordinator の公開 API（コンストラクタ注入・internal メンバー）経由のテストへ書き換え、`ThumbnailGenerationCoordinatorTests.cs` へ移設
- VM 経由では書きにくかった並行制御の単体テストを追加
  - 生成対象フィルタ（フォルダ・キー無しアイテムの除外）
  - セマフォによる並列数制限（最大 3）
  - タイマー Tick によるバッチ更新適用と完了時のタイマー停止
  - キャンセル時のタイマー停止・実行中結果の破棄

## 受け入れ条件の確認

- [x] `FileBrowserPaneViewModel` からサムネイル関連のフィールド・メソッドが消えている
- [x] #147 回帰テスト 2 件が公開 API 経由に書き換えられ、リフレクションが排除されている
- [x] 並行制御（セマフォ・バッチ更新・キャンセル）の単体テストを Coordinator に対して追加
- [x] `dotnet build` / `dotnet test`（Release, x64）成功

## 検証方法

```
dotnet build PhotoGeoExplorer.sln -c Release -p:Platform=x64   # 0 警告 / 0 エラー
dotnet test PhotoGeoExplorer.sln -c Release -p:Platform=x64    # 522 件合格（E2E 3 件は環境変数未設定でスキップ）
dotnet format PhotoGeoExplorer.sln --verify-no-changes         # 差分なし
```

フォルダ切り替え連打・アプリ終了時のクラッシュ回帰（#147）は、Dispose 系回帰テスト 2 件で検証済みです。

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)