### PR TITLE
refactor: FileBrowserPaneView のダイアログ表示を FileBrowserDialogs ヘルパーに分離 (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ## [Unreleased]
 
 ### リファクタリング
+- ダイアログ・ピッカー表示を `FileBrowserPaneView` コードビハインドから `FileBrowserDialogs` ヘルパーへ分離 (#156)
+  - 競合解決（Move/Copy）・テキスト入力・確認・メッセージ・各種操作エラー（作成/リネーム/Move/Copy/削除）ダイアログ、フォルダピッカー（HWND Interop 含む）、`EnsureXamlRootAsync` を `Panes/FileBrowser/FileBrowserDialogs.cs`（internal sealed）へ移動。View は `XamlRoot` 供給元（RootGrid）と `HostWindow` アクセサをコンストラクタで渡し、`_dialogs.ShowXxxAsync(...)` 経由で呼び出す（VM へ渡す競合解決コールバック型は不変）
+  - リソースキー以外ほぼ同一だった `ShowMoveConflictDialogAsync` / `ShowCopyConflictDialogAsync` を、リソースキー接頭辞をパラメータ化した単一実装 `ShowConflictAsync` に統合
+  - 操作エラーダイアログ群（`FileOperationError` → タイトル/メッセージの switch）は分岐表が操作種別ごとに異なるため統合せず移動のみとした（汎用 `DialogService` との統合可否を含め将来のフォローアップは #156 に記録）
+  - `FileBrowserPaneView.xaml.cs` を 1,921 行から 1,515 行へ削減（−406 行）。ダイアログ表示は View の正当な責務のため挙動は不変で、既存テスト 576 件は全件パス
 - ステータス表示とメタデータロードを `FileBrowserPaneViewModel` から子 ViewModel `FileBrowserStatusViewModel` へ分離 (#155)
   - ステータスオーバーレイ（空フォルダ・エラー時の案内とアクション）、ステータスバー（フォルダ/件数/選択/GPS アイコン）、選択アイテムの EXIF メタデータ非同期ロード（先行ロードをキャンセルする CTS 管理を含む）を `Panes/FileBrowser/FileBrowserStatusViewModel.cs`（internal sealed, BindableBase, IDisposable）へ移動
   - 親 ViewModel は `Status` プロパティとして子 VM を公開し、選択変更・フォルダ読み込み・フィルタ変更のタイミングでメソッド呼び出しで状態を渡す（イベント購読ではなく明示的な呼び出し）。XAML バインディングは `Status.StatusBarText` 等のパスに更新（`FileBrowserPaneView.xaml` のオーバーレイ、`MainWindow.xaml` のステータスバー）

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDialogs.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDialogs.cs
@@ -1,0 +1,382 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using PhotoGeoExplorer.Services;
+using PhotoGeoExplorer.ViewModels;
+using Windows.Storage;
+using Windows.Storage.Pickers;
+using WinRT.Interop;
+
+namespace PhotoGeoExplorer.Panes.FileBrowser;
+
+/// <summary>
+/// FileBrowser ペイン固有の複合ダイアログ・ピッカー表示を担うヘルパー。
+/// View から XamlRoot 供給元と HostWindow を受け取り、コードビハインドの肥大化を防ぐ。
+/// 汎用の <see cref="DialogService"/> とは責務が異なるため統合しない（フォローアップは ISSUE #156 参照）。
+/// </summary>
+internal sealed class FileBrowserDialogs
+{
+    private readonly FrameworkElement _xamlRootSource;
+    private readonly Func<Window?> _hostWindowAccessor;
+    private bool _isWaitingForXamlRoot;
+
+    public FileBrowserDialogs(FrameworkElement xamlRootSource, Func<Window?> hostWindowAccessor)
+    {
+        _xamlRootSource = xamlRootSource;
+        _hostWindowAccessor = hostWindowAccessor;
+    }
+
+    public Task<ConflictResolution> ShowMoveConflictAsync(string fileName, bool isFolder)
+        => ShowConflictAsync("Dialog.MoveConflict", fileName);
+
+    public Task<ConflictResolution> ShowCopyConflictAsync(string fileName, bool isFolder)
+        => ShowConflictAsync("Dialog.CopyConflict", fileName);
+
+    public Task ShowFileOperationErrorAsync(FileOperationError error, string defaultTitleKey)
+    {
+        var (title, message) = error switch
+        {
+            FileOperationError.InvalidName => (
+                LocalizationService.GetString("Dialog.InvalidName.Title"),
+                LocalizationService.GetString("Dialog.InvalidName.Detail")),
+            FileOperationError.AlreadyExists => (
+                LocalizationService.GetString("Dialog.AlreadyExists.Title"),
+                LocalizationService.GetString("Dialog.AlreadyExists.Detail")),
+            FileOperationError.NoParent => (
+                LocalizationService.GetString("Dialog.RenameNotAvailable.Title"),
+                LocalizationService.GetString("Dialog.RenameNotAvailable.Detail")),
+            FileOperationError.Unauthorized => (
+                LocalizationService.GetString(defaultTitleKey),
+                LocalizationService.GetString("Dialog.SeeLogDetail")),
+            _ => (
+                LocalizationService.GetString(defaultTitleKey),
+                LocalizationService.GetString("Dialog.SeeLogDetail")),
+        };
+        return ShowMessageAsync(title, message);
+    }
+
+    public Task ShowMoveOperationErrorAsync(FileOperationSummary summary)
+    {
+        var firstError = summary.Failures[0].Error;
+        var (title, message) = firstError switch
+        {
+            FileOperationError.DescendantPath => (
+                LocalizationService.GetString("Dialog.MoveFailed.Title"),
+                LocalizationService.GetString("Dialog.MoveIntoSelf.Detail")),
+            FileOperationError.AlreadyExists => (
+                LocalizationService.GetString("Dialog.AlreadyExists.Title"),
+                LocalizationService.GetString("Dialog.AlreadyExistsDestination.Detail")),
+            FileOperationError.Unauthorized => (
+                LocalizationService.GetString("Dialog.MoveFailed.Title"),
+                LocalizationService.GetString("Dialog.SeeLogDetail")),
+            _ => (
+                LocalizationService.GetString("Dialog.MoveFailed.Title"),
+                LocalizationService.GetString("Dialog.SeeLogDetail")),
+        };
+        return ShowMessageAsync(title, message);
+    }
+
+    public Task ShowCopyOperationErrorAsync(FileOperationSummary summary)
+    {
+        var firstError = summary.Failures[0].Error;
+        var (title, message) = firstError switch
+        {
+            FileOperationError.AlreadyExists => (
+                LocalizationService.GetString("Dialog.AlreadyExists.Title"),
+                LocalizationService.GetString("Dialog.AlreadyExistsDestination.Detail")),
+            FileOperationError.Unauthorized => (
+                LocalizationService.GetString("Dialog.CopyFailed.Title"),
+                LocalizationService.GetString("Dialog.SeeLogDetail")),
+            _ => (
+                LocalizationService.GetString("Dialog.CopyFailed.Title"),
+                LocalizationService.GetString("Dialog.SeeLogDetail")),
+        };
+        return ShowMessageAsync(title, message);
+    }
+
+    public Task ShowDeleteOperationErrorAsync(FileOperationSummary summary)
+    {
+        var firstError = summary.Failures[0].Error;
+        var (title, message) = firstError switch
+        {
+            FileOperationError.NoParent => (
+                LocalizationService.GetString("Dialog.DeleteNotAvailable.Title"),
+                LocalizationService.GetString("Dialog.DeleteNotAvailable.Detail")),
+            FileOperationError.Unauthorized => (
+                LocalizationService.GetString("Dialog.DeleteFailed.Title"),
+                LocalizationService.GetString("Dialog.SeeLogDetail")),
+            _ => (
+                LocalizationService.GetString("Dialog.DeleteFailed.Title"),
+                LocalizationService.GetString("Dialog.SeeLogDetail")),
+        };
+        return ShowMessageAsync(title, message);
+    }
+
+    public static string BuildDeleteMessage(PhotoListItem item)
+    {
+        return item.IsFolder
+            ? LocalizationService.Format("Dialog.DeleteConfirm.Folder", item.FileName)
+            : LocalizationService.Format("Dialog.DeleteConfirm.File", item.FileName);
+    }
+
+    public async Task<StorageFolder?> PickFolderAsync(PickerLocationId startLocation)
+    {
+        var picker = new FolderPicker
+        {
+            SuggestedStartLocation = startLocation
+        };
+        picker.FileTypeFilter.Add("*");
+
+        var hostWindow = _hostWindowAccessor();
+        if (hostWindow is null)
+        {
+            AppLog.Error("HostWindow is not set for FileBrowserPaneView.");
+            return null;
+        }
+
+        var hwnd = WindowNative.GetWindowHandle(hostWindow);
+        InitializeWithWindow.Initialize(picker, hwnd);
+
+        try
+        {
+            return await picker.PickSingleFolderAsync().AsTask().ConfigureAwait(true);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            AppLog.Error("Folder picker failed.", ex);
+        }
+        catch (System.Runtime.InteropServices.COMException ex)
+        {
+            AppLog.Error("Folder picker failed.", ex);
+        }
+
+        return null;
+    }
+
+    public async Task<string?> ShowTextInputAsync(
+        string title,
+        string primaryButtonText,
+        string? defaultText,
+        string placeholderText)
+    {
+        if (!await EnsureXamlRootAsync().ConfigureAwait(true))
+        {
+            return null;
+        }
+
+        var textBox = new TextBox
+        {
+            Text = defaultText ?? string.Empty,
+            PlaceholderText = placeholderText,
+            MinWidth = 260
+        };
+
+        var dialog = new ContentDialog
+        {
+            Title = title,
+            Content = textBox,
+            PrimaryButtonText = primaryButtonText,
+            SecondaryButtonText = LocalizationService.GetString("Common.Cancel"),
+            DefaultButton = ContentDialogButton.Primary,
+            XamlRoot = _xamlRootSource.XamlRoot
+        };
+
+        dialog.IsPrimaryButtonEnabled = !string.IsNullOrWhiteSpace(textBox.Text);
+        textBox.TextChanged += (_, _) =>
+        {
+            dialog.IsPrimaryButtonEnabled = !string.IsNullOrWhiteSpace(textBox.Text);
+        };
+        dialog.Opened += (_, _) =>
+        {
+            textBox.Focus(FocusState.Programmatic);
+            textBox.SelectAll();
+        };
+
+        var result = await dialog.ShowAsync().AsTask().ConfigureAwait(true);
+        if (result != ContentDialogResult.Primary)
+        {
+            return null;
+        }
+
+        var value = textBox.Text.Trim();
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    public async Task<bool> ShowConfirmationAsync(
+        string title,
+        string message,
+        string primaryButtonText)
+    {
+        if (!await EnsureXamlRootAsync().ConfigureAwait(true))
+        {
+            return false;
+        }
+
+        var dialog = new ContentDialog
+        {
+            Title = title,
+            Content = new TextBlock
+            {
+                Text = message,
+                TextWrapping = TextWrapping.Wrap
+            },
+            PrimaryButtonText = primaryButtonText,
+            SecondaryButtonText = LocalizationService.GetString("Common.Cancel"),
+            DefaultButton = ContentDialogButton.Secondary,
+            XamlRoot = _xamlRootSource.XamlRoot
+        };
+
+        var result = await dialog.ShowAsync().AsTask().ConfigureAwait(true);
+        return result == ContentDialogResult.Primary;
+    }
+
+    public async Task ShowMessageAsync(string title, string message)
+    {
+        if (!await EnsureXamlRootAsync().ConfigureAwait(true))
+        {
+            return;
+        }
+
+        var dialog = new ContentDialog
+        {
+            Title = title,
+            Content = new TextBlock
+            {
+                Text = message,
+                TextWrapping = TextWrapping.Wrap
+            },
+            CloseButtonText = LocalizationService.GetString("Common.Ok"),
+            XamlRoot = _xamlRootSource.XamlRoot
+        };
+
+        await dialog.ShowAsync().AsTask().ConfigureAwait(true);
+    }
+
+    /// <summary>
+    /// Move/Copy で共通の競合解決ダイアログ。リソースキー接頭辞のみが異なるため統一実装とする。
+    /// </summary>
+    private async Task<ConflictResolution> ShowConflictAsync(string resourcePrefix, string fileName)
+    {
+        var detail = LocalizationService.Format($"{resourcePrefix}.Detail", fileName);
+
+        // StackPanel で「すべて上書き」「すべてスキップ」ボタンを追加
+        var overwriteAllButton = new Button
+        {
+            Content = LocalizationService.GetString($"{resourcePrefix}.OverwriteAll"),
+            Margin = new Thickness(0, 0, 8, 0),
+        };
+        var skipAllButton = new Button
+        {
+            Content = LocalizationService.GetString($"{resourcePrefix}.SkipAll"),
+        };
+
+        var dialog = new ContentDialog
+        {
+            Title = LocalizationService.GetString($"{resourcePrefix}.Title"),
+            PrimaryButtonText = LocalizationService.GetString($"{resourcePrefix}.Overwrite"),
+            SecondaryButtonText = LocalizationService.GetString($"{resourcePrefix}.Skip"),
+            CloseButtonText = LocalizationService.GetString($"{resourcePrefix}.Cancel"),
+            XamlRoot = _xamlRootSource.XamlRoot,
+            Content = new StackPanel
+            {
+                Spacing = 12,
+                Children =
+                {
+                    new TextBlock { Text = detail, TextWrapping = TextWrapping.Wrap },
+                    new StackPanel
+                    {
+                        Orientation = Orientation.Horizontal,
+                        Children = { overwriteAllButton, skipAllButton },
+                    },
+                },
+            },
+        };
+
+        ConflictResolution? extraChoice = null;
+        overwriteAllButton.Click += (_, _) =>
+        {
+            extraChoice = ConflictResolution.OverwriteAll;
+            dialog.Hide();
+        };
+        skipAllButton.Click += (_, _) =>
+        {
+            extraChoice = ConflictResolution.SkipAll;
+            dialog.Hide();
+        };
+
+        var result = await dialog.ShowAsync();
+        if (extraChoice.HasValue)
+        {
+            return extraChoice.Value;
+        }
+
+        return result switch
+        {
+            ContentDialogResult.Primary => ConflictResolution.Overwrite,
+            ContentDialogResult.Secondary => ConflictResolution.Skip,
+            _ => ConflictResolution.Cancel,
+        };
+    }
+
+    private async Task<bool> EnsureXamlRootAsync()
+    {
+        const int maxWaitMs = 3000;
+        const int intervalMs = 50;
+
+        if (_xamlRootSource.XamlRoot is not null)
+        {
+            return true;
+        }
+
+        // 既に別の呼び出しで待機中の場合は、重複してイベントハンドラを登録しない
+        if (_isWaitingForXamlRoot)
+        {
+            // ポーリングのみで待機
+            var pollingElapsed = 0;
+            while (_xamlRootSource.XamlRoot is null && pollingElapsed < maxWaitMs)
+            {
+                await Task.Delay(intervalMs).ConfigureAwait(true);
+                pollingElapsed += intervalMs;
+            }
+            return _xamlRootSource.XamlRoot is not null;
+        }
+
+        _isWaitingForXamlRoot = true;
+
+        AppLog.Info("EnsureXamlRootAsync: XamlRoot is null, waiting for it to become available...");
+
+        var tcs = new TaskCompletionSource<bool>();
+        void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            _xamlRootSource.Loaded -= OnLoaded;
+            tcs.TrySetResult(true);
+        }
+
+        _xamlRootSource.Loaded += OnLoaded;
+
+        var elapsed = 0;
+        while (_xamlRootSource.XamlRoot is null && elapsed < maxWaitMs)
+        {
+            await Task.Delay(intervalMs).ConfigureAwait(true);
+            elapsed += intervalMs;
+
+            if (tcs.Task.IsCompleted)
+            {
+                break;
+            }
+        }
+
+        _xamlRootSource.Loaded -= OnLoaded;
+        _isWaitingForXamlRoot = false;
+
+        if (_xamlRootSource.XamlRoot is not null)
+        {
+            AppLog.Info($"EnsureXamlRootAsync: XamlRoot became available after {elapsed}ms.");
+            return true;
+        }
+
+        AppLog.Info($"EnsureXamlRootAsync: XamlRoot still null after {elapsed}ms, giving up.");
+        return false;
+    }
+}

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
@@ -19,7 +19,6 @@ using Windows.ApplicationModel.DataTransfer;
 using Windows.Storage;
 using Windows.Storage.Pickers;
 using Windows.System;
-using WinRT.Interop;
 
 namespace PhotoGeoExplorer.Panes.FileBrowser;
 
@@ -34,7 +33,6 @@ internal sealed partial class FileBrowserPaneView : UserControl
     private List<PhotoListItem>? _dragItems;
     private bool _wasInternalDrop;
     private bool _suppressBreadcrumbNavigation;
-    private bool _isWaitingForXamlRoot;
     private bool _fileListInputHandlersRegistered;
     private bool _suppressSelectionChangedForRightTap;
     private IReadOnlyList<PhotoListItem> _selectionBeforeChange = Array.Empty<PhotoListItem>();
@@ -45,10 +43,13 @@ internal sealed partial class FileBrowserPaneView : UserControl
     private ToggleMenuFlyoutItem? _detailsSizeColumnMenuItem;
     private ToggleMenuFlyoutItem? _detailsTakenAtColumnMenuItem;
     private ToggleMenuFlyoutItem? _detailsLocationColumnMenuItem;
+    private readonly FileBrowserDialogs _dialogs;
 
     public FileBrowserPaneView()
     {
         InitializeComponent();
+
+        _dialogs = new FileBrowserDialogs(RootGrid, () => HostWindow);
 
         OpenFolderCommand = new RelayCommand(async () => await OpenFolderAsync().ConfigureAwait(false));
         CreateFolderCommand = new RelayCommand(async () => await CreateFolderAsync().ConfigureAwait(false), () => ViewModel?.CanCreateFolder ?? false);
@@ -443,7 +444,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
         var summary = await ViewModel.ExecuteMoveItemsToFolderAsync(items, target.FullPath).ConfigureAwait(true);
         if (summary.HasFailures)
         {
-            await ShowMoveOperationErrorDialogAsync(summary).ConfigureAwait(true);
+            await _dialogs.ShowMoveOperationErrorAsync(summary).ConfigureAwait(true);
         }
     }
     private void OnFileListDragOver(object sender, DragEventArgs e)
@@ -513,11 +514,11 @@ internal sealed partial class FileBrowserPaneView : UserControl
                 if (e.AcceptedOperation == DataPackageOperation.Copy)
                 {
                     summary = await ViewModel.ExecuteCopyItemsToFolderAsync(
-                        selectedItems, targetFolder.FilePath, ShowCopyConflictDialogAsync)
+                        selectedItems, targetFolder.FilePath, _dialogs.ShowCopyConflictAsync)
                         .ConfigureAwait(true);
                     if (summary.HasFailures && summary.Failures.Any(f => f.Error != FileOperationError.Cancelled))
                     {
-                        await ShowCopyOperationErrorDialogAsync(summary).ConfigureAwait(true);
+                        await _dialogs.ShowCopyOperationErrorAsync(summary).ConfigureAwait(true);
                     }
                 }
                 else
@@ -526,7 +527,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
                         .ConfigureAwait(true);
                     if (summary.HasFailures)
                     {
-                        await ShowMoveOperationErrorDialogAsync(summary).ConfigureAwait(true);
+                        await _dialogs.ShowMoveOperationErrorAsync(summary).ConfigureAwait(true);
                     }
                 }
             }
