### PR TITLE
refactor: FileBrowserPaneViewModel からステータス表示とメタデータロードを FileBrowserStatusViewModel に分離 (#155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   - `SetDispatcherQueue` 経路を廃止。ViewModel は `MainWindow` の DI 構築（UI スレッド上）で生成されるため、View の `OnLoaded` / `OnDataContextChanged` からの再設定は不要と確認
 
 ### 修正
+- メタデータロード中にキャンセル（CTS 破棄）が走った後、ローダーがキャンセルを観測せず正常リターンすると破棄済み CTS の `Token` getter で `ObjectDisposedException` が発生する潜在競合を修正 (#163)
+  - `CancellationToken` を await 前にローカルへ保持し、破棄済み CTS に触れないよう変更。競合を決定的に再現する回帰テストを `FileBrowserStatusViewModelTests` に追加
 - Release ビルドで `HarfBuzzSharp` などのネイティブ依存の PDB を処理しようとして `mspdbcmf.exe` パス構築バグ (MSB6011) が発生し CI が失敗する問題を修正
   - `AppxSymbolPackageEnabled=false` を Release 構成に追加してシンボルパッケージ生成を無効化
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ## [Unreleased]
 
 ### リファクタリング
+- ステータス表示とメタデータロードを `FileBrowserPaneViewModel` から子 ViewModel `FileBrowserStatusViewModel` へ分離 (#155)
+  - ステータスオーバーレイ（空フォルダ・エラー時の案内とアクション）、ステータスバー（フォルダ/件数/選択/GPS アイコン）、選択アイテムの EXIF メタデータ非同期ロード（先行ロードをキャンセルする CTS 管理を含む）を `Panes/FileBrowser/FileBrowserStatusViewModel.cs`（internal sealed, BindableBase, IDisposable）へ移動
+  - 親 ViewModel は `Status` プロパティとして子 VM を公開し、選択変更・フォルダ読み込み・フィルタ変更のタイミングでメソッド呼び出しで状態を渡す（イベント購読ではなく明示的な呼び出し）。XAML バインディングは `Status.StatusBarText` 等のパスに更新（`FileBrowserPaneView.xaml` のオーバーレイ、`MainWindow.xaml` のステータスバー）
+  - メタデータ取得は `Func` 注入のテスト用シーム（既定は `ExifService.GetMetadataAsync`）とし、UI 更新は `IUiDispatcher`（#152）経由を維持。Move/Copy の進捗・完了メッセージは `FileOperationCoordinator`（#154）から `Status.SetStatusBarText` への通知経路で維持
+  - オーバーレイ表示・ステータスバー組み立て・GPS アイコン状態（有効/測位失敗/GPS なし）・メタデータロードのキャンセルを検証する `FileBrowserStatusViewModelTests`（15 件、GPS 状態はパラメータ化テスト）を新設
 - ファイル操作・進捗・クリップボード管理を `FileBrowserPaneViewModel` から `FileOperationCoordinator` へ分離 (#154)
   - Move/Copy でほぼ同一だった進捗管理（CTS・進捗タイマー・カウンタ・キャンセルコマンド連携）を、操作種別（進捗メッセージのリソースキー・進捗状態通知）をパラメータ化した共通実装 `ExecuteTransferAsync` に統一
   - クリップボード状態（項目・Cut/Copy 種別・Cut 全件成功時のクリア判定）を Coordinator へ移動。`IsMoveInProgress` / `IsCopyInProgress` / `CanPasteSelection` 等の XAML バインディングは ViewModel のプロパティとして維持し、コンストラクタ注入のコールバックで変更通知を中継

--- a/PhotoGeoExplorer.Tests/FileBrowserStatusViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserStatusViewModelTests.cs
@@ -283,6 +283,32 @@ public class FileBrowserStatusViewModelTests
     }
 
     [Fact]
+    public async Task LoadMetadataAsyncDiscardsResultWhenCancelledDuringLoad()
+    {
+        var loadStarted = new TaskCompletionSource();
+        var resumeLoad = new TaskCompletionSource();
+        using var viewModel = CreateViewModel(async (_, _) =>
+        {
+            loadStarted.SetResult();
+            await resumeLoad.Task.ConfigureAwait(false);
+            return new PhotoMetadata(null, null, null, latitude: 35.0, longitude: 139.0, hasGpsData: true);
+        });
+        var item = CreateFileItem("photo.jpg");
+        viewModel.UpdateStatusBar("/test", itemCount: 1, selectedCount: 1, selectedItem: item);
+
+        var load = viewModel.LoadMetadataAsync(item);
+        await loadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        viewModel.CancelMetadataLoad();
+        resumeLoad.SetResult();
+
+        await load.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Null(viewModel.SelectedMetadata);
+        Assert.Equal(Visibility.Collapsed, viewModel.StatusBarLocationVisibility);
+    }
+
+    [Fact]
     public async Task CancelMetadataLoadStopsPendingLoad()
     {
         var loadStarted = new TaskCompletionSource();

--- a/PhotoGeoExplorer.Tests/FileBrowserStatusViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserStatusViewModelTests.cs
@@ -1,0 +1,355 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using PhotoGeoExplorer.Models;
+using PhotoGeoExplorer.Panes.FileBrowser;
+using PhotoGeoExplorer.Services;
+using PhotoGeoExplorer.ViewModels;
+using Xunit;
+
+namespace PhotoGeoExplorer.Tests;
+
+/// <summary>
+/// FileBrowserStatusViewModel のテスト
+/// </summary>
+public class FileBrowserStatusViewModelTests
+{
+    [Fact]
+    public void ConstructorThrowsWhenUiDispatcherIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FileBrowserStatusViewModel(null!));
+    }
+
+    [Fact]
+    public void InitialStateHidesOverlayAndLocation()
+    {
+        using var viewModel = CreateViewModel();
+
+        Assert.Equal(Visibility.Collapsed, viewModel.StatusVisibility);
+        Assert.Equal(Visibility.Collapsed, viewModel.StatusPrimaryActionVisibility);
+        Assert.Equal(Visibility.Collapsed, viewModel.StatusSecondaryActionVisibility);
+        Assert.Equal(Visibility.Collapsed, viewModel.StatusBarLocationVisibility);
+        Assert.Null(viewModel.StatusBarText);
+        Assert.Null(viewModel.SelectedMetadata);
+    }
+
+    [Fact]
+    public void SetStatusWithNullMessageHidesOverlay()
+    {
+        using var viewModel = CreateViewModel();
+        viewModel.SetStatus("dummy", InfoBarSeverity.Error);
+
+        viewModel.SetStatus(null, InfoBarSeverity.Informational);
+
+        Assert.Null(viewModel.StatusMessage);
+        Assert.Equal(Visibility.Collapsed, viewModel.StatusVisibility);
+        Assert.Null(viewModel.StatusTitle);
+        Assert.Null(viewModel.StatusDetail);
+        Assert.Equal(Symbol.Help, viewModel.StatusSymbol);
+        Assert.Equal(StatusAction.None, viewModel.StatusPrimaryAction);
+        Assert.Equal(StatusAction.None, viewModel.StatusSecondaryAction);
+    }
+
+    [Fact]
+    public void SetStatusWithNoFilesFoundShowsEmptyFolderOverlay()
+    {
+        using var viewModel = CreateViewModel();
+
+        viewModel.SetStatus(LocalizationService.GetString("Message.NoFilesFound"), InfoBarSeverity.Informational);
+
+        Assert.Equal(Visibility.Visible, viewModel.StatusVisibility);
+        Assert.Equal(LocalizationService.GetString("Overlay.NoFilesFoundTitle"), viewModel.StatusTitle);
+        Assert.Equal(LocalizationService.GetString("Overlay.NoFilesFoundDetail"), viewModel.StatusDetail);
+        Assert.Equal(Symbol.Pictures, viewModel.StatusSymbol);
+        Assert.Equal(StatusAction.OpenFolder, viewModel.StatusPrimaryAction);
+        Assert.Equal(StatusAction.None, viewModel.StatusSecondaryAction);
+        Assert.Equal(Visibility.Visible, viewModel.StatusPrimaryActionVisibility);
+        Assert.Equal(Visibility.Collapsed, viewModel.StatusSecondaryActionVisibility);
+    }
+
+    [Fact]
+    public void SetStatusWithNoFilesFoundAndActiveFiltersShowsResetFiltersAction()
+    {
+        using var viewModel = CreateViewModel();
+        viewModel.NotifyFiltersChanged(hasActiveFilters: true);
+
+        viewModel.SetStatus(LocalizationService.GetString("Message.NoFilesFound"), InfoBarSeverity.Informational);
+
+        Assert.Equal(LocalizationService.GetString("Overlay.NoFilesFoundDetailWithFilters"), viewModel.StatusDetail);
+        Assert.Equal(StatusAction.OpenFolder, viewModel.StatusPrimaryAction);
+        Assert.Equal(StatusAction.ResetFilters, viewModel.StatusSecondaryAction);
+        Assert.Equal(LocalizationService.GetString("Action.ResetFilters"), viewModel.StatusSecondaryActionLabel);
+        Assert.Equal(Visibility.Visible, viewModel.StatusSecondaryActionVisibility);
+    }
+
+    [Fact]
+    public void SetStatusWithErrorShowsErrorOverlay()
+    {
+        using var viewModel = CreateViewModel();
+        const string errorMessage = "error message";
+
+        viewModel.SetStatus(errorMessage, InfoBarSeverity.Error);
+
+        Assert.Equal(Visibility.Visible, viewModel.StatusVisibility);
+        Assert.Equal(InfoBarSeverity.Error, viewModel.StatusSeverity);
+        Assert.Equal(LocalizationService.GetString("Overlay.LoadFolderErrorTitle"), viewModel.StatusTitle);
+        Assert.Equal(errorMessage, viewModel.StatusDetail);
+        Assert.Equal(Symbol.Folder, viewModel.StatusSymbol);
+        Assert.Equal(StatusAction.OpenFolder, viewModel.StatusPrimaryAction);
+        Assert.Equal(StatusAction.GoHome, viewModel.StatusSecondaryAction);
+        Assert.Equal(LocalizationService.GetString("Action.OpenFolder"), viewModel.StatusPrimaryActionLabel);
+        Assert.Equal(LocalizationService.GetString("Action.GoHome"), viewModel.StatusSecondaryActionLabel);
+    }
+
+    [Fact]
+    public void SetStatusWithGenericMessageShowsTitleOnly()
+    {
+        using var viewModel = CreateViewModel();
+        const string message = "generic message";
+
+        viewModel.SetStatus(message, InfoBarSeverity.Informational);
+
+        Assert.Equal(message, viewModel.StatusTitle);
+        Assert.Null(viewModel.StatusDetail);
+        Assert.Equal(Symbol.Help, viewModel.StatusSymbol);
+        Assert.Equal(StatusAction.None, viewModel.StatusPrimaryAction);
+        Assert.Equal(StatusAction.None, viewModel.StatusSecondaryAction);
+    }
+
+    [Fact]
+    public void NotifyFiltersChangedReevaluatesOverlay()
+    {
+        using var viewModel = CreateViewModel();
+        viewModel.SetStatus(LocalizationService.GetString("Message.NoFilesFound"), InfoBarSeverity.Informational);
+        Assert.Equal(StatusAction.None, viewModel.StatusSecondaryAction);
+
+        viewModel.NotifyFiltersChanged(hasActiveFilters: true);
+
+        Assert.Equal(LocalizationService.GetString("Overlay.NoFilesFoundDetailWithFilters"), viewModel.StatusDetail);
+        Assert.Equal(StatusAction.ResetFilters, viewModel.StatusSecondaryAction);
+
+        viewModel.NotifyFiltersChanged(hasActiveFilters: false);
+
+        Assert.Equal(LocalizationService.GetString("Overlay.NoFilesFoundDetail"), viewModel.StatusDetail);
+        Assert.Equal(StatusAction.None, viewModel.StatusSecondaryAction);
+    }
+
+    [Fact]
+    public void UpdateStatusBarWithoutFolderShowsNoFolderLabel()
+    {
+        using var viewModel = CreateViewModel();
+
+        viewModel.UpdateStatusBar(currentFolderPath: null, itemCount: 0, selectedCount: 0, selectedItem: null);
+
+        var expected = $"{LocalizationService.GetString("StatusBar.NoFolderSelected")} | {LocalizationService.Format("StatusBar.Items", 0)}";
+        Assert.Equal(expected, viewModel.StatusBarText);
+        Assert.Equal(Visibility.Collapsed, viewModel.StatusBarLocationVisibility);
+    }
+
+    [Fact]
+    public void UpdateStatusBarWithSingleSelectionShowsFileNameAndResolution()
+    {
+        using var viewModel = CreateViewModel();
+        var item = CreateFileItem("photo.jpg");
+
+        viewModel.UpdateStatusBar("/test", itemCount: 3, selectedCount: 1, selectedItem: item);
+
+        var expected = $"/test | {LocalizationService.Format("StatusBar.Items", 3)} | {LocalizationService.Format("StatusBar.Selected", "photo.jpg")} | {item.ResolutionText}";
+        Assert.Equal(expected, viewModel.StatusBarText);
+    }
+
+    [Fact]
+    public void UpdateStatusBarWithMultipleSelectionShowsCount()
+    {
+        using var viewModel = CreateViewModel();
+        var item = CreateFileItem("photo.jpg");
+
+        viewModel.UpdateStatusBar("/test", itemCount: 5, selectedCount: 3, selectedItem: item);
+
+        var expected = $"/test | {LocalizationService.Format("StatusBar.Items", 5)} | {LocalizationService.Format("StatusBar.SelectedMultiple", 3)}";
+        Assert.Equal(expected, viewModel.StatusBarText);
+        Assert.Equal(Visibility.Collapsed, viewModel.StatusBarLocationVisibility);
+    }
+
+    [Fact]
+    public void SetStatusBarTextOverridesStatusBarText()
+    {
+        using var viewModel = CreateViewModel();
+        viewModel.UpdateStatusBar("/test", itemCount: 1, selectedCount: 0, selectedItem: null);
+
+        viewModel.SetStatusBarText("progress message");
+
+        Assert.Equal("progress message", viewModel.StatusBarText);
+    }
+
+    [Theory]
+    [InlineData(35.0, 139.0, true, Symbol.Map, "StatusBar.GpsAvailable")] // 有効な GPS 座標あり
+    [InlineData(0.0, 0.0, true, Symbol.Important, "StatusBar.GpsFixFailed")] // GPS タグはあるが座標が無効（測位失敗の可能性）
+    [InlineData(null, null, false, Symbol.Cancel, "StatusBar.GpsMissing")] // GPS 情報なし
+    public async Task LoadMetadataAsyncUpdatesLocationStatus(
+        double? latitude, double? longitude, bool hasGpsData, Symbol expectedSymbol, string expectedTooltipKey)
+    {
+        var metadata = new PhotoMetadata(null, null, null, latitude, longitude, hasGpsData);
+        using var viewModel = CreateViewModel((_, _) => Task.FromResult<PhotoMetadata?>(metadata));
+        var item = CreateFileItem("photo.jpg");
+        viewModel.UpdateStatusBar("/test", itemCount: 1, selectedCount: 1, selectedItem: item);
+
+        await viewModel.LoadMetadataAsync(item);
+
+        Assert.Same(metadata, viewModel.SelectedMetadata);
+        Assert.Equal(Visibility.Visible, viewModel.StatusBarLocationVisibility);
+        Assert.Equal(expectedSymbol, viewModel.StatusBarLocationSymbol);
+        Assert.Equal(LocalizationService.GetString(expectedTooltipKey), viewModel.StatusBarLocationTooltip);
+    }
+
+    [Fact]
+    public async Task LoadMetadataAsyncWithNullItemClearsMetadataAndHidesLocation()
+    {
+        var metadata = new PhotoMetadata(null, null, null, latitude: 35.0, longitude: 139.0, hasGpsData: true);
+        using var viewModel = CreateViewModel((_, _) => Task.FromResult<PhotoMetadata?>(metadata));
+        var item = CreateFileItem("photo.jpg");
+        viewModel.UpdateStatusBar("/test", itemCount: 1, selectedCount: 1, selectedItem: item);
+        await viewModel.LoadMetadataAsync(item);
+        Assert.NotNull(viewModel.SelectedMetadata);
+
+        viewModel.UpdateStatusBar("/test", itemCount: 1, selectedCount: 0, selectedItem: null);
+        await viewModel.LoadMetadataAsync(null);
+
+        Assert.Null(viewModel.SelectedMetadata);
+        Assert.Equal(Visibility.Collapsed, viewModel.StatusBarLocationVisibility);
+        Assert.Null(viewModel.StatusBarLocationTooltip);
+    }
+
+    [Fact]
+    public async Task LoadMetadataAsyncWithFolderDoesNotLoadMetadata()
+    {
+        var loadCount = 0;
+        using var viewModel = CreateViewModel((_, _) =>
+        {
+            Interlocked.Increment(ref loadCount);
+            return Task.FromResult<PhotoMetadata?>(null);
+        });
+        var folder = CreateFolderItem("subfolder");
+        viewModel.UpdateStatusBar("/test", itemCount: 1, selectedCount: 1, selectedItem: folder);
+
+        await viewModel.LoadMetadataAsync(folder);
+
+        Assert.Equal(0, loadCount);
+        Assert.Null(viewModel.SelectedMetadata);
+        Assert.Equal(Visibility.Collapsed, viewModel.StatusBarLocationVisibility);
+    }
+
+    [Fact]
+    public async Task LoadMetadataAsyncCancelsPreviousLoad()
+    {
+        var firstLoadStarted = new TaskCompletionSource();
+        var firstLoadCancelled = new TaskCompletionSource();
+        var callCount = 0;
+        using var viewModel = CreateViewModel(async (_, token) =>
+        {
+            if (Interlocked.Increment(ref callCount) == 1)
+            {
+                firstLoadStarted.SetResult();
+                try
+                {
+                    await Task.Delay(Timeout.Infinite, token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    firstLoadCancelled.SetResult();
+                    throw;
+                }
+            }
+
+            return new PhotoMetadata(null, null, null, latitude: 35.0, longitude: 139.0, hasGpsData: true);
+        });
+        var first = CreateFileItem("first.jpg");
+        var second = CreateFileItem("second.jpg");
+        viewModel.UpdateStatusBar("/test", itemCount: 2, selectedCount: 1, selectedItem: first);
+
+        var firstLoad = viewModel.LoadMetadataAsync(first);
+        await firstLoadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        viewModel.UpdateStatusBar("/test", itemCount: 2, selectedCount: 1, selectedItem: second);
+        await viewModel.LoadMetadataAsync(second);
+
+        await firstLoadCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await firstLoad.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.NotNull(viewModel.SelectedMetadata);
+        Assert.Equal(Visibility.Visible, viewModel.StatusBarLocationVisibility);
+    }
+
+    [Fact]
+    public async Task CancelMetadataLoadStopsPendingLoad()
+    {
+        var loadStarted = new TaskCompletionSource();
+        using var viewModel = CreateViewModel(async (_, token) =>
+        {
+            loadStarted.SetResult();
+            await Task.Delay(Timeout.Infinite, token).ConfigureAwait(false);
+            return null;
+        });
+        var item = CreateFileItem("photo.jpg");
+        viewModel.UpdateStatusBar("/test", itemCount: 1, selectedCount: 1, selectedItem: item);
+
+        var load = viewModel.LoadMetadataAsync(item);
+        await loadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        viewModel.CancelMetadataLoad();
+
+        await load.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Null(viewModel.SelectedMetadata);
+    }
+
+    private static FileBrowserStatusViewModel CreateViewModel(
+        Func<string, CancellationToken, Task<PhotoMetadata?>>? getMetadataAsync = null)
+    {
+        return new FileBrowserStatusViewModel(
+            new FakeUiDispatcher(),
+            getMetadataAsync ?? ((_, _) => Task.FromResult<PhotoMetadata?>(null)));
+    }
+
+    private static PhotoListItem CreateFileItem(string fileName)
+        => CreateListItem(fileName, isFolder: false);
+
+    private static PhotoListItem CreateFolderItem(string folderName)
+        => CreateListItem(folderName, isFolder: true);
+
+    private static PhotoListItem CreateListItem(string name, bool isFolder)
+    {
+        var photoItem = new PhotoItem(
+            filePath: $"/test/{name}",
+            sizeBytes: 1000,
+            modifiedAt: DateTimeOffset.UtcNow,
+            isFolder: isFolder,
+            thumbnailPath: null,
+            pixelWidth: 100,
+            pixelHeight: 100);
+
+        return new PhotoListItem(photoItem, thumbnail: null, toolTipText: null, thumbnailKey: null);
+    }
+
+    private sealed class FakeUiDispatcher : IUiDispatcher
+    {
+        public bool IsAvailable => true;
+
+        public Task RunAsync(Action action)
+        {
+            action();
+            return Task.CompletedTask;
+        }
+
+        public Task<T> EnqueueAsync<T>(Func<Task<T>> asyncFunc) => asyncFunc();
+
+        public bool TryEnqueue(Action action)
+        {
+            action();
+            return true;
+        }
+
+        public IUiDispatcherTimer? CreateTimer() => null;
+    }
+}

--- a/PhotoGeoExplorer/MainWindow.xaml
+++ b/PhotoGeoExplorer/MainWindow.xaml
@@ -208,13 +208,13 @@
                     </Grid.ColumnDefinitions>
                     <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                         <SymbolIcon
-                            Symbol="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.StatusBarLocationSymbol}"
-                            Visibility="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.StatusBarLocationVisibility}"
+                            Symbol="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.Status.StatusBarLocationSymbol}"
+                            Visibility="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.Status.StatusBarLocationVisibility}"
                             Width="16"
                             Height="16"
-                            ToolTipService.ToolTip="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.StatusBarLocationTooltip}" />
+                            ToolTipService.ToolTip="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.Status.StatusBarLocationTooltip}" />
                         <TextBlock
-                            Text="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.StatusBarText}"
+                            Text="{Binding ElementName=FileBrowserPaneControl, Path=DataContext.Status.StatusBarText}"
                             TextTrimming="CharacterEllipsis"
                             VerticalAlignment="Center" />
                     </StackPanel>

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml
@@ -453,32 +453,32 @@
                 AllowDrop="True"
                 DragOver="OnFileListDragOver"
                 Drop="OnFileListDrop"
-                Visibility="{Binding StatusVisibility}">
+                Visibility="{Binding Status.StatusVisibility}">
                 <StackPanel Spacing="8" MaxWidth="320" HorizontalAlignment="Center">
                     <SymbolIcon
-                        Symbol="{Binding StatusSymbol}"
+                        Symbol="{Binding Status.StatusSymbol}"
                         Width="28"
                         Height="28"
                         HorizontalAlignment="Center" />
                     <TextBlock
-                        Text="{Binding StatusTitle}"
+                        Text="{Binding Status.StatusTitle}"
                         FontSize="16"
                         FontWeight="SemiBold"
                         TextAlignment="Center"
                         TextWrapping="Wrap" />
                     <TextBlock
-                        Text="{Binding StatusDetail}"
+                        Text="{Binding Status.StatusDetail}"
                         Opacity="0.7"
                         TextAlignment="Center"
                         TextWrapping="Wrap" />
                     <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
                         <Button
-                            Content="{Binding StatusPrimaryActionLabel}"
-                            Visibility="{Binding StatusPrimaryActionVisibility}"
+                            Content="{Binding Status.StatusPrimaryActionLabel}"
+                            Visibility="{Binding Status.StatusPrimaryActionVisibility}"
                             Click="OnStatusPrimaryActionClicked" />
                         <Button
-                            Content="{Binding StatusSecondaryActionLabel}"
-                            Visibility="{Binding StatusSecondaryActionVisibility}"
+                            Content="{Binding Status.StatusSecondaryActionLabel}"
+                            Visibility="{Binding Status.StatusSecondaryActionVisibility}"
                             Click="OnStatusSecondaryActionClicked" />
                     </StackPanel>
                 </StackPanel>

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
@@ -287,7 +287,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
             return;
         }
 
-        await PerformStatusActionAsync(ViewModel.StatusPrimaryAction).ConfigureAwait(true);
+        await PerformStatusActionAsync(ViewModel.Status.StatusPrimaryAction).ConfigureAwait(true);
     }
 
     private async void OnStatusSecondaryActionClicked(object sender, RoutedEventArgs e)
@@ -297,7 +297,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
             return;
         }
 
