### PR TITLE
refactor: FileBrowserDialogs のエラーマッピングをテスト可能な純粋関数へ分離 (#167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ## [Unreleased]
 
 ### リファクタリング
+- `FileBrowserDialogs` のエラー → リソースキーのマッピングをテスト可能な純粋関数 `FileBrowserDialogErrorMap` へ分離 (#167)
+  - 作成/リネーム・Move・Copy・削除の各操作エラー（`FileOperationError` → タイトル/メッセージのリソースキー）の `switch` を、WinUI 非依存の `internal static` クラス `Panes/FileBrowser/FileBrowserDialogErrorMap.cs` へ抽出。`ContentDialog` 表示・`LocalizationService` 解決から切り離し、対応関係をユニットテストで固定できるようにした
+  - `FileBrowserDialogs` の各 `ShowXxxOperationErrorAsync` はマッピング関数の結果（リソースキー）を解決して `ShowMessageAsync` を呼ぶだけに簡素化（表示挙動は不変）
+  - 既知の `FileOperationError` 全 8 値を網羅する `FileBrowserDialogErrorMapTests`（32 ケース、パラメータ化テスト）を新設。default フォールバックも併せて固定
 - ダイアログ・ピッカー表示を `FileBrowserPaneView` コードビハインドから `FileBrowserDialogs` ヘルパーへ分離 (#156)
   - 競合解決（Move/Copy）・テキスト入力・確認・メッセージ・各種操作エラー（作成/リネーム/Move/Copy/削除）ダイアログ、フォルダピッカー（HWND Interop 含む）、`EnsureXamlRootAsync` を `Panes/FileBrowser/FileBrowserDialogs.cs`（internal sealed）へ移動。View は `XamlRoot` 供給元（RootGrid）と `HostWindow` アクセサをコンストラクタで渡し、`_dialogs.ShowXxxAsync(...)` 経由で呼び出す（VM へ渡す競合解決コールバック型は不変）
   - リソースキー以外ほぼ同一だった `ShowMoveConflictDialogAsync` / `ShowCopyConflictDialogAsync` を、リソースキー接頭辞をパラメータ化した単一実装 `ShowConflictAsync` に統合

--- a/PhotoGeoExplorer.Tests/FileBrowserDialogErrorMapTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserDialogErrorMapTests.cs
@@ -1,0 +1,101 @@
+using System;
+using PhotoGeoExplorer.Panes.FileBrowser;
+using PhotoGeoExplorer.Services;
+using Xunit;
+
+namespace PhotoGeoExplorer.Tests;
+
+/// <summary>
+/// FileBrowserDialogErrorMap の純粋マッピング（FileOperationError → リソースキー）の網羅テスト。
+/// ContentDialog 表示やローカライズ解決から独立して、操作種別ごとに異なる対応関係を固定する。
+/// 各操作で既知の FileOperationError 全 8 値を検証し、default フォールバックも併せて固定する。
+/// </summary>
+/// <remarks>
+/// FileOperationError は internal のため、public テストメソッドのパラメータ型には直接使えない（CS0051）。
+/// InlineData では nameof で enum 名を渡し、メソッド内で Enum.Parse して使う。
+/// </remarks>
+public sealed class FileBrowserDialogErrorMapTests
+{
+    private const string DefaultTitleKey = "Dialog.CreateFolderFailed.Title";
+    private const string SeeLogDetailKey = "Dialog.SeeLogDetail";
+
+    [Theory]
+    [InlineData(nameof(FileOperationError.InvalidName), "Dialog.InvalidName.Title", "Dialog.InvalidName.Detail")]
+    [InlineData(nameof(FileOperationError.AlreadyExists), "Dialog.AlreadyExists.Title", "Dialog.AlreadyExists.Detail")]
+    [InlineData(nameof(FileOperationError.NoParent), "Dialog.RenameNotAvailable.Title", "Dialog.RenameNotAvailable.Detail")]
+    [InlineData(nameof(FileOperationError.Unauthorized), DefaultTitleKey, SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.None), DefaultTitleKey, SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.DescendantPath), DefaultTitleKey, SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.IoError), DefaultTitleKey, SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.Cancelled), DefaultTitleKey, SeeLogDetailKey)]
+    public void MapFileOperationError_ReturnsExpectedKeys(
+        string errorName, string expectedTitleKey, string expectedMessageKey)
+    {
+        var error = Enum.Parse<FileOperationError>(errorName);
+
+        var (titleKey, messageKey) = FileBrowserDialogErrorMap.MapFileOperationError(error, DefaultTitleKey);
+
+        Assert.Equal(expectedTitleKey, titleKey);
+        Assert.Equal(expectedMessageKey, messageKey);
+    }
+
+    [Theory]
+    [InlineData(nameof(FileOperationError.DescendantPath), "Dialog.MoveFailed.Title", "Dialog.MoveIntoSelf.Detail")]
+    [InlineData(nameof(FileOperationError.AlreadyExists), "Dialog.AlreadyExists.Title", "Dialog.AlreadyExistsDestination.Detail")]
+    [InlineData(nameof(FileOperationError.Unauthorized), "Dialog.MoveFailed.Title", SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.None), "Dialog.MoveFailed.Title", SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.InvalidName), "Dialog.MoveFailed.Title", SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.NoParent), "Dialog.MoveFailed.Title", SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.IoError), "Dialog.MoveFailed.Title", SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.Cancelled), "Dialog.MoveFailed.Title", SeeLogDetailKey)]
+    public void MapMoveError_ReturnsExpectedKeys(
+        string errorName, string expectedTitleKey, string expectedMessageKey)
+    {
+        var firstError = Enum.Parse<FileOperationError>(errorName);
+
+        var (titleKey, messageKey) = FileBrowserDialogErrorMap.MapMoveError(firstError);
+
+        Assert.Equal(expectedTitleKey, titleKey);
+        Assert.Equal(expectedMessageKey, messageKey);
+    }
+
+    [Theory]
+    [InlineData(nameof(FileOperationError.AlreadyExists), "Dialog.AlreadyExists.Title", "Dialog.AlreadyExistsDestination.Detail")]
+    [InlineData(nameof(FileOperationError.Unauthorized), "Dialog.CopyFailed.Title", SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.None), "Dialog.CopyFailed.Title", SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.InvalidName), "Dialog.CopyFailed.Title", SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.DescendantPath), "Dialog.CopyFailed.Title", SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.NoParent), "Dialog.CopyFailed.Title", SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.IoError), "Dialog.CopyFailed.Title", SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.Cancelled), "Dialog.CopyFailed.Title", SeeLogDetailKey)]
+    public void MapCopyError_ReturnsExpectedKeys(
+        string errorName, string expectedTitleKey, string expectedMessageKey)
+    {
+        var firstError = Enum.Parse<FileOperationError>(errorName);
+
+        var (titleKey, messageKey) = FileBrowserDialogErrorMap.MapCopyError(firstError);
+
+        Assert.Equal(expectedTitleKey, titleKey);
+        Assert.Equal(expectedMessageKey, messageKey);
+    }
+
+    [Theory]
+    [InlineData(nameof(FileOperationError.NoParent), "Dialog.DeleteNotAvailable.Title", "Dialog.DeleteNotAvailable.Detail")]
+    [InlineData(nameof(FileOperationError.Unauthorized), "Dialog.DeleteFailed.Title", SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.None), "Dialog.DeleteFailed.Title", SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.InvalidName), "Dialog.DeleteFailed.Title", SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.AlreadyExists), "Dialog.DeleteFailed.Title", SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.DescendantPath), "Dialog.DeleteFailed.Title", SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.IoError), "Dialog.DeleteFailed.Title", SeeLogDetailKey)]
+    [InlineData(nameof(FileOperationError.Cancelled), "Dialog.DeleteFailed.Title", SeeLogDetailKey)]
+    public void MapDeleteError_ReturnsExpectedKeys(
+        string errorName, string expectedTitleKey, string expectedMessageKey)
+    {
+        var firstError = Enum.Parse<FileOperationError>(errorName);
+
+        var (titleKey, messageKey) = FileBrowserDialogErrorMap.MapDeleteError(firstError);
+
+        Assert.Equal(expectedTitleKey, titleKey);
+        Assert.Equal(expectedMessageKey, messageKey);
+    }
+}

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDialogErrorMap.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDialogErrorMap.cs
@@ -1,0 +1,57 @@
+using PhotoGeoExplorer.Services;
+
+namespace PhotoGeoExplorer.Panes.FileBrowser;
+
+/// <summary>
+/// FileBrowser ペインの操作エラー種別を、ダイアログのタイトル/メッセージのリソースキーへ対応付ける純粋関数群。
+/// ローカライズ文字列の解決や <c>ContentDialog</c> 表示からは独立しているため、操作種別ごとに異なる
+/// 対応関係をユニットテストで固定できる（フォローアップ ISSUE #167）。
+/// </summary>
+internal static class FileBrowserDialogErrorMap
+{
+    private const string SeeLogDetailKey = "Dialog.SeeLogDetail";
+
+    /// <summary>
+    /// 新規フォルダ作成・リネーム失敗時のエラー → リソースキー対応。
+    /// <paramref name="defaultTitleKey"/> は呼び出し元の操作種別ごとに異なる既定タイトル（作成失敗/リネーム失敗）。
+    /// </summary>
+    public static (string TitleKey, string MessageKey) MapFileOperationError(
+        FileOperationError error,
+        string defaultTitleKey)
+        => error switch
+        {
+            FileOperationError.InvalidName => ("Dialog.InvalidName.Title", "Dialog.InvalidName.Detail"),
+            FileOperationError.AlreadyExists => ("Dialog.AlreadyExists.Title", "Dialog.AlreadyExists.Detail"),
+            FileOperationError.NoParent => ("Dialog.RenameNotAvailable.Title", "Dialog.RenameNotAvailable.Detail"),
+            FileOperationError.Unauthorized => (defaultTitleKey, SeeLogDetailKey),
+            _ => (defaultTitleKey, SeeLogDetailKey),
+        };
+
+    /// <summary>Move 操作失敗時の先頭エラー → リソースキー対応。</summary>
+    public static (string TitleKey, string MessageKey) MapMoveError(FileOperationError firstError)
+        => firstError switch
+        {
+            FileOperationError.DescendantPath => ("Dialog.MoveFailed.Title", "Dialog.MoveIntoSelf.Detail"),
+            FileOperationError.AlreadyExists => ("Dialog.AlreadyExists.Title", "Dialog.AlreadyExistsDestination.Detail"),
+            FileOperationError.Unauthorized => ("Dialog.MoveFailed.Title", SeeLogDetailKey),
+            _ => ("Dialog.MoveFailed.Title", SeeLogDetailKey),
+        };
+
+    /// <summary>Copy 操作失敗時の先頭エラー → リソースキー対応。</summary>
+    public static (string TitleKey, string MessageKey) MapCopyError(FileOperationError firstError)
+        => firstError switch
+        {
+            FileOperationError.AlreadyExists => ("Dialog.AlreadyExists.Title", "Dialog.AlreadyExistsDestination.Detail"),
+            FileOperationError.Unauthorized => ("Dialog.CopyFailed.Title", SeeLogDetailKey),
+            _ => ("Dialog.CopyFailed.Title", SeeLogDetailKey),
+        };
+
+    /// <summary>削除操作失敗時の先頭エラー → リソースキー対応。</summary>
+    public static (string TitleKey, string MessageKey) MapDeleteError(FileOperationError firstError)
+        => firstError switch
+        {
+            FileOperationError.NoParent => ("Dialog.DeleteNotAvailable.Title", "Dialog.DeleteNotAvailable.Detail"),
+            FileOperationError.Unauthorized => ("Dialog.DeleteFailed.Title", SeeLogDetailKey),
+            _ => ("Dialog.DeleteFailed.Title", SeeLogDetailKey),
+        };
+}

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDialogs.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDialogs.cs
@@ -34,84 +34,21 @@ internal sealed class FileBrowserDialogs
         => ShowConflictAsync("Dialog.CopyConflict", fileName);
 
     public Task ShowFileOperationErrorAsync(FileOperationError error, string defaultTitleKey)