@@ -880,17 +881,17 @@ internal sealed partial class FileBrowserPaneView : UserControl
 
         var isCut = ViewModel.IsCutClipboard;
         var summary = await ViewModel.ExecutePasteAsync(
-            resolveMoveConflictAsync: isCut ? ShowMoveConflictDialogAsync : null,
-            resolveCopyConflictAsync: isCut ? null : ShowCopyConflictDialogAsync).ConfigureAwait(true);
+            resolveMoveConflictAsync: isCut ? _dialogs.ShowMoveConflictAsync : null,
+            resolveCopyConflictAsync: isCut ? null : _dialogs.ShowCopyConflictAsync).ConfigureAwait(true);
         if (summary.HasFailures && summary.Failures.Any(f => f.Error != FileOperationError.Cancelled))
         {
             if (isCut)
             {
-                await ShowMoveOperationErrorDialogAsync(summary).ConfigureAwait(true);
+                await _dialogs.ShowMoveOperationErrorAsync(summary).ConfigureAwait(true);
             }
             else
             {
-                await ShowCopyOperationErrorDialogAsync(summary).ConfigureAwait(true);
+                await _dialogs.ShowCopyOperationErrorAsync(summary).ConfigureAwait(true);
             }
         }
     }
@@ -916,7 +917,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
             return;
         }
 