-        await PerformStatusActionAsync(ViewModel.StatusSecondaryAction).ConfigureAwait(true);
+        await PerformStatusActionAsync(ViewModel.Status.StatusSecondaryAction).ConfigureAwait(true);
     }
 
     private async Task PerformStatusActionAsync(StatusAction action)
@@ -1222,7 +1222,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
 
     private async void OnOpenInGoogleMapsClicked(object sender, RoutedEventArgs e)
     {
-        var metadata = ViewModel?.SelectedMetadata;
+        var metadata = ViewModel?.Status.SelectedMetadata;
         if (metadata?.HasValidLocation != true)
         {
             return;

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -29,9 +29,6 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     private readonly ThumbnailGenerationCoordinator _thumbnailCoordinator;
 
     private string? _currentFolderPath;
-    private string? _statusMessage;
-    private Visibility _statusVisibility = Visibility.Collapsed;
-    private InfoBarSeverity _statusSeverity = InfoBarSeverity.Informational;
     private bool _showImagesOnly = true;
     private bool _showDetailsModifiedColumn = true;
     private bool _showDetailsResolutionColumn = true;
@@ -47,22 +44,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     private readonly List<PhotoListItem> _selectedItems = new();
     private bool _batchSelectionUpdate;
     private int _selectedCount;
-    private PhotoMetadata? _selectedMetadata;
-    private CancellationTokenSource? _metadataCts;
     private CancellationTokenSource? _loadFolderCts;
-    private string? _statusTitle;
-    private string? _statusDetail;
-    private Symbol _statusSymbol = Symbol.Help;
-    private StatusAction _statusPrimaryAction;
-    private StatusAction _statusSecondaryAction;
-    private string? _statusPrimaryActionLabel;
-    private string? _statusSecondaryActionLabel;
-    private Visibility _statusPrimaryActionVisibility = Visibility.Collapsed;
-    private Visibility _statusSecondaryActionVisibility = Visibility.Collapsed;
-    private string? _statusBarText;
-    private Symbol _statusBarLocationSymbol = Symbol.Map;
-    private Visibility _statusBarLocationVisibility = Visibility.Collapsed;
-    private string? _statusBarLocationTooltip;
     private Func<Task>? _openFolderAction;
     private Func<Task>? _createFolderAction;
     private Func<Task>? _renameSelectionAction;
@@ -97,13 +79,14 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         _folderWatcherService = folderWatcherService ?? new FolderWatcherService();
         _folderWatcherService.FolderChanged += OnFolderWatcherChanged;
         _uiDispatcher = uiDispatcher ?? new UiDispatcher();
+        Status = new FileBrowserStatusViewModel(_uiDispatcher);
         _thumbnailCoordinator = new ThumbnailGenerationCoordinator(_uiDispatcher, _fileOperationService.IsJpegFile);
         _operationCoordinator = new FileOperationCoordinator(
             _fileOperationService,
             _uiDispatcher,
             onMoveInProgressChanged: _ => OnMoveInProgressChanged(),
             onCopyInProgressChanged: _ => OnCopyInProgressChanged(),
-            onStatusBarTextChanged: text => StatusBarText = text,
+            onStatusBarTextChanged: Status.SetStatusBarText,
             onClipboardChanged: OnClipboardChanged);
 
         // WorkspaceState にナビゲーションコールバックを設定
@@ -192,23 +175,8 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         }
     }
 
