### PR TITLE
refactor: FileBrowserPaneViewModel からファイル操作・進捗・クリップボード管理を FileOperationCoordinator に分離 (#154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ## [Unreleased]
 
 ### リファクタリング
+- ファイル操作・進捗・クリップボード管理を `FileBrowserPaneViewModel` から `FileOperationCoordinator` へ分離 (#154)
+  - Move/Copy でほぼ同一だった進捗管理（CTS・進捗タイマー・カウンタ・キャンセルコマンド連携）を、操作種別（進捗メッセージのリソースキー・進捗状態通知）をパラメータ化した共通実装 `ExecuteTransferAsync` に統一
+  - クリップボード状態（項目・Cut/Copy 種別・Cut 全件成功時のクリア判定）を Coordinator へ移動。`IsMoveInProgress` / `IsCopyInProgress` / `CanPasteSelection` 等の XAML バインディングは ViewModel のプロパティとして維持し、コンストラクタ注入のコールバックで変更通知を中継
+  - #137 で入れた CancelCommand との race 対策（`finally` 内の UI スレッド集約）は共通実装でも維持。競合解決コールバックの UI スレッド marshal も `IUiDispatcher` 経由のまま
+  - 操作完了後の `RefreshAsync` 呼び出し・選択復元・完了メッセージ表示は ViewModel 側の責務として残し（共通ヘルパー `FinishTransferAsync` に集約）、`ExecuteXxx` 系の internal シグネチャは View からの呼び出し口として維持（既存テストは VM 経由のまま全件パス）
+  - 統一後の共通進捗実装・キャンセル連携・クリップボード管理・バリデーションを直接検証する `FileOperationCoordinatorTests`（28 件、Move/Copy はパラメータ化テストで対称検証）を新設
 - サムネイル生成処理を `FileBrowserPaneViewModel` から `ThumbnailGenerationCoordinator` へ分離 (#153)
   - SemaphoreSlim による並列数制限・UI スレッドタイマーによるバッチ更新・CancellationTokenSource 管理を `Panes/FileBrowser/ThumbnailGenerationCoordinator.cs`（internal sealed, IDisposable）へ移動。ViewModel は `StartGeneration` / `Dispose` を呼ぶだけになった
   - #147 / #137 で入れた並行処理対策（Task.Run 前のトークンキャプチャ、Dispose 時の全タスク完了待ち、ObjectDisposedException の安全網）は移動先でも維持

--- a/PhotoGeoExplorer.Tests/FileOperationCoordinatorTests.cs
+++ b/PhotoGeoExplorer.Tests/FileOperationCoordinatorTests.cs
@@ -1,0 +1,581 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using PhotoGeoExplorer.Models;
+using PhotoGeoExplorer.Panes.FileBrowser;
+using PhotoGeoExplorer.Services;
+using PhotoGeoExplorer.ViewModels;
+using Xunit;
+
+namespace PhotoGeoExplorer.Tests;
+
+/// <summary>
+/// FileOperationCoordinator のテスト。
+/// Move/Copy 統一後の共通進捗実装（CTS・進捗タイマー・カウンタ・キャンセル連携）と
+/// クリップボード状態管理・バリデーションを Coordinator 直接で検証する。
+/// </summary>
+public sealed class FileOperationCoordinatorTests
+{
+    public enum TransferKind { Move, Copy }
+
+    private static readonly bool[] ExpectedInProgressLifecycle = { true, false };
+
+    // =========================================================
+    // Move/Copy 共通進捗実装
+    // =========================================================
+
+    [Theory]
+    [InlineData(TransferKind.Move)]
+    [InlineData(TransferKind.Copy)]
+    public async Task Transfer_WithoutConflictCallback_UsesSyncPathWithoutProgress(TransferKind kind)
+    {
+        var harness = new CoordinatorHarness();
+        var items = new List<PhotoListItem> { CreatePhotoListItem("photo.jpg") };
+
+        var summary = await TransferAsync(harness.Coordinator, kind, items, resolveConflictAsync: null);
+
+        Assert.Equal(1, summary.SuccessCount);
+        Assert.Equal(kind == TransferKind.Move ? 1 : 0, harness.Service.MoveItemsCallCount);
+        Assert.Equal(kind == TransferKind.Copy ? 1 : 0, harness.Service.CopyItemsCallCount);
+        Assert.Empty(harness.InProgressChanges(kind));
+        Assert.Null(harness.Dispatcher.LastTimer);
+    }
+
+    [Theory]
+    [InlineData(TransferKind.Move)]
+    [InlineData(TransferKind.Copy)]
+    public async Task Transfer_WithConflictCallback_NotifiesProgressLifecycle(TransferKind kind)
+    {
+        var harness = new CoordinatorHarness();
+        var items = new List<PhotoListItem> { CreatePhotoListItem("photo.jpg") };
+
+        var summary = await TransferAsync(
+            harness.Coordinator, kind, items, (_, _) => Task.FromResult(ConflictResolution.Skip));
+
+        Assert.Equal(1, summary.SuccessCount);
+        Assert.Equal(ExpectedInProgressLifecycle, harness.InProgressChanges(kind));
+        Assert.False(kind == TransferKind.Move
+            ? harness.Coordinator.IsMoveInProgress
+            : harness.Coordinator.IsCopyInProgress);
+
+        // 進捗タイマーが構成され、転送完了後に停止している
+        Assert.NotNull(harness.Dispatcher.LastTimer);
+        Assert.False(harness.Dispatcher.LastTimer!.IsRunning);
+    }
+
+    [Theory]
+    [InlineData(TransferKind.Move, "Message.MoveProgress")]
+    [InlineData(TransferKind.Copy, "Message.CopyProgress")]
+    public async Task Transfer_ProgressTimerTick_ReportsStatusBarTextWithOperationSpecificKey(TransferKind kind, string expectedResourceKey)
+    {
+        var harness = new CoordinatorHarness();
+        var items = new List<PhotoListItem> { CreatePhotoListItem("photo.jpg") };
+        harness.Service.TransferAsyncHook = (_, _) =>
+        {
+            harness.Dispatcher.LastTimer?.FireTick();
+            return Task.FromResult(new FileOperationSummary(1, 0, Array.Empty<FileOperationFailure>()));
+        };
+
+        await TransferAsync(harness.Coordinator, kind, items, (_, _) => Task.FromResult(ConflictResolution.Skip));
+
+        // テストホストでは LocalizationService.Format がリソースキーをそのまま返すため、
+        // 操作種別に対応するリソースキーで進捗メッセージが通知されたことを検証する
+        var statusText = Assert.Single(harness.StatusBarTexts);
+        Assert.Equal(expectedResourceKey, statusText);
+    }
+
+    [Theory]
+    [InlineData(TransferKind.Move)]
+    [InlineData(TransferKind.Copy)]
+    public async Task Transfer_ConflictCallback_IsMarshalledThroughUiDispatcher(TransferKind kind)
+    {
+        var harness = new CoordinatorHarness();
+        var items = new List<PhotoListItem> { CreatePhotoListItem("photo.jpg") };
+        harness.Service.TransferAsyncHook = async (_, resolveConflictAsync) =>
+        {
+            var resolution = await resolveConflictAsync("photo.jpg", false).ConfigureAwait(false);
+            Assert.Equal(ConflictResolution.Overwrite, resolution);
+            return new FileOperationSummary(1, 0, Array.Empty<FileOperationFailure>());
+        };
+
+        await TransferAsync(
+            harness.Coordinator, kind, items, (_, _) => Task.FromResult(ConflictResolution.Overwrite));
+
+        Assert.Equal(1, harness.Dispatcher.EnqueueAsyncCallCount);
+    }
+
+    [Theory]
+    [InlineData(TransferKind.Move)]
+    [InlineData(TransferKind.Copy)]
+    public async Task Cancel_DuringTransfer_CancelsTokenAndCompletesLifecycle(TransferKind kind)
+    {
+        var harness = new CoordinatorHarness();
+        var items = new List<PhotoListItem> { CreatePhotoListItem("photo.jpg") };
+        using var transferStarted = new SemaphoreSlim(0, 1);
+        CancellationToken observedToken = default;
+        harness.Service.TransferAsyncTokenHook = async (token, _) =>
+        {
+            observedToken = token;
+            transferStarted.Release();
+            await Task.Delay(Timeout.Infinite, token).ConfigureAwait(false);
+            return new FileOperationSummary(1, 0, Array.Empty<FileOperationFailure>());
+        };
+
+        var transferTask = TransferAsync(
+            harness.Coordinator, kind, items, (_, _) => Task.FromResult(ConflictResolution.Skip));
+        Assert.True(await transferStarted.WaitAsync(5000));
+
+        if (kind == TransferKind.Move)
+        {
+            await harness.Coordinator.CancelMoveAsync();
+        }
+        else
+        {
+            await harness.Coordinator.CancelCopyAsync();
+        }
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => transferTask);
+        Assert.True(observedToken.IsCancellationRequested);
+
+        // キャンセル後も #137 の finally 集約で進捗状態が解除される
+        Assert.Equal(ExpectedInProgressLifecycle, harness.InProgressChanges(kind));
+        Assert.False(kind == TransferKind.Move
+            ? harness.Coordinator.IsMoveInProgress
+            : harness.Coordinator.IsCopyInProgress);
+    }
+
+    [Fact]
+    public async Task Cancel_WithoutRunningTransfer_DoesNotThrow()
+    {
+        var harness = new CoordinatorHarness();
+
+        await harness.Coordinator.CancelMoveAsync();
+        await harness.Coordinator.CancelCopyAsync();
+    }
+
+    [Fact]
+    public async Task Transfer_MoveAndCopy_TrackIndependentProgressStates()
+    {
+        var harness = new CoordinatorHarness();
+        var items = new List<PhotoListItem> { CreatePhotoListItem("photo.jpg") };
+        using var transferStarted = new SemaphoreSlim(0, 1);
+        using var releaseTransfer = new SemaphoreSlim(0, 1);
+        harness.Service.TransferAsyncHook = async (_, _) =>
+        {
+            transferStarted.Release();
+            Assert.True(await releaseTransfer.WaitAsync(5000).ConfigureAwait(false));
+            return new FileOperationSummary(1, 0, Array.Empty<FileOperationFailure>());
+        };
+
+        var moveTask = harness.Coordinator.MoveItemsToFolderAsync(
+            items, Path.GetTempPath(), (_, _) => Task.FromResult(ConflictResolution.Skip));
+        Assert.True(await transferStarted.WaitAsync(5000));
+
+        // Move 実行中でも Copy の進捗状態は独立している
+        Assert.True(harness.Coordinator.IsMoveInProgress);
+        Assert.False(harness.Coordinator.IsCopyInProgress);
+
+        releaseTransfer.Release();
+        await moveTask.ConfigureAwait(true);
+        Assert.False(harness.Coordinator.IsMoveInProgress);
+    }
+
+    // =========================================================
+    // クリップボード状態管理
+    // =========================================================
+
+    [Theory]
+    [InlineData(false)] // Copy
+    [InlineData(true)]  // Cut
+    public void SetClipboard_UpdatesStateAndNotifies(bool expectedIsCut)
+    {
+        var harness = new CoordinatorHarness();
+        var items = new List<PhotoListItem> { CreatePhotoListItem("photo.jpg") };
+
+        harness.Coordinator.SetClipboard(items, expectedIsCut ? ClipboardOperation.Cut : ClipboardOperation.Copy);
+
+        Assert.True(harness.Coordinator.HasClipboardItems);
+        Assert.Equal(expectedIsCut, harness.Coordinator.IsCutClipboard);
+        Assert.Equal(1, harness.ClipboardChangedCount);
+    }
+
+    [Fact]
+    public async Task PasteAsync_EmptyClipboard_ReturnsEmptySummaryWithNoneOperation()
+    {
+        var harness = new CoordinatorHarness();
+
+        var (summary, operation) = await harness.Coordinator.PasteAsync(Path.GetTempPath());
+
+        Assert.Equal(0, summary.SuccessCount);
+        Assert.False(summary.HasFailures);
+        Assert.Equal(ClipboardOperation.None, operation);
+    }
+
+    [Fact]
+    public async Task PasteAsync_CopyOperation_ExecutesCopyAndKeepsClipboard()
+    {
+        var harness = new CoordinatorHarness();
+        harness.Coordinator.SetClipboard(
+            new List<PhotoListItem> { CreatePhotoListItem("photo.jpg") }, ClipboardOperation.Copy);
+
+        var (summary, operation) = await harness.Coordinator.PasteAsync(Path.GetTempPath());
+
+        Assert.Equal(1, summary.SuccessCount);
+        Assert.Equal(ClipboardOperation.Copy, operation);
+        Assert.Equal(1, harness.Service.CopyItemsCallCount);
+        Assert.True(harness.Coordinator.HasClipboardItems);
+    }
+
+    [Fact]
+    public async Task PasteAsync_CutOperation_AllSuccess_ClearsClipboard()
+    {
+        var harness = new CoordinatorHarness();
+        harness.Coordinator.SetClipboard(
+            new List<PhotoListItem> { CreatePhotoListItem("photo.jpg") }, ClipboardOperation.Cut);
+
+        var (summary, operation) = await harness.Coordinator.PasteAsync(Path.GetTempPath());
+
+        Assert.Equal(1, summary.SuccessCount);
+        Assert.Equal(ClipboardOperation.Cut, operation);
+        Assert.Equal(1, harness.Service.MoveItemsCallCount);
+        Assert.False(harness.Coordinator.HasClipboardItems);
+        Assert.False(harness.Coordinator.IsCutClipboard);
+        Assert.Equal(2, harness.ClipboardChangedCount); // SetClipboard + クリア
+    }
+
+    [Theory]
+    [InlineData(0, 0, 1)] // 全件失敗
+    [InlineData(1, 0, 1)] // 部分成功（失敗あり）
+    [InlineData(1, 1, 0)] // スキップあり
+    public async Task PasteAsync_CutOperation_NotAllSuccess_KeepsClipboard(int successCount, int skipCount, int failureCount)
+    {
+        var failures = new FileOperationFailure[failureCount];
+        for (var i = 0; i < failureCount; i++)
+        {
+            failures[i] = new FileOperationFailure($"path{i}", $"photo{i}.jpg", FileOperationError.AlreadyExists);
+        }
+
+        var harness = new CoordinatorHarness();
+        harness.Service.MoveItemsResult = new FileOperationSummary(successCount, skipCount, failures);
+        harness.Coordinator.SetClipboard(
+            new List<PhotoListItem> { CreatePhotoListItem("photo.jpg") }, ClipboardOperation.Cut);
+
+        await harness.Coordinator.PasteAsync(Path.GetTempPath());
+
+        Assert.True(harness.Coordinator.HasClipboardItems);
+        Assert.True(harness.Coordinator.IsCutClipboard);
+    }
+
+    // =========================================================
+    // CreateFolder / Rename バリデーション
+    // =========================================================
+
+    [Theory]
+    [InlineData("bad:name", null, nameof(FileOperationError.InvalidName))]
+    [InlineData("NewFolder", null, nameof(FileOperationError.NoParent))]
+    [InlineData("NewFolder", "", nameof(FileOperationError.NoParent))]
+    public void CreateFolder_InvalidInput_ReturnsFailureWithoutServiceCall(
+        string folderName, string? parentFolderPath, string expectedErrorName)
+    {
+        var harness = new CoordinatorHarness();
+
+        var result = harness.Coordinator.CreateFolder(parentFolderPath, folderName);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(Enum.Parse<FileOperationError>(expectedErrorName), result.Error);
+        Assert.Equal(0, harness.Service.CreateFolderCallCount);
+    }
+
+    [Fact]
+    public void CreateFolder_ValidInput_DelegatesToService()
+    {
+        var harness = new CoordinatorHarness();
+        harness.Service.CreateFolderResult = FileOperationResult.Success("created-path");
+
+        var result = harness.Coordinator.CreateFolder(Path.GetTempPath(), "NewFolder");
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("created-path", result.ResultPath);
+        Assert.Equal(1, harness.Service.CreateFolderCallCount);
+    }
+
+    [Fact]
+    public void Rename_SameName_ReturnsSuccessWithoutServiceCall()
+    {
+        var harness = new CoordinatorHarness();
+        var item = CreatePhotoListItem("photo.jpg");
+
+        var result = harness.Coordinator.Rename(item, "photo.jpg");
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.ResultPath);
+        Assert.False(harness.Service.RenameItemWasCalled);
+    }
+
+    [Fact]
+    public void Rename_InvalidName_ReturnsInvalidName()
+    {
+        var harness = new CoordinatorHarness();
+        var item = CreatePhotoListItem("photo.jpg");
+
+        var result = harness.Coordinator.Rename(item, "bad:name");
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(FileOperationError.InvalidName, result.Error);
+        Assert.False(harness.Service.RenameItemWasCalled);
+    }
+
+    [Fact]
+    public void Rename_ValidNewName_DelegatesToService()
+    {
+        var harness = new CoordinatorHarness();
+        harness.Service.RenameItemResult = FileOperationResult.Success("renamed-path");
+        var item = CreatePhotoListItem("photo.jpg");
+
+        var result = harness.Coordinator.Rename(item, "renamed.jpg");
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("renamed-path", result.ResultPath);
+        Assert.True(harness.Service.RenameItemWasCalled);
+    }
+
+    // =========================================================
+    // Dispose
+    // =========================================================
+
+    [Fact]
+    public async Task Dispose_DuringTransfer_CancelsRunningOperation()
+    {
+        var harness = new CoordinatorHarness();
+        var items = new List<PhotoListItem> { CreatePhotoListItem("photo.jpg") };
+        using var transferStarted = new SemaphoreSlim(0, 1);
+        harness.Service.TransferAsyncTokenHook = async (token, _) =>
+        {
+            transferStarted.Release();
+            await Task.Delay(Timeout.Infinite, token).ConfigureAwait(false);
+            return new FileOperationSummary(1, 0, Array.Empty<FileOperationFailure>());
+        };
+
+        var transferTask = harness.Coordinator.MoveItemsToFolderAsync(
+            items, Path.GetTempPath(), (_, _) => Task.FromResult(ConflictResolution.Skip));
+        Assert.True(await transferStarted.WaitAsync(5000));
+
+        harness.Coordinator.Dispose();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => transferTask);
+    }
+
+    // =========================================================
+    // テストヘルパー
+    // =========================================================
+
+    private static Task<FileOperationSummary> TransferAsync(
+        FileOperationCoordinator coordinator,
+        TransferKind kind,
+        IReadOnlyList<PhotoListItem> items,
+        Func<string, bool, Task<ConflictResolution>>? resolveConflictAsync)
+    {
+        return kind == TransferKind.Move
+            ? coordinator.MoveItemsToFolderAsync(items, Path.GetTempPath(), resolveConflictAsync)
+            : coordinator.CopyItemsToFolderAsync(items, Path.GetTempPath(), resolveConflictAsync);
+    }
+
+    /// <summary>
+    /// Coordinator と依存スタブ・コールバック記録をまとめたテストハーネス。
+    /// </summary>
+    private sealed class CoordinatorHarness
+    {
+        private readonly List<bool> _moveInProgressChanges = new();
+        private readonly List<bool> _copyInProgressChanges = new();
+
+        public CoordinatorHarness()
+        {
+            Coordinator = new FileOperationCoordinator(
+                Service,
+                Dispatcher,
+                onMoveInProgressChanged: _moveInProgressChanges.Add,
+                onCopyInProgressChanged: _copyInProgressChanges.Add,
+                onStatusBarTextChanged: StatusBarTexts.Add,
+                onClipboardChanged: () => ClipboardChangedCount++);
+        }
+
+        public StubFileOperationService Service { get; } = new();
+        public RecordingUiDispatcher Dispatcher { get; } = new();
+        public FileOperationCoordinator Coordinator { get; }
+        public List<string> StatusBarTexts { get; } = new();
+        public int ClipboardChangedCount { get; private set; }
+
+        public List<bool> InProgressChanges(TransferKind kind)
+            => kind == TransferKind.Move ? _moveInProgressChanges : _copyInProgressChanges;
+    }
+
+    private sealed class StubFileOperationService : IFileOperationService
+    {
+        public FileOperationResult CreateFolderResult { get; set; } = FileOperationResult.Success("result");
+        public FileOperationResult RenameItemResult { get; set; } = FileOperationResult.Success("result");
+        public FileOperationSummary MoveItemsResult { get; set; } = new(1, 0, Array.Empty<FileOperationFailure>());
+        public FileOperationSummary CopyItemsResult { get; set; } = new(1, 0, Array.Empty<FileOperationFailure>());
+        public FileOperationSummary DeleteItemsResult { get; set; } = new(1, 0, Array.Empty<FileOperationFailure>());
+        public int CreateFolderCallCount { get; private set; }
+        public bool RenameItemWasCalled { get; private set; }
+        public int MoveItemsCallCount { get; private set; }
+        public int CopyItemsCallCount { get; private set; }
+
+        /// <summary>非同期転送（Move/Copy 共通）の差し替えフック。進捗と競合解決コールバックを受け取る。</summary>
+        public Func<IProgress<int>?, Func<string, bool, Task<ConflictResolution>>, Task<FileOperationSummary>>? TransferAsyncHook { get; set; }
+
+        /// <summary>非同期転送の差し替えフック（CancellationToken 観測用）。</summary>
+        public Func<CancellationToken, IProgress<int>?, Task<FileOperationSummary>>? TransferAsyncTokenHook { get; set; }
+
+        public bool ContainsInvalidFileNameChars(string name) => name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0;
+
+        public string NormalizeName(PhotoListItem item, string newName)
+        {
+            var trimmed = newName.Trim();
+            if (item.IsFolder)
+            {
+                return trimmed;
+            }
+
+            var originalExt = Path.GetExtension(item.FileName);
+            if (string.IsNullOrEmpty(originalExt))
+            {
+                return trimmed;
+            }
+
+            var newExt = Path.GetExtension(trimmed);
+            return string.IsNullOrEmpty(newExt) ? $"{trimmed}{originalExt}" : trimmed;
+        }
+
+        public bool IsDescendantPath(string root, string candidate) => false;
+        public bool IsSamePath(string left, string right) => string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+        public string? GetParentPath(string path) => Path.GetTempPath();
+        public bool ItemExistsAtPath(string path) => false;
+        public bool FolderExistsAtPath(string path) => true;
+        public bool IsJpegFile(string filePath) => false;
+
+        public FileOperationResult CreateFolder(string parentFolder, string folderName)
+        {
+            CreateFolderCallCount++;
+            return CreateFolderResult;
+        }
+
+        public FileOperationResult RenameItem(PhotoListItem item, string normalizedName)
+        {
+            RenameItemWasCalled = true;
+            return RenameItemResult;
+        }
+
+        public FileOperationSummary MoveItems(IReadOnlyList<PhotoListItem> items, string destinationFolder)
+        {
+            MoveItemsCallCount++;
+            return MoveItemsResult;
+        }
+
+        public Task<FileOperationSummary> MoveItemsAsync(
+            IReadOnlyList<PhotoListItem> items,
+            string destinationFolder,
+            Func<string, bool, Task<ConflictResolution>> resolveConflictAsync,
+            IProgress<int>? progress = null,
+            CancellationToken cancellationToken = default)
+            => RunTransferAsync(resolveConflictAsync, progress, MoveItemsResult, cancellationToken);
+
+        public FileOperationSummary CopyItems(IReadOnlyList<PhotoListItem> items, string destinationFolder)
+        {
+            CopyItemsCallCount++;
+            return CopyItemsResult;
+        }
+
+        public Task<FileOperationSummary> CopyItemsAsync(
+            IReadOnlyList<PhotoListItem> items,
+            string destinationFolder,
+            Func<string, bool, Task<ConflictResolution>> resolveConflictAsync,
+            IProgress<int>? progress = null,
+            CancellationToken cancellationToken = default)
+            => RunTransferAsync(resolveConflictAsync, progress, CopyItemsResult, cancellationToken);
+
+        public Task<FileOperationSummary> DeleteItemsAsync(IReadOnlyList<PhotoListItem> items) => Task.FromResult(DeleteItemsResult);
+
+        private Task<FileOperationSummary> RunTransferAsync(
+            Func<string, bool, Task<ConflictResolution>> resolveConflictAsync,
+            IProgress<int>? progress,
+            FileOperationSummary defaultResult,
+            CancellationToken cancellationToken)
+        {
+            if (TransferAsyncTokenHook is not null)
+            {
+                return TransferAsyncTokenHook(cancellationToken, progress);
+            }
+
+            if (TransferAsyncHook is not null)
+            {
+                return TransferAsyncHook(progress, resolveConflictAsync);
+            }
+
+            return Task.FromResult(defaultResult);
+        }
+    }
+
+    private sealed class RecordingUiDispatcher : IUiDispatcher
+    {
+        public RecordingUiDispatcherTimer? LastTimer { get; private set; }
+        public int EnqueueAsyncCallCount { get; private set; }
+
+        public bool IsAvailable => true;
+
+        public Task RunAsync(Action action)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task<T> EnqueueAsync<T>(Func<Task<T>> asyncFunc)
+        {
+            EnqueueAsyncCallCount++;
+            return asyncFunc();
+        }
+
+        public bool TryEnqueue(Action action)
+        {
+            action();
+            return true;
+        }
+
+        public IUiDispatcherTimer? CreateTimer()
+        {
+            LastTimer = new RecordingUiDispatcherTimer();
+            return LastTimer;
+        }
+    }
+
+    private sealed class RecordingUiDispatcherTimer : IUiDispatcherTimer
+    {
+        public TimeSpan Interval { get; set; }
+
+        public bool IsRunning { get; private set; }
+
+        public event EventHandler? Tick;
+
+        public void Start() => IsRunning = true;
+
+        public void Stop() => IsRunning = false;
+
+        public void FireTick() => Tick?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static PhotoListItem CreatePhotoListItem(string fileName)
+    {
+        var photoItem = new PhotoItem(
+            filePath: $"/test/{fileName}",
+            sizeBytes: 1000,
+            modifiedAt: DateTimeOffset.UtcNow,
+            isFolder: false,
+            thumbnailPath: null,
+            pixelWidth: 100,
+            pixelHeight: 100);
+
+        return new PhotoListItem(photoItem, thumbnail: null, toolTipText: null, thumbnailKey: null);
+    }
+}

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -69,18 +69,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     private Func<Task>? _moveSelectionAction;
     private Func<Task>? _moveSelectionToParentAction;
     private Func<Task>? _deleteSelectionAction;
-    private CancellationTokenSource? _moveCts;
-    private int _moveTotal;
-    private int _moveCompleted;
-    private bool _isMoveInProgress;
-    private IUiDispatcherTimer? _moveProgressTimer;
-    private CancellationTokenSource? _copyCts;
-    private int _copyTotal;
-    private int _copyCompleted;
-    private bool _isCopyInProgress;
-    private IUiDispatcherTimer? _copyProgressTimer;
-    private IReadOnlyList<PhotoListItem> _clipboardItems = Array.Empty<PhotoListItem>();
-    private ClipboardOperation _clipboardOperation = ClipboardOperation.None;
+    private readonly FileOperationCoordinator _operationCoordinator;
     private readonly IFolderWatcherService _folderWatcherService;
 
     public FileBrowserPaneViewModel()
@@ -109,6 +98,13 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         _folderWatcherService.FolderChanged += OnFolderWatcherChanged;
         _uiDispatcher = uiDispatcher ?? new UiDispatcher();
         _thumbnailCoordinator = new ThumbnailGenerationCoordinator(_uiDispatcher, _fileOperationService.IsJpegFile);
+        _operationCoordinator = new FileOperationCoordinator(
+            _fileOperationService,
+            _uiDispatcher,
+            onMoveInProgressChanged: _ => OnMoveInProgressChanged(),
+            onCopyInProgressChanged: _ => OnCopyInProgressChanged(),
+            onStatusBarTextChanged: text => StatusBarText = text,
+            onClipboardChanged: OnClipboardChanged);
 
         // WorkspaceState にナビゲーションコールバックを設定
         _workspaceState.SelectNextAction = SelectNext;
@@ -167,8 +163,8 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         DeleteSelectionCommand = new RelayCommand(
             async () => await ExecuteUiActionAsync(_deleteSelectionAction).ConfigureAwait(false),
             () => _deleteSelectionAction is not null && CanModifySelection);
-        CancelMoveCommand = new RelayCommand(async () => await (_moveCts?.CancelAsync() ?? Task.CompletedTask).ConfigureAwait(false), () => IsMoveInProgress);
-        CancelCopyCommand = new RelayCommand(async () => await (_copyCts?.CancelAsync() ?? Task.CompletedTask).ConfigureAwait(false), () => IsCopyInProgress);
+        CancelMoveCommand = new RelayCommand(async () => await _operationCoordinator.CancelMoveAsync().ConfigureAwait(false), () => IsMoveInProgress);
+        CancelCopyCommand = new RelayCommand(async () => await _operationCoordinator.CancelCopyAsync().ConfigureAwait(false), () => IsCopyInProgress);
     }
 
     public ObservableCollection<PhotoListItem> Items { get; }