-        var folderName = await ShowTextInputDialogAsync(
+        var folderName = await _dialogs.ShowTextInputAsync(
             LocalizationService.GetString("Dialog.NewFolder.Title"),
             LocalizationService.GetString("Dialog.NewFolder.Primary"),
             LocalizationService.GetString("Dialog.NewFolder.DefaultName"),
@@ -929,7 +930,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
         var result = await ViewModel.ExecuteCreateFolderAsync(folderName).ConfigureAwait(true);
         if (!result.IsSuccess)
         {
-            await ShowFileOperationErrorDialogAsync(result.Error, "Dialog.CreateFolderFailed.Title").ConfigureAwait(true);
+            await _dialogs.ShowFileOperationErrorAsync(result.Error, "Dialog.CreateFolderFailed.Title").ConfigureAwait(true);
         }
     }
 
@@ -945,7 +946,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
             return;
         }
 
-        var newName = await ShowTextInputDialogAsync(
+        var newName = await _dialogs.ShowTextInputAsync(
             LocalizationService.GetString("Dialog.Rename.Title"),
             LocalizationService.GetString("Dialog.Rename.Primary"),
             item.FileName,
@@ -958,7 +959,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
         var result = await ViewModel.ExecuteRenameAsync(item, newName).ConfigureAwait(true);
         if (!result.IsSuccess)
         {
-            await ShowFileOperationErrorDialogAsync(result.Error, "Dialog.RenameFailed.Title").ConfigureAwait(true);
+            await _dialogs.ShowFileOperationErrorAsync(result.Error, "Dialog.RenameFailed.Title").ConfigureAwait(true);
         }
     }
 
@@ -980,146 +981,19 @@ internal sealed partial class FileBrowserPaneView : UserControl
             return;
         }
 