-    {
-        var (title, message) = error switch
-        {
-            FileOperationError.InvalidName => (
-                LocalizationService.GetString("Dialog.InvalidName.Title"),
-                LocalizationService.GetString("Dialog.InvalidName.Detail")),
-            FileOperationError.AlreadyExists => (
-                LocalizationService.GetString("Dialog.AlreadyExists.Title"),
-                LocalizationService.GetString("Dialog.AlreadyExists.Detail")),
-            FileOperationError.NoParent => (
-                LocalizationService.GetString("Dialog.RenameNotAvailable.Title"),
-                LocalizationService.GetString("Dialog.RenameNotAvailable.Detail")),
-            FileOperationError.Unauthorized => (
-                LocalizationService.GetString(defaultTitleKey),
-                LocalizationService.GetString("Dialog.SeeLogDetail")),
-            _ => (
-                LocalizationService.GetString(defaultTitleKey),
-                LocalizationService.GetString("Dialog.SeeLogDetail")),
-        };
-        return ShowMessageAsync(title, message);
-    }
+        => ShowMappedErrorAsync(FileBrowserDialogErrorMap.MapFileOperationError(error, defaultTitleKey));
 
     public Task ShowMoveOperationErrorAsync(FileOperationSummary summary)
-    {
-        var firstError = summary.Failures[0].Error;
-        var (title, message) = firstError switch
-        {
-            FileOperationError.DescendantPath => (
-                LocalizationService.GetString("Dialog.MoveFailed.Title"),
-                LocalizationService.GetString("Dialog.MoveIntoSelf.Detail")),
-            FileOperationError.AlreadyExists => (
-                LocalizationService.GetString("Dialog.AlreadyExists.Title"),
-                LocalizationService.GetString("Dialog.AlreadyExistsDestination.Detail")),
-            FileOperationError.Unauthorized => (
-                LocalizationService.GetString("Dialog.MoveFailed.Title"),
-                LocalizationService.GetString("Dialog.SeeLogDetail")),
-            _ => (
-                LocalizationService.GetString("Dialog.MoveFailed.Title"),
-                LocalizationService.GetString("Dialog.SeeLogDetail")),
-        };
-        return ShowMessageAsync(title, message);
-    }
+        => ShowMappedErrorAsync(FileBrowserDialogErrorMap.MapMoveError(summary.Failures[0].Error));
 
     public Task ShowCopyOperationErrorAsync(FileOperationSummary summary)