@@ -494,36 +490,16 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         private set => SetProperty(ref _statusBarText, value);
     }
 
-    public bool IsMoveInProgress
-    {
-        get => _isMoveInProgress;
-        private set
-        {
-            if (SetProperty(ref _isMoveInProgress, value))
-            {
-                OnPropertyChanged(nameof(CancelMoveVisibility));
-            }
-        }
-    }
+    public bool IsMoveInProgress => _operationCoordinator.IsMoveInProgress;
 
-    public Visibility CancelMoveVisibility => _isMoveInProgress ? Visibility.Visible : Visibility.Collapsed;
+    public Visibility CancelMoveVisibility => IsMoveInProgress ? Visibility.Visible : Visibility.Collapsed;
 
-    public bool IsCopyInProgress
-    {
-        get => _isCopyInProgress;
-        private set
-        {
-            if (SetProperty(ref _isCopyInProgress, value))
-            {
-                OnPropertyChanged(nameof(CancelCopyVisibility));
-            }
-        }
-    }
+    public bool IsCopyInProgress => _operationCoordinator.IsCopyInProgress;
 
-    public Visibility CancelCopyVisibility => _isCopyInProgress ? Visibility.Visible : Visibility.Collapsed;
+    public Visibility CancelCopyVisibility => IsCopyInProgress ? Visibility.Visible : Visibility.Collapsed;
 