-    public string? StatusMessage
-    {
-        get => _statusMessage;
-        private set => SetProperty(ref _statusMessage, value);
-    }
-
-    public Visibility StatusVisibility
-    {
-        get => _statusVisibility;
-        private set => SetProperty(ref _statusVisibility, value);
-    }
-
-    public InfoBarSeverity StatusSeverity
-    {
-        get => _statusSeverity;
-        private set => SetProperty(ref _statusSeverity, value);
-    }
+    /// <summary>ステータスオーバーレイ・ステータスバー・メタデータロードを担う子 ViewModel。</summary>
+    public FileBrowserStatusViewModel Status { get; }
 
     public bool ShowImagesOnly
     {
@@ -430,66 +398,6 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         }
     }
 
-    public string? StatusTitle
-    {
-        get => _statusTitle;
-        private set => SetProperty(ref _statusTitle, value);
-    }
-
-    public string? StatusDetail
-    {
-        get => _statusDetail;
-        private set => SetProperty(ref _statusDetail, value);
-    }
-
-    public Symbol StatusSymbol
-    {
-        get => _statusSymbol;
-        private set => SetProperty(ref _statusSymbol, value);
-    }
-
-    public StatusAction StatusPrimaryAction
-    {
-        get => _statusPrimaryAction;
-        private set => SetProperty(ref _statusPrimaryAction, value);
-    }
-
-    public StatusAction StatusSecondaryAction
-    {
-        get => _statusSecondaryAction;
-        private set => SetProperty(ref _statusSecondaryAction, value);
-    }
-
-    public string? StatusPrimaryActionLabel
-    {
-        get => _statusPrimaryActionLabel;
-        private set => SetProperty(ref _statusPrimaryActionLabel, value);
-    }
-
-    public string? StatusSecondaryActionLabel
-    {
-        get => _statusSecondaryActionLabel;
-        private set => SetProperty(ref _statusSecondaryActionLabel, value);
-    }
-
-    public Visibility StatusPrimaryActionVisibility
-    {
-        get => _statusPrimaryActionVisibility;
-        private set => SetProperty(ref _statusPrimaryActionVisibility, value);
-    }
-
-    public Visibility StatusSecondaryActionVisibility
-    {
-        get => _statusSecondaryActionVisibility;
-        private set => SetProperty(ref _statusSecondaryActionVisibility, value);
-    }
-
-    public string? StatusBarText
-    {
-        get => _statusBarText;
-        private set => SetProperty(ref _statusBarText, value);
-    }
-
     public bool IsMoveInProgress => _operationCoordinator.IsMoveInProgress;
 
     public Visibility CancelMoveVisibility => IsMoveInProgress ? Visibility.Visible : Visibility.Collapsed;