-        var destination = await PickFolderAsync(PickerLocationId.PicturesLibrary).ConfigureAwait(true);
+        var destination = await _dialogs.PickFolderAsync(PickerLocationId.PicturesLibrary).ConfigureAwait(true);
         if (destination is null)
         {
             return;
         }
 
         var summary = await ViewModel.ExecuteMoveItemsToFolderAsync(
-            ViewModel.SelectedItems, destination.Path, ShowMoveConflictDialogAsync)
+            ViewModel.SelectedItems, destination.Path, _dialogs.ShowMoveConflictAsync)
             .ConfigureAwait(true);
         if (summary.Failures.Any(f => f.Error != FileOperationError.Cancelled))
         {
-            await ShowMoveOperationErrorDialogAsync(summary).ConfigureAwait(true);
+            await _dialogs.ShowMoveOperationErrorAsync(summary).ConfigureAwait(true);
         }
-    }
-
-    private async Task<ConflictResolution> ShowMoveConflictDialogAsync(string fileName, bool isFolder)
-    {
-        var detail = LocalizationService.Format("Dialog.MoveConflict.Detail", fileName);
-        var dialog = new ContentDialog
-        {
-            Title = LocalizationService.GetString("Dialog.MoveConflict.Title"),
-            Content = detail,
-            PrimaryButtonText = LocalizationService.GetString("Dialog.MoveConflict.Overwrite"),
-            SecondaryButtonText = LocalizationService.GetString("Dialog.MoveConflict.Skip"),
-            CloseButtonText = LocalizationService.GetString("Dialog.MoveConflict.Cancel"),
-            XamlRoot = XamlRoot,
-        };
-
-        // StackPanel で「すべて上書き」「すべてスキップ」ボタンを追加
-        var overwriteAllButton = new Button
-        {
-            Content = LocalizationService.GetString("Dialog.MoveConflict.OverwriteAll"),
-            Margin = new Microsoft.UI.Xaml.Thickness(0, 0, 8, 0),
-        };
-        var skipAllButton = new Button
-        {
-            Content = LocalizationService.GetString("Dialog.MoveConflict.SkipAll"),
-        };
-
-        ConflictResolution? extraChoice = null;
-        overwriteAllButton.Click += (_, _) =>
-        {
-            extraChoice = ConflictResolution.OverwriteAll;
-            dialog.Hide();
-        };
-        skipAllButton.Click += (_, _) =>
-        {
-            extraChoice = ConflictResolution.SkipAll;
-            dialog.Hide();
-        };
-
-        dialog.Content = new StackPanel
-        {
-            Spacing = 12,
-            Children =
-            {
-                new TextBlock { Text = detail, TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap },
-                new StackPanel
-                {
-                    Orientation = Microsoft.UI.Xaml.Controls.Orientation.Horizontal,
-                    Children = { overwriteAllButton, skipAllButton },
-                },
-            },
-        };
-
-        var result = await dialog.ShowAsync();
-        if (extraChoice.HasValue)
-        {
-            return extraChoice.Value;
-        }
-
-        return result switch
-        {
-            ContentDialogResult.Primary => ConflictResolution.Overwrite,
-            ContentDialogResult.Secondary => ConflictResolution.Skip,
-            _ => ConflictResolution.Cancel,
-        };
-    }
-
-    private async Task<ConflictResolution> ShowCopyConflictDialogAsync(string fileName, bool isFolder)
-    {
-        var detail = LocalizationService.Format("Dialog.CopyConflict.Detail", fileName);
-        var dialog = new ContentDialog
-        {
-            Title = LocalizationService.GetString("Dialog.CopyConflict.Title"),
-            Content = detail,
-            PrimaryButtonText = LocalizationService.GetString("Dialog.CopyConflict.Overwrite"),
-            SecondaryButtonText = LocalizationService.GetString("Dialog.CopyConflict.Skip"),
-            CloseButtonText = LocalizationService.GetString("Dialog.CopyConflict.Cancel"),
-            XamlRoot = XamlRoot,
-        };
-
-        var overwriteAllButton = new Button
-        {
-            Content = LocalizationService.GetString("Dialog.CopyConflict.OverwriteAll"),
-            Margin = new Microsoft.UI.Xaml.Thickness(0, 0, 8, 0),
-        };
-        var skipAllButton = new Button
-        {
-            Content = LocalizationService.GetString("Dialog.CopyConflict.SkipAll"),
-        };
-
-        ConflictResolution? extraChoice = null;
-        overwriteAllButton.Click += (_, _) =>
-        {
-            extraChoice = ConflictResolution.OverwriteAll;
-            dialog.Hide();
-        };
-        skipAllButton.Click += (_, _) =>
-        {
-            extraChoice = ConflictResolution.SkipAll;
-            dialog.Hide();
-        };
-
-        dialog.Content = new StackPanel
-        {
-            Spacing = 12,
-            Children =
-            {
-                new TextBlock { Text = detail, TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap },
-                new StackPanel
-                {
-                    Orientation = Microsoft.UI.Xaml.Controls.Orientation.Horizontal,
-                    Children = { overwriteAllButton, skipAllButton },
-                },
-            },
-        };
-
-        var result = await dialog.ShowAsync();
-        if (extraChoice.HasValue)
-        {
-            return extraChoice.Value;
-        }
-
-        return result switch
-        {
-            ContentDialogResult.Primary => ConflictResolution.Overwrite,
-            ContentDialogResult.Secondary => ConflictResolution.Skip,
-            _ => ConflictResolution.Cancel,
-        };
     }
 
     private async void OnMoveToParentClicked(object sender, RoutedEventArgs e)