-    public bool CanPasteSelection => _clipboardItems.Count > 0 && !string.IsNullOrWhiteSpace(CurrentFolderPath);
-    public bool IsCutClipboard => _clipboardOperation == ClipboardOperation.Cut;
+    public bool CanPasteSelection => _operationCoordinator.HasClipboardItems && !string.IsNullOrWhiteSpace(CurrentFolderPath);
+    public bool IsCutClipboard => _operationCoordinator.IsCutClipboard;
 
     public ICommand CancelMoveCommand { get; private set; }
     public ICommand CancelCopyCommand { get; private set; }
@@ -627,17 +603,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 
     internal async Task<FileOperationResult> ExecuteCreateFolderAsync(string folderName)
     {
-        if (_fileOperationService.ContainsInvalidFileNameChars(folderName))
-        {
-            return FileOperationResult.Failure(FileOperationError.InvalidName);
-        }
-
-        if (string.IsNullOrWhiteSpace(CurrentFolderPath))
-        {
-            return FileOperationResult.Failure(FileOperationError.NoParent);
-        }
-
-        var result = _fileOperationService.CreateFolder(CurrentFolderPath, folderName);
+        var result = _operationCoordinator.CreateFolder(CurrentFolderPath, folderName);
         if (result.IsSuccess)
         {
             await RefreshAsync().ConfigureAwait(false);
@@ -652,26 +618,13 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 
     internal async Task<FileOperationResult> ExecuteRenameAsync(PhotoListItem item, string newName)
     {
-        var normalizedName = _fileOperationService.NormalizeName(item, newName);
+        var result = _operationCoordinator.Rename(item, newName);
 
-        if (string.Equals(normalizedName, item.FileName, StringComparison.OrdinalIgnoreCase))
-        {
-            return FileOperationResult.Success();
-        }
-
-        if (_fileOperationService.ContainsInvalidFileNameChars(normalizedName))
-        {
-            return FileOperationResult.Failure(FileOperationError.InvalidName);
-        }
-
-        var result = _fileOperationService.RenameItem(item, normalizedName);
-        if (result.IsSuccess)
+        // 同名リネーム（何もしない成功）は ResultPath が null のため Refresh しない
+        if (result.IsSuccess && result.ResultPath is not null)
         {
             await RefreshAsync().ConfigureAwait(false);
-            if (result.ResultPath is not null)
-            {
-                SelectItemByPath(result.ResultPath);
-            }
+            SelectItemByPath(result.ResultPath);
         }
 
         return result;
@@ -682,91 +635,9 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         string destinationFolder,
         Func<string, bool, Task<ConflictResolution>>? resolveConflictAsync = null)
     {
-        if (resolveConflictAsync is null)
-        {
-            var summary = _fileOperationService.MoveItems(items, destinationFolder);
-            if (summary.SuccessCount > 0 || summary.SkipCount > 0)
-            {
-                await RefreshAsync().ConfigureAwait(false);
-            }
-
-            return summary;
-        }
-
-        _moveCts = new CancellationTokenSource();
-        _moveTotal = items.Count;
-        _moveCompleted = 0;
-        IsMoveInProgress = true;
-        ((RelayCommand)CancelMoveCommand).RaiseCanExecuteChanged();
-
-        StartMoveProgressTimer();
-
-        // ファイル操作はバックグラウンドスレッドで実行し UI スレッドをブロックしない。
-        // 競合ダイアログは UI スレッドへ marshal してから表示する。
-        Func<string, bool, Task<ConflictResolution>> marshalledCallback = async (name, isFolder) =>
-            await _uiDispatcher.EnqueueAsync(() => resolveConflictAsync(name, isFolder)).ConfigureAwait(false);
-
-        FileOperationSummary result;
-        try
-        {
-            var progress = new Progress<int>(completed =>
-            {
-                Interlocked.Exchange(ref _moveCompleted, completed);
-            });
-
-            result = await Task.Run(() => _fileOperationService.MoveItemsAsync(
-                items, destinationFolder, marshalledCallback, progress, _moveCts.Token))
-                .ConfigureAwait(false);
-        }
-        finally
-        {
-            // ConfigureAwait(false) により finally はバックグラウンドスレッドで実行される。
-            // 進捗タイマーの Stop()、PropertyChanged 発火、CTS の Dispose/null 化は
-            // すべて UI スレッドで行い、CancelMoveCommand との race を防ぐ（#137）。
-            await _uiDispatcher.RunAsync(() =>
-            {
-                StopMoveProgressTimer();
-                IsMoveInProgress = false;
-                ((RelayCommand)CancelMoveCommand).RaiseCanExecuteChanged();
-                _moveCts?.Dispose();
-                _moveCts = null;
-            }).ConfigureAwait(false);
-        }
-
-        if (result.SuccessCount > 0 || result.SkipCount > 0)
-        {
-            await RefreshAsync().ConfigureAwait(false);
-        }
-
-        var doneText = LocalizationService.Format(
-            "Message.MoveDone", result.SuccessCount, result.SkipCount, result.FailureCount);
-        await _uiDispatcher.RunAsync(() => StatusBarText = doneText).ConfigureAwait(false);
-
-        return result;
-    }
-
-    private void StartMoveProgressTimer()
-    {
-        var timer = _uiDispatcher.CreateTimer();
-        if (timer is null) return;
-
-        _moveProgressTimer = timer;
-        _moveProgressTimer.Interval = TimeSpan.FromMilliseconds(300);
-        _moveProgressTimer.Tick += OnMoveProgressTick;
-        _moveProgressTimer.Start();
-    }
-
-    private void StopMoveProgressTimer()
-    {
-        _moveProgressTimer?.Stop();
-        _moveProgressTimer = null;
-    }
-
-    private void OnMoveProgressTick(object? sender, EventArgs e)
-    {
-        var completed = Volatile.Read(ref _moveCompleted);
-        StatusBarText = LocalizationService.Format(
-            "Message.MoveProgress", completed, _moveTotal);
+        var summary = await _operationCoordinator.MoveItemsToFolderAsync(items, destinationFolder, resolveConflictAsync).ConfigureAwait(false);
+        await FinishTransferAsync(summary, resolveConflictAsync is null ? null : "Message.MoveDone").ConfigureAwait(false);
+        return summary;
     }
 
     internal async Task<FileOperationSummary> ExecuteCopyItemsToFolderAsync(
@@ -774,139 +645,72 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         string destinationFolder,
         Func<string, bool, Task<ConflictResolution>>? resolveConflictAsync = null)
     {
-        if (resolveConflictAsync is null)
-        {
-            var summary = _fileOperationService.CopyItems(items, destinationFolder);
-            if (summary.SuccessCount > 0 || summary.SkipCount > 0)
-            {
-                await RefreshAsync().ConfigureAwait(false);
-            }
+        var summary = await _operationCoordinator.CopyItemsToFolderAsync(items, destinationFolder, resolveConflictAsync).ConfigureAwait(false);
+        await FinishTransferAsync(summary, resolveConflictAsync is null ? null : "Message.CopyDone").ConfigureAwait(false);
+        return summary;
+    }
 
-            return summary;
-        }
-
-        _copyCts = new CancellationTokenSource();
-        _copyTotal = items.Count;
-        _copyCompleted = 0;
-        IsCopyInProgress = true;
-        ((RelayCommand)CancelCopyCommand).RaiseCanExecuteChanged();
-
-        StartCopyProgressTimer();
-
-        Func<string, bool, Task<ConflictResolution>> marshalledCallback = async (name, isFolder) =>
-            await _uiDispatcher.EnqueueAsync(() => resolveConflictAsync(name, isFolder)).ConfigureAwait(false);
-
-        FileOperationSummary result;
-        try
-        {
-            var progress = new Progress<int>(completed =>
-            {
-                Interlocked.Exchange(ref _copyCompleted, completed);
-            });
-
-            result = await Task.Run(() => _fileOperationService.CopyItemsAsync(
-                items, destinationFolder, marshalledCallback, progress, _copyCts.Token))
-                .ConfigureAwait(false);
-        }
-        finally
-        {
-            // ConfigureAwait(false) により finally はバックグラウンドスレッドで実行される。
-            // 進捗タイマーの Stop()、PropertyChanged 発火、CTS の Dispose/null 化は
-            // すべて UI スレッドで行い、CancelCopyCommand との race を防ぐ（#137）。
-            await _uiDispatcher.RunAsync(() =>
-            {
-                StopCopyProgressTimer();
-                IsCopyInProgress = false;
-                ((RelayCommand)CancelCopyCommand).RaiseCanExecuteChanged();
-                _copyCts?.Dispose();
-                _copyCts = null;
-            }).ConfigureAwait(false);
-        }
-
-        if (result.SuccessCount > 0 || result.SkipCount > 0)
+    /// <summary>
+    /// 転送（Move/Copy）完了後の共通処理。1 件でも変化があれば再読み込みし、
+    /// 進捗管理付きパス（競合解決コールバックあり）の場合は完了メッセージを表示する。
+    /// </summary>
+    private async Task FinishTransferAsync(FileOperationSummary summary, string? doneMessageResourceKey)
+    {
+        if (summary.SuccessCount > 0 || summary.SkipCount > 0)
         {
             await RefreshAsync().ConfigureAwait(false);
         }
 
-        var doneText = LocalizationService.Format(
-            "Message.CopyDone", result.SuccessCount, result.SkipCount, result.FailureCount);
-        await _uiDispatcher.RunAsync(() => StatusBarText = doneText).ConfigureAwait(false);
-
-        return result;
-    }
-
-    private void StartCopyProgressTimer()
-    {
-        var timer = _uiDispatcher.CreateTimer();
-        if (timer is null) return;
-
-        _copyProgressTimer = timer;
-        _copyProgressTimer.Interval = TimeSpan.FromMilliseconds(300);
-        _copyProgressTimer.Tick += OnCopyProgressTick;
-        _copyProgressTimer.Start();
-    }
-
-    private void StopCopyProgressTimer()
-    {
-        _copyProgressTimer?.Stop();
-        _copyProgressTimer = null;
-    }
-
-    private void OnCopyProgressTick(object? sender, EventArgs e)
-    {
-        var completed = Volatile.Read(ref _copyCompleted);
-        StatusBarText = LocalizationService.Format(
-            "Message.CopyProgress", completed, _copyTotal);
+        if (doneMessageResourceKey is not null)
+        {
+            var doneText = LocalizationService.Format(
+                doneMessageResourceKey, summary.SuccessCount, summary.SkipCount, summary.FailureCount);
+            await _uiDispatcher.RunAsync(() => StatusBarText = doneText).ConfigureAwait(false);
+        }
     }
 
     internal void SetClipboard(IReadOnlyList<PhotoListItem> items, ClipboardOperation operation)
     {
-        _clipboardItems = items.ToList();
-        _clipboardOperation = operation;
-        OnPropertyChanged(nameof(CanPasteSelection));
-        OnPropertyChanged(nameof(IsCutClipboard));
+        _operationCoordinator.SetClipboard(items, operation);
     }
 
     internal async Task<FileOperationSummary> ExecutePasteAsync(
         Func<string, bool, Task<ConflictResolution>>? resolveMoveConflictAsync = null,
         Func<string, bool, Task<ConflictResolution>>? resolveCopyConflictAsync = null)
     {
-        if (_clipboardItems.Count == 0 || string.IsNullOrWhiteSpace(CurrentFolderPath))
+        if (string.IsNullOrWhiteSpace(CurrentFolderPath))
         {
-            return new FileOperationSummary(0, 0, Array.Empty<FileOperationFailure>());
+            return FileOperationCoordinator.EmptySummary;
         }
 
-        var items = _clipboardItems.ToList();
-        var operation = _clipboardOperation;
+        var (summary, operation) = await _operationCoordinator.PasteAsync(
+            CurrentFolderPath, resolveMoveConflictAsync, resolveCopyConflictAsync).ConfigureAwait(false);
 
-        if (operation == ClipboardOperation.Copy)
+        if (operation == ClipboardOperation.None)
         {
-            return await ExecuteCopyItemsToFolderAsync(items, CurrentFolderPath!, resolveCopyConflictAsync).ConfigureAwait(false);
+            return summary;
         }
 
-        var moveResult = await ExecuteMoveItemsToFolderAsync(items, CurrentFolderPath!, resolveMoveConflictAsync).ConfigureAwait(false);
-        if (moveResult.FailureCount == 0 && moveResult.SkipCount == 0)
-        {
-            _clipboardItems = Array.Empty<PhotoListItem>();
-            _clipboardOperation = ClipboardOperation.None;
-            OnPropertyChanged(nameof(CanPasteSelection));
-            OnPropertyChanged(nameof(IsCutClipboard));
-        }
+        var isCopy = operation == ClipboardOperation.Copy;
+        var resolveConflictAsync = isCopy ? resolveCopyConflictAsync : resolveMoveConflictAsync;
+        await FinishTransferAsync(
+            summary,
+            resolveConflictAsync is null ? null : (isCopy ? "Message.CopyDone" : "Message.MoveDone")).ConfigureAwait(false);
 
-        return moveResult;
+        return summary;
     }
 
     internal async Task<FileOperationSummary> ExecuteMoveToParentAsync()
     {
         if (string.IsNullOrWhiteSpace(CurrentFolderPath) || SelectedItems.Count == 0)
         {
-            return new FileOperationSummary(0, 0, Array.Empty<FileOperationFailure>());
+            return FileOperationCoordinator.EmptySummary;
         }
 
         var parentPath = _fileOperationService.GetParentPath(CurrentFolderPath);
         if (parentPath is null)
         {
-            return new FileOperationSummary(0, 0, Array.Empty<FileOperationFailure>());
+            return FileOperationCoordinator.EmptySummary;
         }
 
         return await ExecuteMoveItemsToFolderAsync(SelectedItems, parentPath).ConfigureAwait(false);
@@ -915,7 +719,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     internal async Task<FileOperationSummary> ExecuteDeleteItemsAsync(
         IReadOnlyList<PhotoListItem> items)
     {
-        var summary = await _fileOperationService.DeleteItemsAsync(items).ConfigureAwait(false);
+        var summary = await _operationCoordinator.DeleteItemsAsync(items).ConfigureAwait(false);
         if (summary.SuccessCount > 0)
         {
             await RefreshAsync().ConfigureAwait(false);
@@ -1305,12 +1109,27 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         _thumbnailCoordinator.Dispose();
         CancelMetadataLoad();
         CancelFolderLoad();
-        StopMoveProgressTimer();
-        _moveCts?.Cancel();
-        _moveCts?.Dispose();
-        StopCopyProgressTimer();
-        _copyCts?.Cancel();
-        _copyCts?.Dispose();
+        _operationCoordinator.Dispose();
+    }
+
+    private void OnMoveInProgressChanged()
+    {
+        OnPropertyChanged(nameof(IsMoveInProgress));
+        OnPropertyChanged(nameof(CancelMoveVisibility));
+        (CancelMoveCommand as RelayCommand)?.RaiseCanExecuteChanged();
+    }
+
+    private void OnCopyInProgressChanged()
+    {
+        OnPropertyChanged(nameof(IsCopyInProgress));
+        OnPropertyChanged(nameof(CancelCopyVisibility));
+        (CancelCopyCommand as RelayCommand)?.RaiseCanExecuteChanged();
+    }
+
+    private void OnClipboardChanged()
+    {
+        OnPropertyChanged(nameof(CanPasteSelection));
+        OnPropertyChanged(nameof(IsCutClipboard));
     }
 
     private void OnWorkspacePhotoFocusRequested(object? sender, WorkspacePhotoFocusRequestedEventArgs e)
@@ -1653,7 +1472,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     {
         _uiDispatcher.TryEnqueue(async () =>
         {
-            if (_isMoveInProgress || _isCopyInProgress)
+            if (IsMoveInProgress || IsCopyInProgress)
             {
                 return;
             }

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileOperationCoordinator.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileOperationCoordinator.cs
@@ -1,0 +1,311 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using PhotoGeoExplorer.Services;
+using PhotoGeoExplorer.ViewModels;
+
+namespace PhotoGeoExplorer.Panes.FileBrowser;
+
+/// <summary>
+/// ファイル操作（作成・リネーム・移動・コピー・貼り付け・削除）の実行と
+/// Move/Copy の進捗管理（CTS・進捗タイマー・カウンタ）、クリップボード状態を担うコーディネーター。
+/// 進捗状態の変化はコンストラクタ注入のコールバックで ViewModel へ通知する。
+/// 操作完了後の Refresh・選択復元は ViewModel 側の責務であり、本クラスは結果サマリーを返すだけにする。
+/// </summary>
+internal sealed class FileOperationCoordinator : IDisposable
+{
+    private const int ProgressTimerIntervalMs = 300;
+
+    internal static readonly FileOperationSummary EmptySummary = new(0, 0, Array.Empty<FileOperationFailure>());
+
+    private readonly IFileOperationService _fileOperationService;
+    private readonly IUiDispatcher _uiDispatcher;
+    private readonly Action<string> _onStatusBarTextChanged;
+    private readonly Action _onClipboardChanged;
+    private readonly TransferProgressState _moveProgress;
+    private readonly TransferProgressState _copyProgress;
+
+    private IReadOnlyList<PhotoListItem> _clipboardItems = Array.Empty<PhotoListItem>();
+    private ClipboardOperation _clipboardOperation = ClipboardOperation.None;
+
+    /// <param name="fileOperationService">ファイル操作の実処理。</param>
+    /// <param name="uiDispatcher">進捗タイマーの構成と UI スレッドへの marshal に使うディスパッチャ。</param>
+    /// <param name="onMoveInProgressChanged">Move 進捗状態の変化通知（UI スレッドで呼ばれる）。</param>
+    /// <param name="onCopyInProgressChanged">Copy 進捗状態の変化通知（UI スレッドで呼ばれる）。</param>
+    /// <param name="onStatusBarTextChanged">進捗メッセージの通知（UI スレッドタイマーの Tick で呼ばれる）。</param>
+    /// <param name="onClipboardChanged">クリップボード状態の変化通知。</param>
+    public FileOperationCoordinator(
+        IFileOperationService fileOperationService,
+        IUiDispatcher uiDispatcher,
+        Action<bool> onMoveInProgressChanged,
+        Action<bool> onCopyInProgressChanged,
+        Action<string> onStatusBarTextChanged,
+        Action onClipboardChanged)
+    {
+        ArgumentNullException.ThrowIfNull(fileOperationService);
+        ArgumentNullException.ThrowIfNull(uiDispatcher);
+        ArgumentNullException.ThrowIfNull(onMoveInProgressChanged);
+        ArgumentNullException.ThrowIfNull(onCopyInProgressChanged);
+        ArgumentNullException.ThrowIfNull(onStatusBarTextChanged);
+        ArgumentNullException.ThrowIfNull(onClipboardChanged);
+
+        _fileOperationService = fileOperationService;
+        _uiDispatcher = uiDispatcher;
+        _onStatusBarTextChanged = onStatusBarTextChanged;
+        _onClipboardChanged = onClipboardChanged;
+        _moveProgress = new TransferProgressState("Message.MoveProgress", onMoveInProgressChanged);
+        _copyProgress = new TransferProgressState("Message.CopyProgress", onCopyInProgressChanged);
+    }
+
+    public bool IsMoveInProgress => _moveProgress.IsInProgress;
+    public bool IsCopyInProgress => _copyProgress.IsInProgress;
+    public bool HasClipboardItems => _clipboardItems.Count > 0;
+    public bool IsCutClipboard => _clipboardOperation == ClipboardOperation.Cut;
+
+    public Task CancelMoveAsync() => _moveProgress.Cts?.CancelAsync() ?? Task.CompletedTask;
+    public Task CancelCopyAsync() => _copyProgress.Cts?.CancelAsync() ?? Task.CompletedTask;
+
+    public FileOperationResult CreateFolder(string? parentFolderPath, string folderName)
+    {
+        if (_fileOperationService.ContainsInvalidFileNameChars(folderName))
+        {
+            return FileOperationResult.Failure(FileOperationError.InvalidName);
+        }
+
+        if (string.IsNullOrWhiteSpace(parentFolderPath))
+        {
+            return FileOperationResult.Failure(FileOperationError.NoParent);
+        }
+
+        return _fileOperationService.CreateFolder(parentFolderPath, folderName);
+    }
+
+    /// <summary>
+    /// 名前を正規化・検証してリネームを実行する。
+    /// 正規化後の名前が現在と同じ場合は何もせず成功（ResultPath は null）を返す。
+    /// </summary>
+    public FileOperationResult Rename(PhotoListItem item, string newName)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        var normalizedName = _fileOperationService.NormalizeName(item, newName);
+
+        if (string.Equals(normalizedName, item.FileName, StringComparison.OrdinalIgnoreCase))
+        {
+            return FileOperationResult.Success();
+        }
+
+        if (_fileOperationService.ContainsInvalidFileNameChars(normalizedName))
+        {
+            return FileOperationResult.Failure(FileOperationError.InvalidName);
+        }
+
+        return _fileOperationService.RenameItem(item, normalizedName);
+    }
+
+    public Task<FileOperationSummary> MoveItemsToFolderAsync(
+        IReadOnlyList<PhotoListItem> items,
+        string destinationFolder,
+        Func<string, bool, Task<ConflictResolution>>? resolveConflictAsync = null)
+    {
+        return ExecuteTransferAsync(
+            _moveProgress,
+            items,
+            destinationFolder,
+            _fileOperationService.MoveItems,
+            _fileOperationService.MoveItemsAsync,
+            resolveConflictAsync);
+    }
+
+    public Task<FileOperationSummary> CopyItemsToFolderAsync(
+        IReadOnlyList<PhotoListItem> items,
+        string destinationFolder,
+        Func<string, bool, Task<ConflictResolution>>? resolveConflictAsync = null)
+    {
+        return ExecuteTransferAsync(
+            _copyProgress,
+            items,
+            destinationFolder,
+            _fileOperationService.CopyItems,
+            _fileOperationService.CopyItemsAsync,
+            resolveConflictAsync);
+    }
+
+    public Task<FileOperationSummary> DeleteItemsAsync(IReadOnlyList<PhotoListItem> items)
+        => _fileOperationService.DeleteItemsAsync(items);
+
+    public void SetClipboard(IReadOnlyList<PhotoListItem> items, ClipboardOperation operation)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+
+        _clipboardItems = items.ToList();
+        _clipboardOperation = operation;
+        _onClipboardChanged();
+    }
+
+    /// <summary>
+    /// クリップボードの内容を現在のフォルダへ貼り付ける。
+    /// Cut 操作が全件成功（失敗・スキップなし）した場合のみクリップボードをクリアする。
+    /// </summary>
+    /// <returns>結果サマリーと、実行されたクリップボード操作種別（クリップボードが空の場合は None）。</returns>
+    public async Task<(FileOperationSummary Summary, ClipboardOperation Operation)> PasteAsync(
+        string destinationFolder,
+        Func<string, bool, Task<ConflictResolution>>? resolveMoveConflictAsync = null,
+        Func<string, bool, Task<ConflictResolution>>? resolveCopyConflictAsync = null)
+    {
+        if (_clipboardItems.Count == 0)
+        {
+            return (EmptySummary, ClipboardOperation.None);
+        }
+
+        var items = _clipboardItems;
+        var operation = _clipboardOperation;
+
+        if (operation == ClipboardOperation.Copy)
+        {
+            var copyResult = await CopyItemsToFolderAsync(items, destinationFolder, resolveCopyConflictAsync).ConfigureAwait(false);
+            return (copyResult, operation);
+        }
+
+        var moveResult = await MoveItemsToFolderAsync(items, destinationFolder, resolveMoveConflictAsync).ConfigureAwait(false);
+        if (moveResult.FailureCount == 0 && moveResult.SkipCount == 0)
+        {
+            _clipboardItems = Array.Empty<PhotoListItem>();
+            _clipboardOperation = ClipboardOperation.None;
+            _onClipboardChanged();
+        }
+
+        return (moveResult, operation);
+    }
+
+    public void Dispose()
+    {
+        DisposeTransferState(_moveProgress);
+        DisposeTransferState(_copyProgress);
+    }
+
+    /// <summary>
+    /// Move/Copy 共通の転送実装。競合解決コールバックが null の場合は同期パス（進捗管理なし）。
+    /// それ以外はバックグラウンドスレッドで転送し、進捗タイマー・キャンセル・完了通知を管理する。
+    /// </summary>
+    private async Task<FileOperationSummary> ExecuteTransferAsync(
+        TransferProgressState state,
+        IReadOnlyList<PhotoListItem> items,
+        string destinationFolder,
+        Func<IReadOnlyList<PhotoListItem>, string, FileOperationSummary> transferItems,
+        Func<IReadOnlyList<PhotoListItem>, string, Func<string, bool, Task<ConflictResolution>>, IProgress<int>?, CancellationToken, Task<FileOperationSummary>> transferItemsAsync,
+        Func<string, bool, Task<ConflictResolution>>? resolveConflictAsync)
+    {
+        if (resolveConflictAsync is null)
+        {
+            return transferItems(items, destinationFolder);
+        }
+
+        var cts = new CancellationTokenSource();
+        state.Cts = cts;
+        // cts が後で破棄されても ObjectDisposedException が発生しないよう、Task.Run 前にトークン値をキャプチャする
+        var token = cts.Token;
+        state.Total = items.Count;
+        Volatile.Write(ref state.Completed, 0);
+        SetInProgress(state, true);
+        StartProgressTimer(state);
+
+        // ファイル操作はバックグラウンドスレッドで実行し UI スレッドをブロックしない。
+        // 競合ダイアログは UI スレッドへ marshal してから表示する。
+        Func<string, bool, Task<ConflictResolution>> marshalledCallback = async (name, isFolder) =>
+            await _uiDispatcher.EnqueueAsync(() => resolveConflictAsync(name, isFolder)).ConfigureAwait(false);
+
+        try
+        {
+            var progress = new Progress<int>(completed =>
+            {
+                Interlocked.Exchange(ref state.Completed, completed);
+            });
+
+            return await Task.Run(() => transferItemsAsync(
+                items, destinationFolder, marshalledCallback, progress, token))
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            // ConfigureAwait(false) により finally はバックグラウンドスレッドで実行される。
+            // 進捗タイマーの Stop()、進捗状態の変更通知、CTS の Dispose/null 化は
+            // すべて UI スレッドで行い、キャンセルコマンドとの race を防ぐ（#137）。
+            await _uiDispatcher.RunAsync(() =>
+            {
+                StopProgressTimer(state);
+                SetInProgress(state, false);
+                state.Cts?.Dispose();
+                state.Cts = null;
+            }).ConfigureAwait(false);
+        }
+    }
+
+    private static void SetInProgress(TransferProgressState state, bool value)
+    {
+        if (state.IsInProgress == value)
+        {
+            return;
+        }
+
+        state.IsInProgress = value;
+        state.OnInProgressChanged(value);
+    }
+
+    private void StartProgressTimer(TransferProgressState state)
+    {
+        var timer = _uiDispatcher.CreateTimer();
+        if (timer is null)
+        {
+            return;
+        }
+
+        state.Timer = timer;
+        timer.Interval = TimeSpan.FromMilliseconds(ProgressTimerIntervalMs);
+        timer.Tick += (_, _) => ReportProgress(state);
+        timer.Start();
+    }
+
+    private static void StopProgressTimer(TransferProgressState state)
+    {
+        state.Timer?.Stop();
+        state.Timer = null;
+    }
+
+    private void ReportProgress(TransferProgressState state)
+    {
+        var completed = Volatile.Read(ref state.Completed);
+        _onStatusBarTextChanged(LocalizationService.Format(state.ProgressResourceKey, completed, state.Total));
+    }
+
+    private static void DisposeTransferState(TransferProgressState state)
+    {
+        StopProgressTimer(state);
+        state.Cts?.Cancel();
+        state.Cts?.Dispose();
+        state.Cts = null;
+    }
+
+    /// <summary>
+    /// 操作種別（Move/Copy）ごとの進捗状態。進捗メッセージのリソースキーと
+    /// 進捗状態の変更通知コールバックをパラメータ化することで、両操作の実装を統一する。
+    /// </summary>
+    private sealed class TransferProgressState
+    {
+        public TransferProgressState(string progressResourceKey, Action<bool> onInProgressChanged)
+        {
+            ProgressResourceKey = progressResourceKey;
+            OnInProgressChanged = onInProgressChanged;
+        }
+
+        public string ProgressResourceKey { get; }
+        public Action<bool> OnInProgressChanged { get; }
+        public CancellationTokenSource? Cts;
+        public int Total;
+        public int Completed;
+        public bool IsInProgress;
+        public IUiDispatcherTimer? Timer;
+    }
+}


### PR DESCRIPTION
## 要約

#150 Phase 1（`FileBrowserPaneViewModel.cs` 分割）の第3弾。ファイル操作（作成・リネーム・移動・コピー・貼り付け・削除）の実行と進捗管理・クリップボード状態を `Panes/FileBrowser/FileOperationCoordinator.cs`（新設）へ分離しました。

Closes #154

## 変更内容

### Move/Copy 進捗管理の単一実装への統一
- ほぼ同一のコードが二重に存在していた Move/Copy の進捗管理（CTS・進捗タイマー・カウンタ・キャンセルコマンド連携）を、操作種別ごとの `TransferProgressState`（進捗メッセージのリソースキー・進捗状態通知コールバックをパラメータ化）による共通実装 `ExecuteTransferAsync` に統一
- **#137 の race 対策（`finally` 内の UI スレッド集約）は共通実装でも維持**。競合解決コールバックの UI スレッド marshal も `IUiDispatcher.EnqueueAsync` 経由のまま

### 責務の分担（ISSUE の設計方針どおり）
- 進捗状態（`IsMoveInProgress` / `IsCopyInProgress` / `StatusBarText` 更新）・クリップボード変化は、コンストラクタ注入のコールバック（#153 の `ThumbnailGenerationCoordinator` と同じイディオム）で VM へ通知し、**XAML バインディングは現行のまま維持**
- 操作完了後の `RefreshAsync` 呼び出し・選択復元・完了メッセージ表示は VM 側の責務として残し、共通ヘルパー `FinishTransferAsync` に集約（Coordinator は結果サマリーを返すだけ）
- クリップボード状態（項目・Cut/Copy 種別・Cut 全件成功時のクリア判定）は Coordinator へ移動
- VM の `ExecuteXxx` 系 internal シグネチャは View からの呼び出し口として維持（VM → Coordinator への薄い委譲）。**既存テストは VM 経由のまま無変更で全件パス**し、委譲の結線も検証される

### テスト
- `FileOperationCoordinatorTests.cs` を新設（28 件）。統一後の共通進捗実装（ライフサイクル通知・進捗 Tick・キャンセル連携・Move/Copy 状態の独立性）・クリップボード管理・`CreateFolder` / `Rename` バリデーション・Dispose 時のキャンセルを Coordinator 直接で検証。Move/Copy 対称のケースは `[Theory]` でパラメータ化

## 行数の変化
- `FileBrowserPaneViewModel.cs`: 1,665 行 → 1,484 行（-181 行）
- `FileOperationCoordinator.cs`: +311 行（新設）

## 受け入れ条件の確認
- [x] Move/Copy の進捗管理コードが単一実装に統一されている
- [x] `FileBrowserPaneViewModel` からファイル操作の実行ループ・進捗フィールドが消えている
- [x] 移動・コピー・貼り付け・削除・キャンセルの既存テストがすべてパスする（VM 経由のまま、移行なし）
- [x] Move/Copy 統一後の共通進捗実装に Coordinator 直接の単体テストが追加されている
- [x] 移動/コピー中のキャンセルでクラッシュしない（#137 の finally 内 UI スレッド集約を維持、キャンセルの回帰テストを Coordinator 直接で追加）
- [x] `dotnet build` / `dotnet test`（Release, x64）が成功する

## 検証

```
dotnet build PhotoGeoExplorer.sln -c Release -p:Platform=x64
# → 0 警告 0 エラー

dotnet test PhotoGeoExplorer.sln -c Release -p:Platform=x64
# → 成功! 失敗: 0、合格: 550、スキップ: 0（PhotoGeoExplorer.Tests）

dotnet format PhotoGeoExplorer.sln --verify-no-changes
# → 変更なし
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)