@@ -503,24 +411,6 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 
     public ICommand CancelMoveCommand { get; private set; }
     public ICommand CancelCopyCommand { get; private set; }
-
-    public Symbol StatusBarLocationSymbol
-    {
-        get => _statusBarLocationSymbol;
-        private set => SetProperty(ref _statusBarLocationSymbol, value);
-    }
-
-    public Visibility StatusBarLocationVisibility
-    {
-        get => _statusBarLocationVisibility;
-        private set => SetProperty(ref _statusBarLocationVisibility, value);
-    }
-
-    public string? StatusBarLocationTooltip
-    {
-        get => _statusBarLocationTooltip;
-        private set => SetProperty(ref _statusBarLocationTooltip, value);
-    }
 
     public ICommand NavigateBackCommand { get; }
     public ICommand NavigateForwardCommand { get; }
@@ -553,8 +443,6 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     public bool CanCopySelection => SelectedCount > 0;
     public bool CanOpenInExplorer => !string.IsNullOrWhiteSpace(CurrentFolderPath);
     public bool CanOpenInGoogleMaps => SelectedCount == 1 && SelectedItem?.HasLocation == true;
-
-    internal PhotoMetadata? SelectedMetadata => _selectedMetadata;
 
     public string NameSortIndicator => GetSortIndicator(FileSortColumn.Name);
     public string TakenAtSortIndicator => GetSortIndicator(FileSortColumn.TakenAt);