@@ -1137,7 +1011,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
         var summary = await ViewModel.ExecuteMoveToParentAsync().ConfigureAwait(true);
         if (summary.HasFailures)
         {
-            await ShowMoveOperationErrorDialogAsync(summary).ConfigureAwait(true);
+            await _dialogs.ShowMoveOperationErrorAsync(summary).ConfigureAwait(true);
         }
     }
 
@@ -1154,9 +1028,9 @@ internal sealed partial class FileBrowserPaneView : UserControl
         }
 
         var message = ViewModel.SelectedItems.Count == 1
-            ? BuildDeleteMessage(ViewModel.SelectedItems[0])
+            ? FileBrowserDialogs.BuildDeleteMessage(ViewModel.SelectedItems[0])
             : LocalizationService.Format("Dialog.DeleteConfirm.Multiple", ViewModel.SelectedItems.Count);
-        var confirmed = await ShowConfirmationDialogAsync(
+        var confirmed = await _dialogs.ShowConfirmationAsync(
             LocalizationService.GetString("Dialog.DeleteConfirm.Title"),
             message,
             LocalizationService.GetString("Common.Delete")).ConfigureAwait(true);
@@ -1169,7 +1043,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
         var summary = await ViewModel.ExecuteDeleteItemsAsync(itemsToDelete).ConfigureAwait(true);
         if (summary.HasFailures)
         {
-            await ShowDeleteOperationErrorDialogAsync(summary).ConfigureAwait(true);
+            await _dialogs.ShowDeleteOperationErrorAsync(summary).ConfigureAwait(true);
         }
     }
 