-    {
-        var firstError = summary.Failures[0].Error;
-        var (title, message) = firstError switch
-        {
-            FileOperationError.AlreadyExists => (
-                LocalizationService.GetString("Dialog.AlreadyExists.Title"),
-                LocalizationService.GetString("Dialog.AlreadyExistsDestination.Detail")),
-            FileOperationError.Unauthorized => (
-                LocalizationService.GetString("Dialog.CopyFailed.Title"),
-                LocalizationService.GetString("Dialog.SeeLogDetail")),
-            _ => (
-                LocalizationService.GetString("Dialog.CopyFailed.Title"),
-                LocalizationService.GetString("Dialog.SeeLogDetail")),
-        };
-        return ShowMessageAsync(title, message);
-    }
+        => ShowMappedErrorAsync(FileBrowserDialogErrorMap.MapCopyError(summary.Failures[0].Error));
 
     public Task ShowDeleteOperationErrorAsync(FileOperationSummary summary)
-    {
-        var firstError = summary.Failures[0].Error;
-        var (title, message) = firstError switch
-        {
-            FileOperationError.NoParent => (
-                LocalizationService.GetString("Dialog.DeleteNotAvailable.Title"),
-                LocalizationService.GetString("Dialog.DeleteNotAvailable.Detail")),
-            FileOperationError.Unauthorized => (
-                LocalizationService.GetString("Dialog.DeleteFailed.Title"),
-                LocalizationService.GetString("Dialog.SeeLogDetail")),
-            _ => (
-                LocalizationService.GetString("Dialog.DeleteFailed.Title"),
-                LocalizationService.GetString("Dialog.SeeLogDetail")),
-        };
-        return ShowMessageAsync(title, message);
-    }
+        => ShowMappedErrorAsync(FileBrowserDialogErrorMap.MapDeleteError(summary.Failures[0].Error));
+
+    private Task ShowMappedErrorAsync((string TitleKey, string MessageKey) keys)
+        => ShowMessageAsync(
+            LocalizationService.GetString(keys.TitleKey),
+            LocalizationService.GetString(keys.MessageKey));
 
     public static string BuildDeleteMessage(PhotoListItem item)
     {


### PR DESCRIPTION
## 概要

#167 のフォローアップ実装。`FileBrowserDialogs` の操作エラー → リソースキーのマッピングを、WinUI 非依存の純粋 static クラス `FileBrowserDialogErrorMap` へ分離し、対応関係をユニットテストで固定した。

## 理由

`ShowFileOperationErrorAsync` / `ShowMove・Copy・DeleteOperationErrorAsync` は「`FileOperationError` → タイトル/メッセージのリソースキー」を決定する `switch` と、`LocalizationService` 解決・`ContentDialog` 表示が一体化しており、純粋なマッピングロジックが live XamlRoot を要する UI 表示と結合してユニットテストできなかった（#166 のレビュー残課題）。操作種別ごとに分岐表が異なるため回帰検出の価値が高い。

## 変更内容

- `Panes/FileBrowser/FileBrowserDialogErrorMap.cs`（新設・internal static・WinUI 非依存）
  - `MapFileOperationError(error, defaultTitleKey)` / `MapMoveError` / `MapCopyError` / `MapDeleteError` を `(string TitleKey, string MessageKey)` を返す純粋関数として抽出。分岐は元実装を忠実に移植（挙動不変）
- `FileBrowserDialogs.cs`
  - 4 つの `ShowXxxOperationErrorAsync` を、マッピング関数の結果を `LocalizationService` で解決して `ShowMessageAsync` を呼ぶだけに簡素化（共通ヘルパー `ShowMappedErrorAsync` を private 追加）
- `FileBrowserDialogErrorMapTests.cs`（新設）
  - 既知の `FileOperationError` 全 8 値 × 4 マッピング = **32 ケース**のパラメータ化テスト。default フォールバックも固定
  - `FileOperationError` は internal のため、`InlineData` では `nameof` で enum 名を渡し、メソッド内で `Enum.Parse`（public テストメソッドのシグネチャに internal 型を出さず CS0051 を回避）

### 設計判断

- マッピングを `FileBrowserDialogs`（WinUI 型を保持する sealed class）内の static にせず**専用クラスへ切り出した**。型ロード時の CsWinRT 初期化リスクを避け、テストを WinUI 依存から完全に独立させるため。
- リソースキー（解決済み文字列ではなく）を返す設計とし、`LocalizationService`（ロケール）にも依存しない完全な純粋関数とした。

## 検証

- `dotnet build PhotoGeoExplorer.sln -c Release -p:Platform=x64` → 0 警告 / 0 エラー
- `dotnet test`（Release, x64, E2E 除く）→ **608 件全件パス**（既存 576 + 新規 32、回帰なし）
- `dotnet format --verify-no-changes` → ExitCode 0

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)