### PR TITLE
fix: LoadFolderAsync の並行実行で破棄済み CTS アクセスによりエラーオーバーレイが誤表示される競合を修正 (#164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   - `CancellationToken` を CTS 生成直後にローカルへ保持し、並行呼び出しが CTS を `Cancel` + `Dispose` した後も破棄済み CTS に触れないよう変更。並行実行を決定的に再現する回帰テストを `FileBrowserPaneViewModelTests` に追加
   - 競合の引き金だった「画像のみ表示」トグルの二重発火を解消。チェックボックスの `Checked`/`Unchecked` ハンドラと `ToggleImagesOnlyCommand` 内の `RefreshAsync` を削除し、再読み込みは `ShowImagesOnly` setter（`UpdateFilterState`）の 1 経路に統一
   - `FileBrowserStatusViewModel.LoadMetadataAsync` の同系統 race（`_metadataCts` の差し替えが最初の await 後に行われるため、連続選択時に先行ロードのキャンセル漏れ→古いメタデータで GPS アイコン・`SelectedMetadata` が上書きされる）も修正。差し替えを最初の await より前の同期実行に移動し、回帰テストを追加
+  - `ResetFilters` で 2 つのフィルタを setter 経由で更新すると `UpdateFilterState` が二重発火し `LoadFolderAsync` が並行実行される残存パターンを解消（レビュー指摘対応）。フィールドを直接更新して再読み込みを 1 回に合流させ、回帰テストを追加
 - メタデータロード中にキャンセル（CTS 破棄）が走った後、ローダーがキャンセルを観測せず正常リターンすると破棄済み CTS の `Token` getter で `ObjectDisposedException` が発生する潜在競合を修正 (#163)
   - `CancellationToken` を await 前にローカルへ保持し、破棄済み CTS に触れないよう変更。競合を決定的に再現する回帰テストを `FileBrowserStatusViewModelTests` に追加
 - Release ビルドで `HarfBuzzSharp` などのネイティブ依存の PDB を処理しようとして `mspdbcmf.exe` パス構築バグ (MSB6011) が発生し CI が失敗する問題を修正

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   - 競合の引き金だった「画像のみ表示」トグルの二重発火を解消。チェックボックスの `Checked`/`Unchecked` ハンドラと `ToggleImagesOnlyCommand` 内の `RefreshAsync` を削除し、再読み込みは `ShowImagesOnly` setter（`UpdateFilterState`）の 1 経路に統一
   - `FileBrowserStatusViewModel.LoadMetadataAsync` の同系統 race（`_metadataCts` の差し替えが最初の await 後に行われるため、連続選択時に先行ロードのキャンセル漏れ→古いメタデータで GPS アイコン・`SelectedMetadata` が上書きされる）も修正。差し替えを最初の await より前の同期実行に移動し、回帰テストを追加
   - `ResetFilters` で 2 つのフィルタを setter 経由で更新すると `UpdateFilterState` が二重発火し `LoadFolderAsync` が並行実行される残存パターンを解消（レビュー指摘対応）。フィールドを直接更新して再読み込みを 1 回に合流させ、回帰テストを追加
+  - overlay の「フィルタをリセット」経路で View 側 `ResetFiltersAsync` が `ResetFilters()` の直後に `RefreshAsync()` を呼び `LoadFolderAsync` が 2 回並行実行される（メニュー経路は 1 回で挙動が割れていた）残存パターンを解消（レビュー指摘対応）。`ResetFilters()` が再読み込みを担う設計に合わせ View 側の冗長な `RefreshAsync` 呼び出しを除去し、両 UI 経路を 1 回に統一
 - メタデータロード中にキャンセル（CTS 破棄）が走った後、ローダーがキャンセルを観測せず正常リターンすると破棄済み CTS の `Token` getter で `ObjectDisposedException` が発生する潜在競合を修正 (#163)
   - `CancellationToken` を await 前にローカルへ保持し、破棄済み CTS に触れないよう変更。競合を決定的に再現する回帰テストを `FileBrowserStatusViewModelTests` に追加
 - Release ビルドで `HarfBuzzSharp` などのネイティブ依存の PDB を処理しようとして `mspdbcmf.exe` パス構築バグ (MSB6011) が発生し CI が失敗する問題を修正

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
   - `SetDispatcherQueue` 経路を廃止。ViewModel は `MainWindow` の DI 構築（UI スレッド上）で生成されるため、View の `OnLoaded` / `OnDataContextChanged` からの再設定は不要と確認
 
 ### 修正
+- `LoadFolderAsync` の並行実行で破棄済み CTS の `Token` アクセスにより `ObjectDisposedException` が発生し、フォルダ読み込みは成功しているのに「フォルダーの読み込みに失敗しました」エラーオーバーレイが誤表示される問題を修正 (#164)
+  - `CancellationToken` を CTS 生成直後にローカルへ保持し、並行呼び出しが CTS を `Cancel` + `Dispose` した後も破棄済み CTS に触れないよう変更。並行実行を決定的に再現する回帰テストを `FileBrowserPaneViewModelTests` に追加
+  - 競合の引き金だった「画像のみ表示」トグルの二重発火を解消。チェックボックスの `Checked`/`Unchecked` ハンドラと `ToggleImagesOnlyCommand` 内の `RefreshAsync` を削除し、再読み込みは `ShowImagesOnly` setter（`UpdateFilterState`）の 1 経路に統一
+  - `FileBrowserStatusViewModel.LoadMetadataAsync` の同系統 race（`_metadataCts` の差し替えが最初の await 後に行われるため、連続選択時に先行ロードのキャンセル漏れ→古いメタデータで GPS アイコン・`SelectedMetadata` が上書きされる）も修正。差し替えを最初の await より前の同期実行に移動し、回帰テストを追加
 - メタデータロード中にキャンセル（CTS 破棄）が走った後、ローダーがキャンセルを観測せず正常リターンすると破棄済み CTS の `Token` getter で `ObjectDisposedException` が発生する潜在競合を修正 (#163)
   - `CancellationToken` を await 前にローカルへ保持し、破棄済み CTS に触れないよう変更。競合を決定的に再現する回帰テストを `FileBrowserStatusViewModelTests` に追加
 - Release ビルドで `HarfBuzzSharp` などのネイティブ依存の PDB を処理しようとして `mspdbcmf.exe` パス構築バグ (MSB6011) が発生し CI が失敗する問題を修正

--- a/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
@@ -445,6 +445,42 @@ public class FileBrowserPaneViewModelTests
     }
 
     [Fact]
+    public async Task ResetFiltersWithBothFiltersActiveReloadsFolderExactlyOnce()
+    {
+        // 2 つのフィルタが同時に変化しても再読み込みは 1 回に合流すること（#164 と同根の二重発火対策）
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            using var viewModel = CreateViewModelWithFakes(out var fakePaneService, out _);
+            await viewModel.LoadFolderAsync(tempDir).ConfigureAwait(true);
+            viewModel.SearchText = "test";
+            viewModel.ShowImagesOnly = false;
+            Assert.Equal(3, fakePaneService.LoadFolderCallCount);
+
+            viewModel.ResetFilters();
+
+            Assert.Null(viewModel.SearchText);
+            Assert.True(viewModel.ShowImagesOnly);
+            Assert.Equal(4, fakePaneService.LoadFolderCallCount);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public void ResetFiltersWithDefaultFiltersDoesNotReloadFolder()
+    {
+        // フィルタが既定値のままなら再読み込みを起動しないこと
+        using var viewModel = CreateViewModelWithFakes(out var fakePaneService, out _);
+
+        viewModel.ResetFilters();
+
+        Assert.Equal(0, fakePaneService.LoadFolderCallCount);
+    }
+
+    [Fact]
     public void CanCreateFolderDefaultsToFalse()
     {
         // Arrange

--- a/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
@@ -370,6 +370,81 @@ public class FileBrowserPaneViewModelTests
     }
 
     [Fact]
+    public async Task LoadFolderAsyncCancelledByConcurrentCallDoesNotShowErrorOverlay()
+    {
+        // 並行する LoadFolderAsync が先行呼び出しの CTS を Cancel + Dispose した後、
+        // 先行側が破棄済み CTS に触れて ObjectDisposedException となり
+        // エラーオーバーレイを誤表示しないこと（#164 回帰テスト）
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            var paneService = new GatedFileBrowserPaneService
+            {
+                SecondLoadResult = [CreatePhotoListItem("photo.jpg")],
+            };
+            using var viewModel = new FileBrowserPaneViewModel(
+                paneService, new WorkspaceState(), null, null, new StubFileOperationService());
+
+            var firstLoad = viewModel.LoadFolderAsync(tempDir);
+            await viewModel.LoadFolderAsync(tempDir, updateHistory: false).ConfigureAwait(true);
+
+            paneService.FirstLoadGate.SetResult();
+            await firstLoad.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(true);
+
+            Assert.Equal(Visibility.Collapsed, viewModel.Status.StatusVisibility);
+            Assert.Null(viewModel.Status.StatusMessage);
+            Assert.Single(viewModel.Items);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public async Task ShowImagesOnlyChangeReloadsFolderExactlyOnce()
+    {
+        // setter（UpdateFilterState）由来の再読み込みは 1 回だけであること（#164 二重発火対策）
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            using var viewModel = CreateViewModelWithFakes(out var fakePaneService, out _);
+            await viewModel.LoadFolderAsync(tempDir).ConfigureAwait(true);
+            Assert.Equal(1, fakePaneService.LoadFolderCallCount);
+
+            viewModel.ShowImagesOnly = false;
+
+            Assert.Equal(2, fakePaneService.LoadFolderCallCount);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public async Task ToggleImagesOnlyCommandReloadsFolderExactlyOnce()
+    {
+        // コマンド経由のトグルでも再読み込みが重複しないこと（#164 二重発火対策）
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            using var viewModel = CreateViewModelWithFakes(out var fakePaneService, out _);
+            await viewModel.LoadFolderAsync(tempDir).ConfigureAwait(true);
+            Assert.Equal(1, fakePaneService.LoadFolderCallCount);
+
+            viewModel.ToggleImagesOnlyCommand.Execute(null);
+
+            Assert.False(viewModel.ShowImagesOnly);
+            Assert.Equal(2, fakePaneService.LoadFolderCallCount);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    [Fact]
     public void CanCreateFolderDefaultsToFalse()
     {
         // Arrange
@@ -1362,6 +1437,38 @@ public class FileBrowserPaneViewModelTests
         {
             LoadFolderCallCount++;
             return Task.FromResult(new List<PhotoListItem>());
+        }
+
+        public ObservableCollection<BreadcrumbSegment> GetBreadcrumbs(string folderPath) => [];
+        public List<PhotoListItem> ApplySort(IEnumerable<PhotoListItem> items, FileSortColumn column, SortDirection direction) => [.. items];
+        public PhotoListItem? FindItemByFilePath(IEnumerable<PhotoListItem> items, string filePath) => null;
+        public IReadOnlyList<PhotoListItem> ResolveItemsByFilePaths(IEnumerable<PhotoListItem> items, IReadOnlyList<string> filePaths) => Array.Empty<PhotoListItem>();
+        public string? NavigateBack(string currentPath) => null;
+        public string? NavigateForward(string currentPath) => null;
+        public void PushToBackStack(string path) { }
+        public void PushToForwardStack(string path) { }
+        public void ClearForwardStack() { }
+        public bool CanNavigateBack => false;
+        public bool CanNavigateForward => false;
+    }
+
+    /// <summary>最初の LoadFolderAsync 呼び出しだけ gate を待つ pane service。並行実行の競合再現用。</summary>
+    private sealed class GatedFileBrowserPaneService : IFileBrowserPaneService
+    {
+        private int _loadFolderCallCount;
+
+        public TaskCompletionSource FirstLoadGate { get; } = new();
+        public List<PhotoListItem> SecondLoadResult { get; set; } = [];
+
+        public async Task<List<PhotoListItem>> LoadFolderAsync(string folderPath, bool showImagesOnly, string? searchText)
+        {
+            if (Interlocked.Increment(ref _loadFolderCallCount) == 1)
+            {
+                await FirstLoadGate.Task.ConfigureAwait(false);
+                return [];
+            }
+
+            return SecondLoadResult;
         }
 
         public ObservableCollection<BreadcrumbSegment> GetBreadcrumbs(string folderPath) => [];

--- a/PhotoGeoExplorer.Tests/FileBrowserStatusViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserStatusViewModelTests.cs
@@ -330,6 +330,34 @@ public class FileBrowserStatusViewModelTests
         Assert.Null(viewModel.SelectedMetadata);
     }
 
+    [Fact]
+    public async Task LoadMetadataAsyncCancelsPreviousLoadSuspendedBeforeLoaderStarts()
+    {
+        // 先行呼び出しが最初の dispatcher await で中断している間に後続の呼び出しが走っても、
+        // 先行の CTS が観測されてキャンセルされ、古いメタデータで上書きされないこと（#164 回帰テスト）
+        var firstDispatchGate = new TaskCompletionSource();
+        var metadataFirst = new PhotoMetadata(null, null, null, latitude: 1.0, longitude: 1.0, hasGpsData: true);
+        var metadataSecond = new PhotoMetadata(null, null, null, latitude: 35.0, longitude: 139.0, hasGpsData: true);
+        using var viewModel = new FileBrowserStatusViewModel(
+            new GatedFirstRunUiDispatcher(firstDispatchGate.Task),
+            (path, _) => Task.FromResult<PhotoMetadata?>(
+                path.EndsWith("first.jpg", StringComparison.Ordinal) ? metadataFirst : metadataSecond));
+        var first = CreateFileItem("first.jpg");
+        var second = CreateFileItem("second.jpg");
+        viewModel.UpdateStatusBar("/test", itemCount: 2, selectedCount: 1, selectedItem: first);
+
+        var firstLoad = viewModel.LoadMetadataAsync(first);
+
+        viewModel.UpdateStatusBar("/test", itemCount: 2, selectedCount: 1, selectedItem: second);
+        await viewModel.LoadMetadataAsync(second);
+
+        firstDispatchGate.SetResult();
+        await firstLoad.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Same(metadataSecond, viewModel.SelectedMetadata);
+        Assert.Equal(Visibility.Visible, viewModel.StatusBarLocationVisibility);
+    }
+
     private static FileBrowserStatusViewModel CreateViewModel(
         Func<string, CancellationToken, Task<PhotoMetadata?>>? getMetadataAsync = null)
     {
@@ -366,6 +394,37 @@ public class FileBrowserStatusViewModelTests
         {
             action();
             return Task.CompletedTask;
+        }
+
+        public Task<T> EnqueueAsync<T>(Func<Task<T>> asyncFunc) => asyncFunc();
+
+        public bool TryEnqueue(Action action)
+        {
+            action();
+            return true;
+        }
+
+        public IUiDispatcherTimer? CreateTimer() => null;
+    }
+
+    /// <summary>最初の RunAsync 呼び出しだけ gate を待ってから実行するディスパッチャ。swap race の再現用。</summary>
+    private sealed class GatedFirstRunUiDispatcher : IUiDispatcher
+    {
+        private readonly Task _gate;
+        private int _runAsyncCallCount;
+
+        public GatedFirstRunUiDispatcher(Task gate) => _gate = gate;
+
+        public bool IsAvailable => true;
+
+        public async Task RunAsync(Action action)
+        {
+            if (Interlocked.Increment(ref _runAsyncCallCount) == 1)
+            {
+                await _gate.ConfigureAwait(false);
+            }
+
+            action();
         }
 
         public Task<T> EnqueueAsync<T>(Func<Task<T>> asyncFunc) => asyncFunc();

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml
@@ -255,8 +255,6 @@
             Content="Show images only"
             Margin="0,8,0,0"
             IsChecked="{Binding ShowImagesOnly, Mode=TwoWay}"
-            Checked="OnFiltersChanged"
-            Unchecked="OnFiltersChanged"
             AutomationProperties.AutomationId="ShowImagesOnlyCheckBox"
             x:Uid="ShowImagesOnlyCheckBox" />
         <Grid

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
@@ -157,15 +157,13 @@ internal sealed partial class FileBrowserPaneView : UserControl
         return ViewModel?.RefreshAsync() ?? Task.CompletedTask;
     }
 
-    public async Task ResetFiltersAsync()
+    public Task ResetFiltersAsync()
     {
-        if (ViewModel is null)
-        {
-            return;
-        }
-
-        ViewModel.ResetFilters();
-        await ViewModel.RefreshAsync().ConfigureAwait(true);
+        // ResetFilters() が UpdateFilterState 経由でフォルダ再読み込みまで担うため、
+        // ここで RefreshAsync を重ねると LoadFolderAsync が並行実行される（#164 と同根）。
+        // メニュー経路（ResetFiltersCommand）と同じく再読み込みを 1 回に揃える。
+        ViewModel?.ResetFilters();
+        return Task.CompletedTask;
     }
 
     public Task CreateFolderAsync()

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
@@ -275,11 +275,6 @@ internal sealed partial class FileBrowserPaneView : UserControl
         _detailsColumnsFlyout.ShowAt(anchor);
     }
 
-    private async void OnFiltersChanged(object sender, RoutedEventArgs e)
-    {
-        await RefreshAsync().ConfigureAwait(true);
-    }
-
     private async void OnStatusPrimaryActionClicked(object sender, RoutedEventArgs e)
     {
         if (ViewModel is null)

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -913,8 +913,20 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
 
     public void ResetFilters()
     {
-        SearchText = null;
-        ShowImagesOnly = true;
+        // setter 経由で 2 つのフィルタを更新すると UpdateFilterState が二重発火し、
+        // LoadFolderAsync が並行実行される（#164 と同じパターン）ため、
+        // フィールドを直接更新して再読み込みを 1 回に合流させる
+        var searchTextChanged = SetProperty(ref _searchText, null, nameof(SearchText));
+        var showImagesOnlyChanged = SetProperty(ref _showImagesOnly, true, nameof(ShowImagesOnly));
+        if (showImagesOnlyChanged)
+        {
+            OnPropertyChanged(nameof(ToggleImagesOnlyMenuText));
+        }
+
+        if (searchTextChanged || showImagesOnlyChanged)
+        {
+            UpdateFilterState();
+        }
     }
 
     // View が listView.SelectedItems を一括操作する間、TwoWay バインディング経由の

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -115,8 +115,10 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         });
         ToggleImagesOnlyCommand = new RelayCommand(async () =>
         {
+            // setter の UpdateFilterState がフォルダ再読み込みまで行うため、ここでの Refresh は不要
+            // （重複させると LoadFolderAsync が並行実行され、先行側がキャンセルされる）
             ShowImagesOnly = !ShowImagesOnly;
-            await RefreshAsync().ConfigureAwait(false);
+            await Task.CompletedTask.ConfigureAwait(false);
         });
         EditExifCommand = new RelayCommand(async () => await EditExifAsync().ConfigureAwait(true), () => CanEditExif);
         SetViewModeCommand = new RelayCommand<string>(tag =>
@@ -651,6 +653,9 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         // 既存の読み込み処理をキャンセル
         var previousCts = _loadFolderCts;
         var cts = new CancellationTokenSource();
+        // 後続の呼び出しや CancelFolderLoad が CTS を Dispose した後に Token getter へ触れると
+        // ObjectDisposedException になるため、await 前に CancellationToken を保持する
+        var token = cts.Token;
         _loadFolderCts = cts;
 
         if (previousCts is not null)
@@ -674,7 +679,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
             var items = await _service.LoadFolderAsync(folderPath, ShowImagesOnly, SearchText).ConfigureAwait(false);
 
             // キャンセルされた場合は処理を中断
-            cts.Token.ThrowIfCancellationRequested();
+            token.ThrowIfCancellationRequested();
 
             var sorted = _service.ApplySort(items, SortColumn, SortDirection);
 

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserStatusViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserStatusViewModel.cs
@@ -230,29 +230,37 @@ internal sealed class FileBrowserStatusViewModel : BindableBase, IDisposable
     /// </summary>
     public async Task LoadMetadataAsync(PhotoListItem? item)
     {
+        // _metadataCts の差し替え（先行 CTS の取得と新 CTS の公開）は最初の await より前に
+        // 同期的に行う。await 後に公開すると、連続呼び出し時に後続が先行の CTS を観測できず
+        // キャンセル漏れが起き、古い選択のメタデータで表示が上書きされる（#164）
         var previousCts = _metadataCts;
-        _metadataCts = null;
+        CancellationToken token = default;
+        if (item is null || item.IsFolder)
+        {
+            _metadataCts = null;
+        }
+        else
+        {
+            var cts = new CancellationTokenSource();
+            // CancelMetadataLoad が CTS を Dispose した後に Token getter へ触れると
+            // ObjectDisposedException になるため、await 前に CancellationToken を保持する
+            token = cts.Token;
+            _metadataCts = cts;
+        }
+
         if (previousCts is not null)
         {
             await previousCts.CancelAsync().ConfigureAwait(false);
             previousCts.Dispose();
         }
 
-        if (item is null || item.IsFolder)
-        {
-            _selectedMetadata = null;
-            await _uiDispatcher.RunAsync(UpdateStatusBarLocation).ConfigureAwait(false);
-            return;
-        }
-
         _selectedMetadata = null;
         await _uiDispatcher.RunAsync(UpdateStatusBarLocation).ConfigureAwait(false);
 
-        var cts = new CancellationTokenSource();
-        // CancelMetadataLoad が CTS を Dispose した後に Token getter へ触れると
-        // ObjectDisposedException になるため、await 前に CancellationToken を保持する
-        var token = cts.Token;
-        _metadataCts = cts;
+        if (item is null || item.IsFolder)
+        {
+            return;
+        }
 
         try
         {


### PR DESCRIPTION
## 要約

#164 の修正。`LoadFolderAsync` が並行実行されると、後続呼び出しが先行呼び出しの CTS を `Cancel` + `Dispose` した後、先行側が破棄済み CTS の `Token` getter に触れて `ObjectDisposedException` が発生し、フォルダ読み込みは成功しているのに「フォルダーの読み込みに失敗しました」エラーオーバーレイが誤表示され `Items.Clear()` まで実行される問題を修正しました。あわせて、PR #163 再レビューで指摘された `FileBrowserStatusViewModel.LoadMetadataAsync` の同系統 swap race と、競合の引き金だったトグル二重発火も解消しています。

## 変更内容

### `FileBrowserPaneViewModel.LoadFolderAsync`（#164 本体）
- `CancellationToken` を CTS 生成直後にローカル保持し、`cts.Token.ThrowIfCancellationRequested()` をローカル `token` 経由に変更（4d43004 と同パターン）。並行呼び出しにキャンセルされた側は `OperationCanceledException` の正常キャンセル経路に入り、エラーオーバーレイを表示しない

### トグル二重発火の解消（補足調査事項の結果）
- 原因: 「画像のみ表示」CheckBox が `IsChecked` の TwoWay バインディング（setter → `UpdateFilterState` → fire-and-forget の `LoadFolderAsync`）と `Checked`/`Unchecked="OnFiltersChanged"`（→ `RefreshAsync` → `LoadFolderAsync`）の 2 経路で再読み込みを起動し、並行実行が発生（issue のログで `EnumerateFiles` が同時刻に 2 回の現象と一致）。メニューの `ToggleImagesOnlyCommand` も setter + `RefreshAsync` で同様
- CheckBox の `Checked`/`Unchecked` ハンドラ（未使用になった `OnFiltersChanged` 含む）と `ToggleImagesOnlyCommand` 内の `RefreshAsync` を削除し、再読み込みを `ShowImagesOnly` setter の 1 経路に統一。設定画面からの同期（PropertyChanged 経由で CheckBox に伝播 → Checked 発火）で起きていた二重再読み込みも同時に解消

### `FileBrowserStatusViewModel.LoadMetadataAsync`（スコープ追加分）
- `_metadataCts` の差し替え（先行 CTS の取得・新 CTS の公開・`Token` のローカル保持）を最初の await より前に移動し、呼び出し元（UI スレッド）上で同期的に完了させた。これにより連続選択時に後続呼び出しが先行 CTS を確実に観測してキャンセルでき、古い選択のメタデータで `SelectedMetadata`・GPS アイコンが上書きされる race を解消

### テスト
- `LoadFolderAsyncCancelledByConcurrentCallDoesNotShowErrorOverlay`: gate 付き pane service で並行実行を決定的に再現。**修正前はエラーオーバーレイ Visible（issue の症状）で fail することを確認済み**
- `LoadMetadataAsyncCancelsPreviousLoadSuspendedBeforeLoaderStarts`: 最初の dispatcher await だけ gate するディスパッチャで swap race を決定的に再現。**修正前は古いメタデータの上書きで fail することを確認済み**
- `ToggleImagesOnlyCommandReloadsFolderExactlyOnce`: **修正前は再読み込み 2 回で fail することを確認済み**
- `ShowImagesOnlyChangeReloadsFolderExactlyOnce`: setter 経路の再読み込みが 1 回である不変条件を固定

## 検証

```
dotnet build PhotoGeoExplorer.sln -c Release -p:Platform=x64  # 0 警告 0 エラー
dotnet test PhotoGeoExplorer.sln -c Release -p:Platform=x64   # 574 件全合格（新規 4 件含む）
dotnet format PhotoGeoExplorer.sln --verify-no-changes        # 差分なし
```

新規回帰テスト 3 件は、プロダクション側修正を `git stash` で一時退避した状態で実行し、3 件すべて fail することを確認しています。

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