@@ -1251,7 +1125,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
             return;
         }
 
-        var destination = await PickFolderAsync(PickerLocationId.PicturesLibrary).ConfigureAwait(true);
+        var destination = await _dialogs.PickFolderAsync(PickerLocationId.PicturesLibrary).ConfigureAwait(true);
         if (destination is null)
         {
             return;
@@ -1261,26 +1135,8 @@ internal sealed partial class FileBrowserPaneView : UserControl
             .ConfigureAwait(true);
         if (summary.HasFailures)
         {
-            await ShowCopyOperationErrorDialogAsync(summary).ConfigureAwait(true);
+            await _dialogs.ShowCopyOperationErrorAsync(summary).ConfigureAwait(true);
         }
-    }
-
-    private Task ShowCopyOperationErrorDialogAsync(FileOperationSummary summary)
-    {
-        var firstError = summary.Failures[0].Error;
-        var (title, message) = firstError switch
-        {
-            FileOperationError.AlreadyExists => (
-                LocalizationService.GetString("Dialog.AlreadyExists.Title"),
-                LocalizationService.GetString("Dialog.AlreadyExistsDestination.Detail")),
-            FileOperationError.Unauthorized => (
-                LocalizationService.GetString("Dialog.CopyFailed.Title"),
-                LocalizationService.GetString("Dialog.SeeLogDetail")),
-            _ => (
-                LocalizationService.GetString("Dialog.CopyFailed.Title"),
-                LocalizationService.GetString("Dialog.SeeLogDetail")),
-        };
-        return ShowMessageDialogAsync(title, message);
     }
 
     private void OnDetailsSortClicked(object sender, RoutedEventArgs e)
@@ -1618,75 +1474,6 @@ internal sealed partial class FileBrowserPaneView : UserControl
         return false;
     }
 