@@ -665,7 +553,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         {
             var doneText = LocalizationService.Format(
                 doneMessageResourceKey, summary.SuccessCount, summary.SkipCount, summary.FailureCount);
-            await _uiDispatcher.RunAsync(() => StatusBarText = doneText).ConfigureAwait(false);
+            await _uiDispatcher.RunAsync(() => Status.SetStatusBarText(doneText)).ConfigureAwait(false);
         }
     }
 
@@ -746,7 +634,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         {
             await _uiDispatcher.RunAsync(() =>
             {
-                SetStatus(LocalizationService.GetString("Message.FolderPathEmpty"), InfoBarSeverity.Error);
+                Status.SetStatus(LocalizationService.GetString("Message.FolderPathEmpty"), InfoBarSeverity.Error);
             }).ConfigureAwait(false);
             return;
         }
@@ -755,7 +643,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         {
             await _uiDispatcher.RunAsync(() =>
             {
-                SetStatus(LocalizationService.GetString("Message.FolderNotFound"), InfoBarSeverity.Error);
+                Status.SetStatus(LocalizationService.GetString("Message.FolderNotFound"), InfoBarSeverity.Error);
             }).ConfigureAwait(false);
             return;
         }
@@ -778,7 +666,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
             {
                 CurrentFolderPath = folderPath;
                 UpdateBreadcrumbs(folderPath);
-                SetStatus(null, InfoBarSeverity.Informational);
+                Status.SetStatus(null, InfoBarSeverity.Informational);
                 SelectedItem = null;
                 UpdateSelection(Array.Empty<PhotoListItem>());
             }).ConfigureAwait(false);
@@ -806,7 +694,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
                     UpdateNavigationCommands();
                 }
 
-                SetStatus(
+                Status.SetStatus(
                     Items.Count == 0 ? LocalizationService.GetString("Message.NoFilesFound") : null,
                     InfoBarSeverity.Informational);
                 UpdateStatusBar();
@@ -830,7 +718,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
             AppLog.Error($"Failed to access folder: {folderPath}", ex);
             await _uiDispatcher.RunAsync(() =>
             {
-                SetStatus(LocalizationService.GetString("Message.AccessDeniedSeeLog"), InfoBarSeverity.Error);
+                Status.SetStatus(LocalizationService.GetString("Message.AccessDeniedSeeLog"), InfoBarSeverity.Error);
             }).ConfigureAwait(false);
         }
         catch (DirectoryNotFoundException ex)
@@ -838,7 +726,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
             AppLog.Error($"Folder not found: {folderPath}", ex);
             await _uiDispatcher.RunAsync(() =>
             {
-                SetStatus(LocalizationService.GetString("Message.FolderNotFoundSeeLog"), InfoBarSeverity.Error);
+                Status.SetStatus(LocalizationService.GetString("Message.FolderNotFoundSeeLog"), InfoBarSeverity.Error);
             }).ConfigureAwait(false);
         }
         catch (IOException ex)
@@ -846,7 +734,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
             AppLog.Error($"Failed to read folder: {folderPath}", ex);
             await _uiDispatcher.RunAsync(() =>
             {
-                SetStatus(LocalizationService.GetString("Message.FailedReadFolderSeeLog"), InfoBarSeverity.Error);
+                Status.SetStatus(LocalizationService.GetString("Message.FailedReadFolderSeeLog"), InfoBarSeverity.Error);
             }).ConfigureAwait(false);
         }
 #pragma warning disable CA1031
@@ -857,7 +745,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
             await _uiDispatcher.RunAsync(() =>
             {
                 Items.Clear();
-                SetStatus(LocalizationService.GetString("Message.FailedReadFolderSeeLog"), InfoBarSeverity.Error);
+                Status.SetStatus(LocalizationService.GetString("Message.FailedReadFolderSeeLog"), InfoBarSeverity.Error);
             }).ConfigureAwait(false);
         }
     }
@@ -869,7 +757,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         {
             await _uiDispatcher.RunAsync(() =>
             {
-                SetStatus(LocalizationService.GetString("Message.PicturesFolderNotFound"), InfoBarSeverity.Error);
+                Status.SetStatus(LocalizationService.GetString("Message.PicturesFolderNotFound"), InfoBarSeverity.Error);
             }).ConfigureAwait(false);
             return;
         }
@@ -1107,7 +995,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         _folderWatcherService.FolderChanged -= OnFolderWatcherChanged;
         _folderWatcherService.Dispose();
         _thumbnailCoordinator.Dispose();
-        CancelMetadataLoad();
+        Status.Dispose();
         CancelFolderLoad();
         _operationCoordinator.Dispose();
     }
@@ -1193,80 +1081,13 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     private void UpdateFilterState()
     {
         HasActiveFilters = !string.IsNullOrWhiteSpace(SearchText) || !ShowImagesOnly;
-        UpdateStatusOverlay(StatusMessage, _statusSeverity);
+        Status.NotifyFiltersChanged(HasActiveFilters);
 
         // フィルタ変更時は現在のフォルダを再読み込み（履歴には追加しない）
         if (!string.IsNullOrWhiteSpace(CurrentFolderPath))
         {
             _ = LoadFolderAsync(CurrentFolderPath, updateHistory: false);
         }
-    }
-
-    private void SetStatus(string? message, InfoBarSeverity severity)
-    {
-        _statusSeverity = severity;
-        StatusMessage = message;
-        StatusSeverity = severity;
-        StatusVisibility = string.IsNullOrWhiteSpace(message) ? Visibility.Collapsed : Visibility.Visible;
-        UpdateStatusOverlay(message, severity);
-    }
-
-    private void UpdateStatusOverlay(string? message, InfoBarSeverity severity)
-    {
-        if (string.IsNullOrWhiteSpace(message))
-        {
-            StatusTitle = null;
-            StatusDetail = null;
-            StatusSymbol = Symbol.Help;
-            SetStatusActions(StatusAction.None, StatusAction.None);
-            return;
-        }
-
-        if (message == LocalizationService.GetString("Message.NoFilesFound"))
-        {
-            StatusTitle = LocalizationService.GetString("Overlay.NoFilesFoundTitle");
-            StatusDetail = HasActiveFilters
-                ? LocalizationService.GetString("Overlay.NoFilesFoundDetailWithFilters")
-                : LocalizationService.GetString("Overlay.NoFilesFoundDetail");
-            StatusSymbol = Symbol.Pictures;
-            SetStatusActions(StatusAction.OpenFolder, HasActiveFilters ? StatusAction.ResetFilters : StatusAction.None);
-            return;
-        }
-
-        if (severity == InfoBarSeverity.Error)
-        {
-            StatusTitle = LocalizationService.GetString("Overlay.LoadFolderErrorTitle");
-            StatusDetail = message;
-            StatusSymbol = Symbol.Folder;
-            SetStatusActions(StatusAction.OpenFolder, StatusAction.GoHome);
-            return;
-        }
-
-        StatusTitle = message;
-        StatusDetail = null;
-        StatusSymbol = Symbol.Help;
-        SetStatusActions(StatusAction.None, StatusAction.None);
-    }
-
-    private void SetStatusActions(StatusAction primary, StatusAction secondary)
-    {
-        StatusPrimaryAction = primary;
-        StatusSecondaryAction = secondary;
-        StatusPrimaryActionLabel = GetActionLabel(primary);
-        StatusSecondaryActionLabel = GetActionLabel(secondary);
-        StatusPrimaryActionVisibility = primary == StatusAction.None ? Visibility.Collapsed : Visibility.Visible;
-        StatusSecondaryActionVisibility = secondary == StatusAction.None ? Visibility.Collapsed : Visibility.Visible;
-    }
-
-    private static string? GetActionLabel(StatusAction action)
-    {
-        return action switch
-        {
-            StatusAction.OpenFolder => LocalizationService.GetString("Action.OpenFolder"),
-            StatusAction.GoHome => LocalizationService.GetString("Action.GoHome"),
-            StatusAction.ResetFilters => LocalizationService.GetString("Action.ResetFilters"),
-            _ => null
-        };
     }
 
     private void UpdateNavigationCommands()