-    private static string BuildDeleteMessage(PhotoListItem item)
-    {
-        return item.IsFolder
-            ? LocalizationService.Format("Dialog.DeleteConfirm.Folder", item.FileName)
-            : LocalizationService.Format("Dialog.DeleteConfirm.File", item.FileName);
-    }
-
-    private Task ShowFileOperationErrorDialogAsync(FileOperationError error, string defaultTitleKey)
-    {
-        var (title, message) = error switch
-        {
-            FileOperationError.InvalidName => (
-                LocalizationService.GetString("Dialog.InvalidName.Title"),
-                LocalizationService.GetString("Dialog.InvalidName.Detail")),
-            FileOperationError.AlreadyExists => (
-                LocalizationService.GetString("Dialog.AlreadyExists.Title"),
-                LocalizationService.GetString("Dialog.AlreadyExists.Detail")),
-            FileOperationError.NoParent => (
-                LocalizationService.GetString("Dialog.RenameNotAvailable.Title"),
-                LocalizationService.GetString("Dialog.RenameNotAvailable.Detail")),
-            FileOperationError.Unauthorized => (
-                LocalizationService.GetString(defaultTitleKey),
-                LocalizationService.GetString("Dialog.SeeLogDetail")),
-            _ => (
-                LocalizationService.GetString(defaultTitleKey),
-                LocalizationService.GetString("Dialog.SeeLogDetail")),
-        };
-        return ShowMessageDialogAsync(title, message);
-    }
-
-    private Task ShowMoveOperationErrorDialogAsync(FileOperationSummary summary)
-    {
-        var firstError = summary.Failures[0].Error;
-        var (title, message) = firstError switch
-        {
-            FileOperationError.DescendantPath => (
-                LocalizationService.GetString("Dialog.MoveFailed.Title"),
-                LocalizationService.GetString("Dialog.MoveIntoSelf.Detail")),
-            FileOperationError.AlreadyExists => (
-                LocalizationService.GetString("Dialog.AlreadyExists.Title"),
-                LocalizationService.GetString("Dialog.AlreadyExistsDestination.Detail")),
-            FileOperationError.Unauthorized => (
-                LocalizationService.GetString("Dialog.MoveFailed.Title"),
-                LocalizationService.GetString("Dialog.SeeLogDetail")),
-            _ => (
-                LocalizationService.GetString("Dialog.MoveFailed.Title"),
-                LocalizationService.GetString("Dialog.SeeLogDetail")),
-        };
-        return ShowMessageDialogAsync(title, message);
-    }
-
-    private Task ShowDeleteOperationErrorDialogAsync(FileOperationSummary summary)
-    {
-        var firstError = summary.Failures[0].Error;
-        var (title, message) = firstError switch
-        {
-            FileOperationError.NoParent => (
-                LocalizationService.GetString("Dialog.DeleteNotAvailable.Title"),
-                LocalizationService.GetString("Dialog.DeleteNotAvailable.Detail")),
-            FileOperationError.Unauthorized => (
-                LocalizationService.GetString("Dialog.DeleteFailed.Title"),
-                LocalizationService.GetString("Dialog.SeeLogDetail")),
-            _ => (
-                LocalizationService.GetString("Dialog.DeleteFailed.Title"),
-                LocalizationService.GetString("Dialog.SeeLogDetail")),
-        };
-        return ShowMessageDialogAsync(title, message);
-    }
-
     private async Task OpenFolderPickerAsync()
     {
         if (ViewModel is null)
@@ -1694,7 +1481,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
             return;
         }
 
-        var folder = await PickFolderAsync(PickerLocationId.PicturesLibrary).ConfigureAwait(true);
+        var folder = await _dialogs.PickFolderAsync(PickerLocationId.PicturesLibrary).ConfigureAwait(true);
 
         if (folder is null)
         {
@@ -1702,199 +1489,6 @@ internal sealed partial class FileBrowserPaneView : UserControl
         }
 
         await ViewModel.LoadFolderAsync(folder.Path).ConfigureAwait(true);
-    }
-
-    private async Task<StorageFolder?> PickFolderAsync(PickerLocationId startLocation)
-    {
-        var picker = new FolderPicker
-        {
-            SuggestedStartLocation = startLocation
-        };
-        picker.FileTypeFilter.Add("*");
-
-        if (HostWindow is null)
-        {
-            AppLog.Error("HostWindow is not set for FileBrowserPaneView.");
-            return null;
-        }
-
-        var hwnd = WindowNative.GetWindowHandle(HostWindow);
-        InitializeWithWindow.Initialize(picker, hwnd);
-
-        try
-        {
-            return await picker.PickSingleFolderAsync().AsTask().ConfigureAwait(true);
-        }
-        catch (UnauthorizedAccessException ex)
-        {
-            AppLog.Error("Folder picker failed.", ex);
-        }
-        catch (System.Runtime.InteropServices.COMException ex)
-        {
-            AppLog.Error("Folder picker failed.", ex);
-        }
-
-        return null;
-    }
-
-    private async Task<string?> ShowTextInputDialogAsync(
-        string title,
-        string primaryButtonText,
-        string? defaultText,
-        string placeholderText)
-    {
-        if (!await EnsureXamlRootAsync().ConfigureAwait(true))
-        {
-            return null;
-        }
-
-        var textBox = new TextBox
-        {
-            Text = defaultText ?? string.Empty,
-            PlaceholderText = placeholderText,
-            MinWidth = 260
-        };
-
-        var dialog = new ContentDialog
-        {
-            Title = title,
-            Content = textBox,
-            PrimaryButtonText = primaryButtonText,
-            SecondaryButtonText = LocalizationService.GetString("Common.Cancel"),
-            DefaultButton = ContentDialogButton.Primary,
-            XamlRoot = RootGrid.XamlRoot
-        };
-
-        dialog.IsPrimaryButtonEnabled = !string.IsNullOrWhiteSpace(textBox.Text);
-        textBox.TextChanged += (_, _) =>
-        {
-            dialog.IsPrimaryButtonEnabled = !string.IsNullOrWhiteSpace(textBox.Text);
-        };
-        dialog.Opened += (_, _) =>
-        {
-            textBox.Focus(FocusState.Programmatic);
-            textBox.SelectAll();
-        };
-
-        var result = await dialog.ShowAsync().AsTask().ConfigureAwait(true);
-        if (result != ContentDialogResult.Primary)
-        {
-            return null;
-        }
-
-        var value = textBox.Text.Trim();
-        return string.IsNullOrWhiteSpace(value) ? null : value;
-    }
-
-    private async Task<bool> ShowConfirmationDialogAsync(
-        string title,
-        string message,
-        string primaryButtonText)
-    {
-        if (!await EnsureXamlRootAsync().ConfigureAwait(true))
-        {
-            return false;
-        }
-
-        var dialog = new ContentDialog
-        {
-            Title = title,
-            Content = new TextBlock
-            {
-                Text = message,
-                TextWrapping = TextWrapping.Wrap
-            },
-            PrimaryButtonText = primaryButtonText,
-            SecondaryButtonText = LocalizationService.GetString("Common.Cancel"),
-            DefaultButton = ContentDialogButton.Secondary,
-            XamlRoot = RootGrid.XamlRoot
-        };
-
-        var result = await dialog.ShowAsync().AsTask().ConfigureAwait(true);
-        return result == ContentDialogResult.Primary;
-    }
-
-    private async Task ShowMessageDialogAsync(string title, string message)
-    {
-        if (!await EnsureXamlRootAsync().ConfigureAwait(true))
-        {
-            return;
-        }
-
-        var dialog = new ContentDialog
-        {
-            Title = title,
-            Content = new TextBlock
-            {
-                Text = message,
-                TextWrapping = TextWrapping.Wrap
-            },
-            CloseButtonText = LocalizationService.GetString("Common.Ok"),
-            XamlRoot = RootGrid.XamlRoot
-        };
-
-        await dialog.ShowAsync().AsTask().ConfigureAwait(true);
-    }
-
-    private async Task<bool> EnsureXamlRootAsync()
-    {
-        const int maxWaitMs = 3000;
-        const int intervalMs = 50;
-
-        if (RootGrid.XamlRoot is not null)
-        {
-            return true;
-        }
-
-        // 既に別の呼び出しで待機中の場合は、重複してイベントハンドラを登録しない
-        if (_isWaitingForXamlRoot)
-        {
-            // ポーリングのみで待機
-            var pollingElapsed = 0;
-            while (RootGrid.XamlRoot is null && pollingElapsed < maxWaitMs)
-            {
-                await Task.Delay(intervalMs).ConfigureAwait(true);
-                pollingElapsed += intervalMs;
-            }
-            return RootGrid.XamlRoot is not null;
-        }
-
-        _isWaitingForXamlRoot = true;
-
-        AppLog.Info("EnsureXamlRootAsync: XamlRoot is null, waiting for it to become available...");
-
-        var tcs = new TaskCompletionSource<bool>();
-        void OnLoaded(object sender, RoutedEventArgs e)
-        {
-            RootGrid.Loaded -= OnLoaded;
-            tcs.TrySetResult(true);
-        }
-
-        RootGrid.Loaded += OnLoaded;
-
-        var elapsed = 0;
-        while (RootGrid.XamlRoot is null && elapsed < maxWaitMs)
-        {
-            await Task.Delay(intervalMs).ConfigureAwait(true);
-            elapsed += intervalMs;
-
-            if (tcs.Task.IsCompleted)
-            {
-                break;
-            }
-        }
-
-        RootGrid.Loaded -= OnLoaded;
-        _isWaitingForXamlRoot = false;
-
-        if (RootGrid.XamlRoot is not null)
-        {
-            AppLog.Info($"EnsureXamlRootAsync: XamlRoot became available after {elapsed}ms.");
-            return true;
-        }
-
-        AppLog.Info($"EnsureXamlRootAsync: XamlRoot still null after {elapsed}ms, giving up.");
-        return false;
     }
 
     private ListViewBase? GetFileListView()