@@ -1313,139 +1134,11 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         }
 
         UpdateStatusBar();
-        _ = LoadMetadataAsync(SelectedItem);
+        _ = Status.LoadMetadataAsync(SelectedItem);
     }
 
     private void UpdateStatusBar()
-    {
-        var folderLabel = string.IsNullOrWhiteSpace(CurrentFolderPath)
-            ? LocalizationService.GetString("StatusBar.NoFolderSelected")
-            : CurrentFolderPath;
-        var itemCount = Items.Count;
-        string? selectedLabel;
-        if (SelectedCount == 0)
-        {
-            selectedLabel = null;
-        }
-        else if (SelectedCount == 1 && SelectedItem is not null)
-        {
-            selectedLabel = LocalizationService.Format("StatusBar.Selected", SelectedItem.FileName);
-        }
-        else
-        {
-            selectedLabel = LocalizationService.Format("StatusBar.SelectedMultiple", SelectedCount);
-        }
-
-        var resolutionLabel = SelectedCount == 1 && SelectedItem is not null && !SelectedItem.IsFolder
-            ? SelectedItem.ResolutionText
-            : null;
-
-        var itemsLabel = LocalizationService.Format("StatusBar.Items", itemCount);
-        var statusText = selectedLabel is null
-            ? $"{folderLabel} | {itemsLabel}"
-            : $"{folderLabel} | {itemsLabel} | {selectedLabel}";
-        if (!string.IsNullOrWhiteSpace(resolutionLabel))
-        {
-            statusText = $"{statusText} | {resolutionLabel}";
-        }
-
-        StatusBarText = statusText;
-        UpdateStatusBarLocation();
-    }
-
-    private void UpdateStatusBarLocation()
-    {
-        if (SelectedCount != 1 || SelectedItem is null || SelectedItem.IsFolder)
-        {
-            StatusBarLocationVisibility = Visibility.Collapsed;
-            StatusBarLocationSymbol = Symbol.Map;
-            StatusBarLocationTooltip = null;
-            return;
-        }
-
-        if (_selectedMetadata?.HasValidLocation == true)
-        {
-            StatusBarLocationVisibility = Visibility.Visible;
-            StatusBarLocationSymbol = Symbol.Map;
-            StatusBarLocationTooltip = LocalizationService.GetString("StatusBar.GpsAvailable");
-        }
-        else if (_selectedMetadata is null)
-        {
-            StatusBarLocationVisibility = Visibility.Collapsed;
-            StatusBarLocationSymbol = Symbol.Map;
-            StatusBarLocationTooltip = null;
-        }
-        else if (_selectedMetadata.IsLikelyLocationFixFailed)
-        {
-            StatusBarLocationVisibility = Visibility.Visible;
-            StatusBarLocationSymbol = Symbol.Important;
-            StatusBarLocationTooltip = LocalizationService.GetString("StatusBar.GpsFixFailed");
-        }
-        else
-        {
-            StatusBarLocationVisibility = Visibility.Visible;
-            StatusBarLocationSymbol = Symbol.Cancel;
-            StatusBarLocationTooltip = LocalizationService.GetString("StatusBar.GpsMissing");
-        }
-    }
-
-    private async Task LoadMetadataAsync(PhotoListItem? item)
-    {
-        var previousCts = _metadataCts;
-        _metadataCts = null;
-        if (previousCts is not null)
-        {
-            await previousCts.CancelAsync().ConfigureAwait(false);
-            previousCts.Dispose();
-        }
-
-        if (item is null || item.IsFolder)
-        {
-            _selectedMetadata = null;
-            await _uiDispatcher.RunAsync(UpdateStatusBarLocation).ConfigureAwait(false);
-            return;
-        }
-
-        _selectedMetadata = null;
-        await _uiDispatcher.RunAsync(UpdateStatusBarLocation).ConfigureAwait(false);
-
-        var cts = new CancellationTokenSource();
-        _metadataCts = cts;
-
-        try
-        {
-            var metadata = await ExifService.GetMetadataAsync(item.FilePath, cts.Token).ConfigureAwait(false);
-            if (cts.Token.IsCancellationRequested)
-            {
-                return;
-            }
-
-            _selectedMetadata = metadata;
-            await _uiDispatcher.RunAsync(UpdateStatusBarLocation).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-            // メタデータ読み込み処理がキャンセルされた場合は想定された動作のため、何もしない
-        }
-    }
-
-    private void CancelMetadataLoad()
-    {
-        var previousCts = _metadataCts;
-        _metadataCts = null;
-        if (previousCts is not null)
-        {
-            try
-            {
-                previousCts.Cancel();
-                previousCts.Dispose();
-            }
-            catch (ObjectDisposedException)
-            {
-                // 既に破棄済み
-            }
-        }
-    }
+        => Status.UpdateStatusBar(CurrentFolderPath, Items.Count, SelectedCount, SelectedItem);
 
     private bool IsJpegFile(PhotoListItem? item)
         => item is { IsFolder: false } && _fileOperationService.IsJpegFile(item.FilePath);

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserStatusViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserStatusViewModel.cs
@@ -1,0 +1,387 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using PhotoGeoExplorer.Models;
+using PhotoGeoExplorer.Services;
+using PhotoGeoExplorer.ViewModels;
+
+namespace PhotoGeoExplorer.Panes.FileBrowser;
+
+/// <summary>
+/// ファイルブラウザのステータス表示を担う子 ViewModel。
+/// ステータスオーバーレイ（空フォルダ・エラー時の案内）、ステータスバー（フォルダ/件数/選択/GPS 表示）、
+/// 選択アイテムの EXIF メタデータ非同期ロード（CTS 管理を含む）を担当する。
+/// 親 ViewModel から選択変更・フォルダ読み込み・フィルタ変更のタイミングでメソッド呼び出しで状態を受け取る。
+/// </summary>
+internal sealed class FileBrowserStatusViewModel : BindableBase, IDisposable
+{
+    private readonly IUiDispatcher _uiDispatcher;
+    private readonly Func<string, CancellationToken, Task<PhotoMetadata?>> _getMetadataAsync;
+
+    private string? _statusMessage;
+    private Visibility _statusVisibility = Visibility.Collapsed;
+    private InfoBarSeverity _statusSeverity = InfoBarSeverity.Informational;
+    private string? _statusTitle;
+    private string? _statusDetail;
+    private Symbol _statusSymbol = Symbol.Help;
+    private StatusAction _statusPrimaryAction;
+    private StatusAction _statusSecondaryAction;
+    private string? _statusPrimaryActionLabel;
+    private string? _statusSecondaryActionLabel;
+    private Visibility _statusPrimaryActionVisibility = Visibility.Collapsed;
+    private Visibility _statusSecondaryActionVisibility = Visibility.Collapsed;
+    private string? _statusBarText;
+    private Symbol _statusBarLocationSymbol = Symbol.Map;
+    private Visibility _statusBarLocationVisibility = Visibility.Collapsed;
+    private string? _statusBarLocationTooltip;
+    private PhotoMetadata? _selectedMetadata;
+    private CancellationTokenSource? _metadataCts;
+    private bool _hasActiveFilters;
+    private int _selectedCount;
+    private PhotoListItem? _selectedItem;
+
+    /// <param name="uiDispatcher">メタデータロード完了時の UI 更新に使うディスパッチャ。</param>
+    /// <param name="getMetadataAsync">EXIF メタデータ取得処理。null の場合は <see cref="ExifService.GetMetadataAsync"/>（テスト用シーム）。</param>
+    public FileBrowserStatusViewModel(
+        IUiDispatcher uiDispatcher,
+        Func<string, CancellationToken, Task<PhotoMetadata?>>? getMetadataAsync = null)
+    {
+        ArgumentNullException.ThrowIfNull(uiDispatcher);
+
+        _uiDispatcher = uiDispatcher;
+        _getMetadataAsync = getMetadataAsync ?? ExifService.GetMetadataAsync;
+    }
+
+    public string? StatusMessage
+    {
+        get => _statusMessage;
+        private set => SetProperty(ref _statusMessage, value);
+    }
+
+    public Visibility StatusVisibility
+    {
+        get => _statusVisibility;
+        private set => SetProperty(ref _statusVisibility, value);
+    }
+
+    public InfoBarSeverity StatusSeverity
+    {
+        get => _statusSeverity;
+        private set => SetProperty(ref _statusSeverity, value);
+    }
+
+    public string? StatusTitle
+    {
+        get => _statusTitle;
+        private set => SetProperty(ref _statusTitle, value);
+    }
+
+    public string? StatusDetail
+    {
+        get => _statusDetail;
+        private set => SetProperty(ref _statusDetail, value);
+    }
+
+    public Symbol StatusSymbol
+    {
+        get => _statusSymbol;
+        private set => SetProperty(ref _statusSymbol, value);
+    }
+
+    public StatusAction StatusPrimaryAction
+    {
+        get => _statusPrimaryAction;
+        private set => SetProperty(ref _statusPrimaryAction, value);
+    }
+
+    public StatusAction StatusSecondaryAction
+    {
+        get => _statusSecondaryAction;
+        private set => SetProperty(ref _statusSecondaryAction, value);
+    }
+
+    public string? StatusPrimaryActionLabel
+    {
+        get => _statusPrimaryActionLabel;
+        private set => SetProperty(ref _statusPrimaryActionLabel, value);
+    }
+
+    public string? StatusSecondaryActionLabel
+    {
+        get => _statusSecondaryActionLabel;
+        private set => SetProperty(ref _statusSecondaryActionLabel, value);
+    }
+
+    public Visibility StatusPrimaryActionVisibility
+    {
+        get => _statusPrimaryActionVisibility;
+        private set => SetProperty(ref _statusPrimaryActionVisibility, value);
+    }
+
+    public Visibility StatusSecondaryActionVisibility
+    {
+        get => _statusSecondaryActionVisibility;
+        private set => SetProperty(ref _statusSecondaryActionVisibility, value);
+    }
+
+    public string? StatusBarText
+    {
+        get => _statusBarText;
+        private set => SetProperty(ref _statusBarText, value);
+    }
+
+    public Symbol StatusBarLocationSymbol
+    {
+        get => _statusBarLocationSymbol;
+        private set => SetProperty(ref _statusBarLocationSymbol, value);
+    }
+
+    public Visibility StatusBarLocationVisibility
+    {
+        get => _statusBarLocationVisibility;
+        private set => SetProperty(ref _statusBarLocationVisibility, value);
+    }
+
+    public string? StatusBarLocationTooltip
+    {
+        get => _statusBarLocationTooltip;
+        private set => SetProperty(ref _statusBarLocationTooltip, value);
+    }
+
+    /// <summary>選択中アイテムの EXIF メタデータ。View のコンテキストメニュー（Google Maps で開く等）から参照される。</summary>
+    internal PhotoMetadata? SelectedMetadata => _selectedMetadata;
+
+    /// <summary>
+    /// ステータスメッセージを設定し、オーバーレイ表示を更新する。UI スレッド上から呼び出すこと。
+    /// </summary>
+    public void SetStatus(string? message, InfoBarSeverity severity)
+    {
+        StatusMessage = message;
+        StatusSeverity = severity;
+        StatusVisibility = string.IsNullOrWhiteSpace(message) ? Visibility.Collapsed : Visibility.Visible;
+        UpdateStatusOverlay(message, severity);
+    }
+
+    /// <summary>
+    /// フィルタ状態の変化を受け取り、オーバーレイの文言・アクションを再評価する。
+    /// </summary>
+    public void NotifyFiltersChanged(bool hasActiveFilters)
+    {
+        _hasActiveFilters = hasActiveFilters;
+        UpdateStatusOverlay(StatusMessage, _statusSeverity);
+    }
+
+    /// <summary>
+    /// 現在のフォルダ・件数・選択状態からステータスバーのテキストと GPS アイコンを更新する。
+    /// 選択状態はメタデータロード完了時の GPS アイコン再評価にも使うため内部に保持する。
+    /// </summary>
+    public void UpdateStatusBar(string? currentFolderPath, int itemCount, int selectedCount, PhotoListItem? selectedItem)
+    {
+        _selectedCount = selectedCount;
+        _selectedItem = selectedItem;
+
+        var folderLabel = string.IsNullOrWhiteSpace(currentFolderPath)
+            ? LocalizationService.GetString("StatusBar.NoFolderSelected")
+            : currentFolderPath;
+        string? selectedLabel;
+        if (selectedCount == 0)
+        {
+            selectedLabel = null;
+        }
+        else if (selectedCount == 1 && selectedItem is not null)
+        {
+            selectedLabel = LocalizationService.Format("StatusBar.Selected", selectedItem.FileName);
+        }
+        else
+        {
+            selectedLabel = LocalizationService.Format("StatusBar.SelectedMultiple", selectedCount);
+        }
+
+        var resolutionLabel = selectedCount == 1 && selectedItem is not null && !selectedItem.IsFolder
+            ? selectedItem.ResolutionText
+            : null;
+
+        var itemsLabel = LocalizationService.Format("StatusBar.Items", itemCount);
+        var statusText = selectedLabel is null
+            ? $"{folderLabel} | {itemsLabel}"
+            : $"{folderLabel} | {itemsLabel} | {selectedLabel}";
+        if (!string.IsNullOrWhiteSpace(resolutionLabel))
+        {
+            statusText = $"{statusText} | {resolutionLabel}";
+        }
+
+        StatusBarText = statusText;
+        UpdateStatusBarLocation();
+    }
+
+    /// <summary>
+    /// ステータスバーのテキストを直接設定する（Move/Copy の進捗・完了メッセージ用）。
+    /// </summary>
+    public void SetStatusBarText(string? text)
+    {
+        StatusBarText = text;
+    }
+
+    /// <summary>
+    /// 選択アイテムの EXIF メタデータを非同期ロードし、完了時に GPS アイコンを更新する。
+    /// 先行するロードはキャンセルする。
+    /// </summary>
+    public async Task LoadMetadataAsync(PhotoListItem? item)
+    {
+        var previousCts = _metadataCts;
+        _metadataCts = null;
+        if (previousCts is not null)
+        {
+            await previousCts.CancelAsync().ConfigureAwait(false);
+            previousCts.Dispose();
+        }
+
+        if (item is null || item.IsFolder)
+        {
+            _selectedMetadata = null;
+            await _uiDispatcher.RunAsync(UpdateStatusBarLocation).ConfigureAwait(false);
+            return;
+        }
+
+        _selectedMetadata = null;
+        await _uiDispatcher.RunAsync(UpdateStatusBarLocation).ConfigureAwait(false);
+
+        var cts = new CancellationTokenSource();
+        _metadataCts = cts;
+
+        try
+        {
+            var metadata = await _getMetadataAsync(item.FilePath, cts.Token).ConfigureAwait(false);
+            if (cts.Token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            _selectedMetadata = metadata;
+            await _uiDispatcher.RunAsync(UpdateStatusBarLocation).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // メタデータ読み込み処理がキャンセルされた場合は想定された動作のため、何もしない
+        }
+    }
+
+    public void CancelMetadataLoad()
+    {
+        var previousCts = _metadataCts;
+        _metadataCts = null;
+        if (previousCts is not null)
+        {
+            try
+            {
+                previousCts.Cancel();
+                previousCts.Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+                // 既に破棄済み
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        CancelMetadataLoad();
+    }
+
+    private void UpdateStatusOverlay(string? message, InfoBarSeverity severity)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            StatusTitle = null;
+            StatusDetail = null;
+            StatusSymbol = Symbol.Help;
+            SetStatusActions(StatusAction.None, StatusAction.None);
+            return;
+        }
+
+        if (message == LocalizationService.GetString("Message.NoFilesFound"))
+        {
+            StatusTitle = LocalizationService.GetString("Overlay.NoFilesFoundTitle");
+            StatusDetail = _hasActiveFilters
+                ? LocalizationService.GetString("Overlay.NoFilesFoundDetailWithFilters")
+                : LocalizationService.GetString("Overlay.NoFilesFoundDetail");
+            StatusSymbol = Symbol.Pictures;
+            SetStatusActions(StatusAction.OpenFolder, _hasActiveFilters ? StatusAction.ResetFilters : StatusAction.None);
+            return;
+        }
+
+        if (severity == InfoBarSeverity.Error)
+        {
+            StatusTitle = LocalizationService.GetString("Overlay.LoadFolderErrorTitle");
+            StatusDetail = message;
+            StatusSymbol = Symbol.Folder;
+            SetStatusActions(StatusAction.OpenFolder, StatusAction.GoHome);
+            return;
+        }
+
+        StatusTitle = message;
+        StatusDetail = null;
+        StatusSymbol = Symbol.Help;
+        SetStatusActions(StatusAction.None, StatusAction.None);
+    }
+
+    private void SetStatusActions(StatusAction primary, StatusAction secondary)
+    {
+        StatusPrimaryAction = primary;
+        StatusSecondaryAction = secondary;
+        StatusPrimaryActionLabel = GetActionLabel(primary);
+        StatusSecondaryActionLabel = GetActionLabel(secondary);
+        StatusPrimaryActionVisibility = primary == StatusAction.None ? Visibility.Collapsed : Visibility.Visible;
+        StatusSecondaryActionVisibility = secondary == StatusAction.None ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    private static string? GetActionLabel(StatusAction action)
+    {
+        return action switch
+        {
+            StatusAction.OpenFolder => LocalizationService.GetString("Action.OpenFolder"),
+            StatusAction.GoHome => LocalizationService.GetString("Action.GoHome"),
+            StatusAction.ResetFilters => LocalizationService.GetString("Action.ResetFilters"),
+            _ => null
+        };
+    }
+
+    private void UpdateStatusBarLocation()
+    {
+        if (_selectedCount != 1 || _selectedItem is null || _selectedItem.IsFolder)
+        {
+            StatusBarLocationVisibility = Visibility.Collapsed;
+            StatusBarLocationSymbol = Symbol.Map;
+            StatusBarLocationTooltip = null;
+            return;
+        }
+
+        if (_selectedMetadata?.HasValidLocation == true)
+        {
+            StatusBarLocationVisibility = Visibility.Visible;
+            StatusBarLocationSymbol = Symbol.Map;
+            StatusBarLocationTooltip = LocalizationService.GetString("StatusBar.GpsAvailable");
+        }
+        else if (_selectedMetadata is null)
+        {
+            StatusBarLocationVisibility = Visibility.Collapsed;
+            StatusBarLocationSymbol = Symbol.Map;
+            StatusBarLocationTooltip = null;
+        }
+        else if (_selectedMetadata.IsLikelyLocationFixFailed)
+        {
+            StatusBarLocationVisibility = Visibility.Visible;
+            StatusBarLocationSymbol = Symbol.Important;
+            StatusBarLocationTooltip = LocalizationService.GetString("StatusBar.GpsFixFailed");
+        }
+        else
+        {
+            StatusBarLocationVisibility = Visibility.Visible;
+            StatusBarLocationSymbol = Symbol.Cancel;
+            StatusBarLocationTooltip = LocalizationService.GetString("StatusBar.GpsMissing");
+        }
+    }
+}

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserStatusViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserStatusViewModel.cs
@@ -249,12 +249,15 @@ internal sealed class FileBrowserStatusViewModel : BindableBase, IDisposable
         await _uiDispatcher.RunAsync(UpdateStatusBarLocation).ConfigureAwait(false);
 
         var cts = new CancellationTokenSource();
+        // CancelMetadataLoad が CTS を Dispose した後に Token getter へ触れると
+        // ObjectDisposedException になるため、await 前に CancellationToken を保持する
+        var token = cts.Token;
         _metadataCts = cts;
 
         try
         {
-            var metadata = await _getMetadataAsync(item.FilePath, cts.Token).ConfigureAwait(false);
-            if (cts.Token.IsCancellationRequested)
+            var metadata = await _getMetadataAsync(item.FilePath, token).ConfigureAwait(false);
+            if (token.IsCancellationRequested)
             {
                 return;
             }


### PR DESCRIPTION
## 要約

#150 Phase 1 の第4弾（#155）。`FileBrowserPaneViewModel.cs`（1,485 行）からステータスオーバーレイ・ステータスバー・選択アイテムの EXIF メタデータ非同期ロード（約 340 行）を子 ViewModel `FileBrowserStatusViewModel` へ分離しました。

## 変更内容

### `Panes/FileBrowser/FileBrowserStatusViewModel.cs`（新設）
- ステータスオーバーレイ: `StatusTitle` / `StatusDetail` / `StatusSymbol` / `StatusPrimaryAction` / `StatusSecondaryAction` / 各 Label・Visibility、`SetStatus` / `UpdateStatusOverlay` / `SetStatusActions` / `GetActionLabel`
- ステータスバー: `StatusBarText` / `StatusBarLocationSymbol` / `StatusBarLocationVisibility` / `StatusBarLocationTooltip`、`UpdateStatusBar` / `UpdateStatusBarLocation`
- メタデータロード: `LoadMetadataAsync` / `CancelMetadataLoad`。先行ロードをキャンセルする CTS 管理は子 VM 内に閉じ、UI 更新は `IUiDispatcher`（#152）経由
- `SelectedMetadata` は View のコンテキストメニュー（Google Maps で開く）から参照されるため `internal` で公開を維持
- メタデータ取得は `Func` 注入のテスト用シーム（既定は `ExifService.GetMetadataAsync`、`ThumbnailGenerationCoordinator` と同パターン）

### 親 ViewModel
- `Status` プロパティとして子 VM を公開。選択変更・フォルダ読み込み・フィルタ変更のタイミングで子 VM のメソッドを呼ぶ（イベント購読でなく明示的なメソッド呼び出し）
- Move/Copy の進捗・完了メッセージは `FileOperationCoordinator`（#154）→ `Status.SetStatusBarText` の通知経路で維持
- `SetStatus` 内にあった `_statusSeverity` へのフィールド直接代入と `StatusSeverity` setter の二重代入は、子 VM では setter 経由に一本化（`StatusSeverity` は XAML 未バインドのため表示挙動は不変）

### XAML / View
- `FileBrowserPaneView.xaml`: オーバーレイの 8 バインディングを `Status.*` パスへ更新
- `MainWindow.xaml`: ステータスバーの 4 バインディングを `DataContext.Status.*` パスへ更新
- `FileBrowserPaneView.xaml.cs`: `StatusPrimaryAction` / `StatusSecondaryAction` / `SelectedMetadata` の参照を `ViewModel.Status.*` へ更新

### テスト
- `FileBrowserStatusViewModelTests`（15 件）を新設。オーバーレイ表示分岐・フィルタ変更時の再評価・ステータスバー組み立て・GPS アイコン状態（有効/測位失敗/GPS なし、パラメータ化テスト）・メタデータロードの先行キャンセル・`CancelMetadataLoad` を検証
- ステータス関連の既存テストは親 VM 側に存在しなかったため、移行ではなく新規追加

## 受け入れ条件の確認

- [x] ステータス関連プロパティ・メソッドが子 VM に移動し、親 VM から消えている
- [x] XAML バインディングが更新され、オーバーレイ・ステータスバー・GPS アイコンの表示経路が維持されている
- [x] ステータス関連のテストが子 VM のテストとして整備され、すべてパスする
- [x] `dotnet build` / `dotnet test`（Release, x64）が成功する

## 検証

```
dotnet build PhotoGeoExplorer.sln -c Release -p:Platform=x64  # 0 警告 0 エラー
dotnet test PhotoGeoExplorer.sln -c Release -p:Platform=x64   # 569 件全合格（新規 15 件含む）
dotnet format PhotoGeoExplorer.sln --verify-no-changes        # 差分なし
```

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)