### PR DESCRIPTION
## 概要

#150 Phase 1（`FileBrowserPaneView.xaml.cs` 分割）の View 側第1弾。ダイアログ・ピッカー表示を View コードビハインドから新設の `FileBrowserDialogs`（internal sealed）へ分離した。

## 理由

ダイアログ表示は View の正当な責務（MVVM ガードレール準拠）だが、コードビハインドに置く必然性はなく、約520行を占めていた。特に `ShowMoveConflictDialogAsync` / `ShowCopyConflictDialogAsync` はリソースキー以外ほぼ同一の実装が二重に存在していた。`XamlRoot` 供給元と `HostWindow` を受け取るヘルパーへ移すことでコードビハインドを縮小し、競合ダイアログの重複を解消する。

## 変更内容

- `Panes/FileBrowser/FileBrowserDialogs.cs`（新設）へ以下を移動
  - 競合解決（Move/Copy）・テキスト入力・確認・メッセージ
  - 操作エラー（作成/リネーム・Move・Copy・削除）
  - フォルダピッカー（HWND Interop 含む）・`EnsureXamlRootAsync`・`BuildDeleteMessage`
- View は `new FileBrowserDialogs(RootGrid, () => HostWindow)` を構築し、`_dialogs.ShowXxxAsync(...)` 経由で呼び出す。VM へ渡す競合解決コールバック型（`Func<string, bool, Task<ConflictResolution>>`）は不変
- `ShowMove/CopyConflictDialogAsync` を、リソースキー接頭辞をパラメータ化した単一実装 `ShowConflictAsync` に統合
- `FileBrowserPaneView.xaml.cs`: 1,921 → 1,515 行（**−406 行**）

### 設計判断

- 操作エラーダイアログ群（`FileOperationError` → タイトル/メッセージの switch）は、分岐表が操作種別ごとに異なるため共通テーブル化せず移動のみとした（必要最小限・回帰リスク回避）。汎用 `Services/DialogService.cs` との統合可否を含め、将来の整理は本 PR スコープ外とし #156 のフォローアップに委ねる

## 受け入れ条件

- [x] 対象メソッドが View から消え、`FileBrowserPaneView.xaml.cs` が約500行（実績 −406 行）削減
- [x] Move/Copy 競合ダイアログが単一実装になっている
- [x] 新規フォルダ作成・リネーム・削除確認・競合解決・各エラーダイアログが現行どおり表示される（ダイアログ表示は挙動不変で移動）
- [x] `dotnet build` / `dotnet test`（Release, x64）が成功

## 検証

- `dotnet build PhotoGeoExplorer.sln -c Release -p:Platform=x64` → 0 警告 / 0 エラー
- `dotnet test`（Release, x64）→ 576 件全件パス
- `dotnet format --verify-no-changes` → ExitCode 0

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)