### PR TITLE
refactor: FileBrowserPaneView のドラッグ&ドロップ処理を専用ハンドラに分離 (#157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ## [Unreleased]
 
 ### リファクタリング
+- ドラッグ＆ドロップ処理を `FileBrowserPaneView` コードビハインドから `FileBrowserDragDropHandler` へ分離 (#157)
+  - 内部項目の移動/コピー（`OnFileListDragOver` / `OnFileListDrop`）、Explorer 等へのドラッグアウト（`OnFileItemsDragStarting` の StorageItems 遅延提供・`OnFileItemsDragCompleted` の Move 完了後リフレッシュ）、外部ファイル/フォルダの受け入れ、ブレッドクラムへのドロップ（`OnBreadcrumbDragOver` / `OnBreadcrumbDrop`）、ヒットテスト（`IsInternalDrag` / `TryGetDropTargetFolder` / `TryGetBreadcrumbTarget`）、ドラッグ状態（`_dragItems` / `_wasInternalDrop` / `InternalDragKey`）を `Panes/FileBrowser/FileBrowserDragDropHandler.cs`（internal sealed）へ移動
+  - D&D はビジュアルツリー操作・`DataPackage` 操作を伴う純粋な View 責務のため、ViewModel ではなく View 層ヘルパーとして分離（MVVM ガードレール準拠）。ハンドラはコンストラクタでヒットテスト用ルート要素（RootGrid）・ViewModel アクセサ・`FileBrowserDialogs` を受け取る
+  - XAML のイベント結線（`DragOver` / `Drop` / `DragItemsStarting` / `DragItemsCompleted`）は View に薄い委譲ハンドラとして残し、処理本体をハンドラへ移譲（表示・操作挙動は不変）
+  - `FileBrowserPaneView.xaml.cs` を 1,515 行から 1,191 行へ削減（−324 行）。ビジュアルツリー汎用ヘルパー `FindAncestor<T>` は View の他箇所でも使用するため View に残し、D&D 専用の `IsDescendantOf` はハンドラへ移動
 - `FileBrowserDialogs` のエラー → リソースキーのマッピングをテスト可能な純粋関数 `FileBrowserDialogErrorMap` へ分離 (#167)
   - 作成/リネーム・Move・Copy・削除の各操作エラー（`FileOperationError` → タイトル/メッセージのリソースキー）の `switch` を、WinUI 非依存の `internal static` クラス `Panes/FileBrowser/FileBrowserDialogErrorMap.cs` へ抽出。`ContentDialog` 表示・`LocalizationService` 解決から切り離し、対応関係をユニットテストで固定できるようにした
   - `FileBrowserDialogs` の各 `ShowXxxOperationErrorAsync` はマッピング関数の結果（リソースキー）を解決して `ShowMessageAsync` を呼ぶだけに簡素化（表示挙動は不変）

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDragDropHandler.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDragDropHandler.cs
@@ -1,0 +1,404 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Microsoft.UI.Input;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using PhotoGeoExplorer.Models;
+using PhotoGeoExplorer.Services;
+using PhotoGeoExplorer.ViewModels;
+using Windows.ApplicationModel.DataTransfer;
+using Windows.Storage;
+using Windows.System;
+
+namespace PhotoGeoExplorer.Panes.FileBrowser;
+
+/// <summary>
+/// FileBrowser ペインのドラッグ＆ドロップ処理を担う View 層ハンドラ。
+/// 内部項目の移動/コピー・外部ファイル/フォルダの受け入れ・Explorer 等へのドラッグアウト・
+/// ブレッドクラムへのドロップを扱う。ビジュアルツリー操作・DataPackage 操作を伴う純粋な
+/// View 責務のため、ViewModel ではなく View 層のヘルパーとして分離する（MVVM ガードレール準拠）。
+/// </summary>
+internal sealed class FileBrowserDragDropHandler
+{
+    private const string InternalDragKey = "PhotoGeoExplorer.InternalDrag";
+
+    private readonly FrameworkElement _root;
+    private readonly Func<FileBrowserPaneViewModel?> _viewModelAccessor;
+    private readonly FileBrowserDialogs _dialogs;
+
+    private List<PhotoListItem>? _dragItems;
+    private bool _wasInternalDrop;
+
+    public FileBrowserDragDropHandler(
+        FrameworkElement root,
+        Func<FileBrowserPaneViewModel?> viewModelAccessor,
+        FileBrowserDialogs dialogs)
+    {
+        _root = root;
+        _viewModelAccessor = viewModelAccessor;
+        _dialogs = dialogs;
+    }
+
+    private FileBrowserPaneViewModel? ViewModel => _viewModelAccessor();
+
+    public void OnBreadcrumbDragOver(object sender, DragEventArgs e)
+    {
+        if (!IsInternalDrag(e))
+        {
+            e.AcceptedOperation = DataPackageOperation.None;
+            e.Handled = true;
+            return;
+        }
+
+        if (sender is not BreadcrumbBar breadcrumbBar)
+        {
+            return;
+        }
+
+        var accepted = TryGetBreadcrumbTarget(breadcrumbBar, e, out _)
+            ? DataPackageOperation.Move
+            : DataPackageOperation.None;
+
+        e.AcceptedOperation = accepted;
+        if (accepted != DataPackageOperation.None)
+        {
+            e.DragUIOverride.Caption = LocalizationService.GetString("DragCaption.Move");
+            e.DragUIOverride.IsCaptionVisible = true;
+        }
+
+        e.Handled = true;
+    }
+
+    public async Task OnBreadcrumbDropAsync(object sender, DragEventArgs e)
+    {
+        if (ViewModel is null || !IsInternalDrag(e))
+        {
+            return;
+        }
+
+        if (sender is not BreadcrumbBar breadcrumbBar)
+        {
+            return;
+        }
+
+        if (!TryGetBreadcrumbTarget(breadcrumbBar, e, out var target))
+        {
+            return;
+        }
+
+        _wasInternalDrop = true;
+        var items = _dragItems ?? ViewModel.SelectedItems;
+        var summary = await ViewModel.ExecuteMoveItemsToFolderAsync(items, target.FullPath).ConfigureAwait(true);
+        if (summary.HasFailures)
+        {
+            await _dialogs.ShowMoveOperationErrorAsync(summary).ConfigureAwait(true);
+        }
+    }
+
+    public void OnFileListDragOver(object sender, DragEventArgs e)
+    {
+        if (IsInternalDrag(e))
+        {
+            if (sender is not ListViewBase)
+            {
+                e.AcceptedOperation = DataPackageOperation.None;
+                e.Handled = true;
+                return;
+            }
+
+            if (sender is ListViewBase listView && TryGetDropTargetFolder(listView, e, out _))
+            {
+                var ctrlState = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control);
+                var isCopy = (ctrlState & Windows.UI.Core.CoreVirtualKeyStates.Down) != 0;
+                e.AcceptedOperation = isCopy ? DataPackageOperation.Copy : DataPackageOperation.Move;
+                e.DragUIOverride.Caption = isCopy
+                    ? LocalizationService.GetString("DragCaption.Copy")
+                    : LocalizationService.GetString("DragCaption.Move");
+                e.DragUIOverride.IsCaptionVisible = true;
+            }
+            else
+            {
+                e.AcceptedOperation = DataPackageOperation.None;
+            }
+
+            e.Handled = true;
+            return;
+        }
+
+        if (e.DataView.Contains(StandardDataFormats.StorageItems))
+        {
+            e.AcceptedOperation = DataPackageOperation.Copy;
+            e.DragUIOverride.Caption = LocalizationService.GetString("DragCaption.Copy");
+            e.DragUIOverride.IsCaptionVisible = true;
+        }
+        else
+        {
+            e.AcceptedOperation = DataPackageOperation.None;
+        }
+
+        e.Handled = true;
+    }
+
+    public async Task OnFileListDropAsync(object sender, DragEventArgs e)
+    {
+        if (ViewModel is null)
+        {
+            return;
+        }
+
+        if (IsInternalDrag(e))
+        {
+            if (sender is not ListViewBase)
+            {
+                return;
+            }
+
+            if (sender is ListViewBase listView
+                && TryGetDropTargetFolder(listView, e, out var targetFolder))
+            {
+                _wasInternalDrop = true;
+                var selectedItems = _dragItems ?? ViewModel.SelectedItems;
+                FileOperationSummary summary;
+                if (e.AcceptedOperation == DataPackageOperation.Copy)
+                {
+                    summary = await ViewModel.ExecuteCopyItemsToFolderAsync(
+                        selectedItems, targetFolder.FilePath, _dialogs.ShowCopyConflictAsync)
+                        .ConfigureAwait(true);
+                    if (summary.HasFailures && summary.Failures.Any(f => f.Error != FileOperationError.Cancelled))
+                    {
+                        await _dialogs.ShowCopyOperationErrorAsync(summary).ConfigureAwait(true);
+                    }
+                }
+                else
+                {
+                    summary = await ViewModel.ExecuteMoveItemsToFolderAsync(selectedItems, targetFolder.FilePath)
+                        .ConfigureAwait(true);
+                    if (summary.HasFailures)
+                    {
+                        await _dialogs.ShowMoveOperationErrorAsync(summary).ConfigureAwait(true);
+                    }
+                }
+            }
+
+            return;
+        }
+
+        if (!e.DataView.Contains(StandardDataFormats.StorageItems))
+        {
+            return;
+        }
+
+        var items = await e.DataView.GetStorageItemsAsync();
+        if (items is null || items.Count == 0)
+        {
+            return;
+        }
+
+        StorageFolder? folder = null;
+        StorageFile? firstFile = null;
+        foreach (var item in items)
+        {
+            if (item is StorageFolder droppedFolder)
+            {
+                folder = droppedFolder;
+                break;
+            }
+
+            if (firstFile is null && item is StorageFile droppedFile)
+            {
+                firstFile = droppedFile;
+            }
+        }
+
+        if (folder is not null)
+        {
+            await ViewModel.LoadFolderAsync(folder.Path).ConfigureAwait(true);
+            return;
+        }
+
+        if (firstFile is null)
+        {
+            return;
+        }
+
+        await ViewModel.HandleExternalFileDropAsync(firstFile.Path).ConfigureAwait(true);
+    }
+
+    public void OnFileItemsDragStarting(object sender, DragItemsStartingEventArgs e)
+    {
+        if (ViewModel is null)
+        {
+            return;
+        }
+
+        _dragItems = e.Items.OfType<PhotoListItem>().ToList();
+        if (_dragItems.Count == 0 && ViewModel.SelectedItems.Count > 0)
+        {
+            _dragItems = ViewModel.SelectedItems.ToList();
+        }
+
+        // Copy と Move の両方を提供することで、外部アプリがドライブ情報に基づき操作を決定できる
+        e.Data.RequestedOperation = DataPackageOperation.Copy | DataPackageOperation.Move;
+        e.Data.Properties[InternalDragKey] = true;
+
+        // ドラッグアウト: StorageItems を遅延提供して Explorer や他アプリが受け取れるようにする
+        var capturedItems = _dragItems.ToList();
+        e.Data.SetDataProvider(StandardDataFormats.StorageItems, async request =>
+        {
+            var deferral = request.GetDeferral();
+            try
+            {
+                var storageItems = new List<IStorageItem>();
+                foreach (var item in capturedItems)
+                {
+                    try
+                    {
+                        IStorageItem storageItem = item.IsFolder
+                            ? await StorageFolder.GetFolderFromPathAsync(item.FilePath)
+                            : await StorageFile.GetFileFromPathAsync(item.FilePath);
+                        storageItems.Add(storageItem);
+                    }
+                    catch (Exception ex) when (ex is FileNotFoundException
+                        or UnauthorizedAccessException
+                        or ArgumentException
+                        or NotSupportedException
+                        or PathTooLongException
+                        or COMException)
+                    {
+                        AppLog.Error($"Failed to provide drag storage item: {item.FilePath}", ex);
+                    }
+                }
+
+                request.SetData(storageItems);
+            }
+            finally
+            {
+                deferral.Complete();
+            }
+        });
+    }
+
+    public async Task OnFileItemsDragCompletedAsync(object sender, DragItemsCompletedEventArgs e)
+    {
+        var items = _dragItems;
+        var wasInternal = _wasInternalDrop;
+        _dragItems = null;
+        _wasInternalDrop = false;
+
+        // 外部アプリへの Move 完了後にリストを更新して移動済みアイテムを除去する
+        if (ViewModel is not null
+            && items is { Count: > 0 }
+            && e.DropResult == DataPackageOperation.Move
+            && !wasInternal)
+        {
+            await ViewModel.RefreshAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static bool IsInternalDrag(DragEventArgs e)
+    {
+        if (!e.DataView.Properties.TryGetValue(InternalDragKey, out var value))
+        {
+            return false;
+        }
+
+        return value is bool isInternal && isInternal;
+    }
+
+    private bool TryGetDropTargetFolder(ListViewBase listView, DragEventArgs e, out PhotoListItem target)
+    {
+        target = null!;
+        var point = e.GetPosition(_root);
+        var elements = Microsoft.UI.Xaml.Media.VisualTreeHelper.FindElementsInHostCoordinates(point, _root);
+        foreach (var element in elements)
+        {
+            var container = element as SelectorItem ?? FindAncestor<SelectorItem>(element);
+            if (container is null)
+            {
+                continue;
+            }
+
+            if (!IsDescendantOf(container, listView))
+            {
+                continue;
+            }
+
+            if (listView.ItemFromContainer(container) is not PhotoListItem item || !item.IsFolder)
+            {
+                continue;
+            }
+
+            target = item;
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryGetBreadcrumbTarget(BreadcrumbBar breadcrumbBar, DragEventArgs e, out BreadcrumbSegment target)
+    {
+        target = null!;
+        var point = e.GetPosition(_root);
+        var elements = Microsoft.UI.Xaml.Media.VisualTreeHelper.FindElementsInHostCoordinates(point, _root);
+        foreach (var element in elements)
+        {
+            var container = element as BreadcrumbBarItem ?? FindAncestor<BreadcrumbBarItem>(element);
+            if (container is null)
+            {
+                continue;
+            }
+
+            if (!IsDescendantOf(container, breadcrumbBar))
+            {
+                continue;
+            }
+
+            if (container.DataContext is not BreadcrumbSegment segment)
+            {
+                continue;
+            }
+
+            target = segment;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static T? FindAncestor<T>(DependencyObject? source) where T : DependencyObject
+    {
+        var current = source;
+        while (current is not null)
+        {
+            if (current is T match)
+            {
+                return match;
+            }
+
+            current = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(current);
+        }
+
+        return null;
+    }
+
+    private static bool IsDescendantOf(DependencyObject? child, DependencyObject ancestor)
+    {
+        var current = child;
+        while (current is not null)
+        {
+            if (ReferenceEquals(current, ancestor))
+            {
+                return true;
+            }
+
+            current = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(current);
+        }
+
+        return false;
+    }
+}

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.UI.Input;
@@ -16,7 +14,6 @@ using PhotoGeoExplorer.Models;
 using PhotoGeoExplorer.Services;
 using PhotoGeoExplorer.ViewModels;
 using Windows.ApplicationModel.DataTransfer;
-using Windows.Storage;
 using Windows.Storage.Pickers;
 using Windows.System;
 
@@ -24,14 +21,11 @@ namespace PhotoGeoExplorer.Panes.FileBrowser;
 
 internal sealed partial class FileBrowserPaneView : UserControl
 {
-    private const string InternalDragKey = "PhotoGeoExplorer.InternalDrag";
     private const string DetailsColumnModifiedTag = "Modified";
     private const string DetailsColumnResolutionTag = "Resolution";
     private const string DetailsColumnSizeTag = "Size";
     private const string DetailsColumnTakenAtTag = "TakenAt";
     private const string DetailsColumnLocationTag = "Location";
-    private List<PhotoListItem>? _dragItems;
-    private bool _wasInternalDrop;
     private bool _suppressBreadcrumbNavigation;
     private bool _fileListInputHandlersRegistered;
     private bool _suppressSelectionChangedForRightTap;
@@ -44,12 +38,14 @@ internal sealed partial class FileBrowserPaneView : UserControl
     private ToggleMenuFlyoutItem? _detailsTakenAtColumnMenuItem;
     private ToggleMenuFlyoutItem? _detailsLocationColumnMenuItem;
     private readonly FileBrowserDialogs _dialogs;
+    private readonly FileBrowserDragDropHandler _dragDropHandler;
 
     public FileBrowserPaneView()
     {
         InitializeComponent();
 
         _dialogs = new FileBrowserDialogs(RootGrid, () => HostWindow);
+        _dragDropHandler = new FileBrowserDragDropHandler(RootGrid, () => ViewModel, _dialogs);
 
         OpenFolderCommand = new RelayCommand(async () => await OpenFolderAsync().ConfigureAwait(false));
         CreateFolderCommand = new RelayCommand(async () => await CreateFolderAsync().ConfigureAwait(false), () => ViewModel?.CanCreateFolder ?? false);
@@ -395,257 +391,22 @@ internal sealed partial class FileBrowserPaneView : UserControl
     }
 
     private void OnBreadcrumbDragOver(object sender, DragEventArgs e)
-    {
-        if (!IsInternalDrag(e))
-        {
-            e.AcceptedOperation = DataPackageOperation.None;
-            e.Handled = true;
-            return;
-        }
-
-        if (sender is not BreadcrumbBar breadcrumbBar)
-        {
-            return;
-        }
-
-        var accepted = TryGetBreadcrumbTarget(breadcrumbBar, e, out _)
-            ? DataPackageOperation.Move
-            : DataPackageOperation.None;
-
-        e.AcceptedOperation = accepted;
-        if (accepted != DataPackageOperation.None)
-        {
-            e.DragUIOverride.Caption = LocalizationService.GetString("DragCaption.Move");
-            e.DragUIOverride.IsCaptionVisible = true;
-        }
-
-        e.Handled = true;
-    }
+        => _dragDropHandler.OnBreadcrumbDragOver(sender, e);
 
     private async void OnBreadcrumbDrop(object sender, DragEventArgs e)
-    {
-        if (ViewModel is null || !IsInternalDrag(e))
-        {
-            return;
-        }
+        => await _dragDropHandler.OnBreadcrumbDropAsync(sender, e).ConfigureAwait(true);
 
-        if (sender is not BreadcrumbBar breadcrumbBar)
-        {
-            return;
-        }
-
-        if (!TryGetBreadcrumbTarget(breadcrumbBar, e, out var target))
-        {
-            return;
-        }
-
-        _wasInternalDrop = true;
-        var items = _dragItems ?? ViewModel.SelectedItems;
-        var summary = await ViewModel.ExecuteMoveItemsToFolderAsync(items, target.FullPath).ConfigureAwait(true);
-        if (summary.HasFailures)
-        {
-            await _dialogs.ShowMoveOperationErrorAsync(summary).ConfigureAwait(true);
-        }
-    }
     private void OnFileListDragOver(object sender, DragEventArgs e)
-    {
-        if (IsInternalDrag(e))
-        {
-            if (sender is not ListViewBase)
-            {
-                e.AcceptedOperation = DataPackageOperation.None;
-                e.Handled = true;
-                return;
-            }
-
-            if (sender is ListViewBase listView && TryGetDropTargetFolder(listView, RootGrid, e, out _))
-            {
-                var ctrlState = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control);
-                var isCopy = (ctrlState & Windows.UI.Core.CoreVirtualKeyStates.Down) != 0;
-                e.AcceptedOperation = isCopy ? DataPackageOperation.Copy : DataPackageOperation.Move;
-                e.DragUIOverride.Caption = isCopy
-                    ? LocalizationService.GetString("DragCaption.Copy")
-                    : LocalizationService.GetString("DragCaption.Move");
-                e.DragUIOverride.IsCaptionVisible = true;
-            }
-            else
-            {
-                e.AcceptedOperation = DataPackageOperation.None;
-            }
-
-            e.Handled = true;
-            return;
-        }
-
-        if (e.DataView.Contains(StandardDataFormats.StorageItems))
-        {
-            e.AcceptedOperation = DataPackageOperation.Copy;
-            e.DragUIOverride.Caption = LocalizationService.GetString("DragCaption.Copy");
-            e.DragUIOverride.IsCaptionVisible = true;
-        }
-        else
-        {
-            e.AcceptedOperation = DataPackageOperation.None;
-        }
-
-        e.Handled = true;
-    }
+        => _dragDropHandler.OnFileListDragOver(sender, e);
 
     private async void OnFileListDrop(object sender, DragEventArgs e)
-    {
-        if (ViewModel is null)
-        {
-            return;
-        }
-
-        if (IsInternalDrag(e))
-        {
-            if (sender is not ListViewBase)
-            {
-                return;
-            }
-
-            if (sender is ListViewBase listView
-                && TryGetDropTargetFolder(listView, RootGrid, e, out var targetFolder))
-            {
-                _wasInternalDrop = true;
-                var selectedItems = _dragItems ?? ViewModel.SelectedItems;
-                FileOperationSummary summary;
-                if (e.AcceptedOperation == DataPackageOperation.Copy)
-                {
-                    summary = await ViewModel.ExecuteCopyItemsToFolderAsync(
-                        selectedItems, targetFolder.FilePath, _dialogs.ShowCopyConflictAsync)
-                        .ConfigureAwait(true);
-                    if (summary.HasFailures && summary.Failures.Any(f => f.Error != FileOperationError.Cancelled))
-                    {
-                        await _dialogs.ShowCopyOperationErrorAsync(summary).ConfigureAwait(true);
-                    }
-                }
-                else
-                {
-                    summary = await ViewModel.ExecuteMoveItemsToFolderAsync(selectedItems, targetFolder.FilePath)
-                        .ConfigureAwait(true);
-                    if (summary.HasFailures)
-                    {
-                        await _dialogs.ShowMoveOperationErrorAsync(summary).ConfigureAwait(true);
-                    }
-                }
-            }
-
-            return;
-        }
-
-        if (!e.DataView.Contains(StandardDataFormats.StorageItems))
-        {
-            return;
-        }
-
-        var items = await e.DataView.GetStorageItemsAsync();
-        if (items is null || items.Count == 0)
-        {
-            return;
-        }
-
-        StorageFolder? folder = null;
-        StorageFile? firstFile = null;
-        foreach (var item in items)
-        {
-            if (item is StorageFolder droppedFolder)
-            {
-                folder = droppedFolder;
-                break;
-            }
-
-            if (firstFile is null && item is StorageFile droppedFile)
-            {
-                firstFile = droppedFile;
-            }
-        }
-
-        if (folder is not null)
-        {
-            await ViewModel.LoadFolderAsync(folder.Path).ConfigureAwait(true);
-            return;
-        }
-
-        if (firstFile is null)
-        {
-            return;
-        }
-
-        await ViewModel.HandleExternalFileDropAsync(firstFile.Path).ConfigureAwait(true);
-    }
+        => await _dragDropHandler.OnFileListDropAsync(sender, e).ConfigureAwait(true);
 
     private void OnFileItemsDragStarting(object sender, DragItemsStartingEventArgs e)
-    {
-        if (ViewModel is null)
-        {
-            return;
-        }
-
-        _dragItems = e.Items.OfType<PhotoListItem>().ToList();
-        if (_dragItems.Count == 0 && ViewModel.SelectedItems.Count > 0)
-        {
-            _dragItems = ViewModel.SelectedItems.ToList();
-        }
-
-        // Copy と Move の両方を提供することで、外部アプリがドライブ情報に基づき操作を決定できる
-        e.Data.RequestedOperation = DataPackageOperation.Copy | DataPackageOperation.Move;
-        e.Data.Properties[InternalDragKey] = true;
-
-        // ドラッグアウト: StorageItems を遅延提供して Explorer や他アプリが受け取れるようにする
-        var capturedItems = _dragItems.ToList();
-        e.Data.SetDataProvider(StandardDataFormats.StorageItems, async request =>
-        {
-            var deferral = request.GetDeferral();
-            try
-            {
-                var storageItems = new List<IStorageItem>();
-                foreach (var item in capturedItems)
-                {
-                    try
-                    {
-                        IStorageItem storageItem = item.IsFolder
-                            ? await StorageFolder.GetFolderFromPathAsync(item.FilePath)
-                            : await StorageFile.GetFileFromPathAsync(item.FilePath);
-                        storageItems.Add(storageItem);
-                    }
-                    catch (Exception ex) when (ex is FileNotFoundException
-                        or UnauthorizedAccessException
-                        or ArgumentException
-                        or NotSupportedException
-                        or PathTooLongException
-                        or COMException)
-                    {
-                        AppLog.Error($"Failed to provide drag storage item: {item.FilePath}", ex);
-                    }
-                }
-
-                request.SetData(storageItems);
-            }
-            finally
-            {
-                deferral.Complete();
-            }
-        });
-    }
+        => _dragDropHandler.OnFileItemsDragStarting(sender, e);
 
     private async void OnFileItemsDragCompleted(object sender, DragItemsCompletedEventArgs e)
-    {
-        var items = _dragItems;
-        var wasInternal = _wasInternalDrop;
-        _dragItems = null;
-        _wasInternalDrop = false;
-
-        // 外部アプリへの Move 完了後にリストを更新して移動済みアイテムを除去する
-        if (ViewModel is not null
-            && items is { Count: > 0 }
-            && e.DropResult == DataPackageOperation.Move
-            && !wasInternal)
-        {
-            await ViewModel.RefreshAsync().ConfigureAwait(false);
-        }
-    }
+        => await _dragDropHandler.OnFileItemsDragCompletedAsync(sender, e).ConfigureAwait(false);
 
     private void OnFileListRightTapped(object sender, RightTappedRoutedEventArgs e)
     {
@@ -1373,75 +1134,6 @@ internal sealed partial class FileBrowserPaneView : UserControl
         return flyout;
     }
 
-    private static bool IsInternalDrag(DragEventArgs e)
-    {
-        if (!e.DataView.Properties.TryGetValue(InternalDragKey, out var value))
-        {
-            return false;
-        }
-
-        return value is bool isInternal && isInternal;
-    }
-
-    private static bool TryGetDropTargetFolder(ListViewBase listView, UIElement root, DragEventArgs e, out PhotoListItem target)
-    {
-        target = null!;
-        var point = e.GetPosition(root);
-        var elements = Microsoft.UI.Xaml.Media.VisualTreeHelper.FindElementsInHostCoordinates(point, root);
-        foreach (var element in elements)
-        {
-            var container = element as SelectorItem ?? FindAncestor<SelectorItem>(element);
-            if (container is null)
-            {
-                continue;
-            }
-
-            if (!IsDescendantOf(container, listView))
-            {
-                continue;
-            }
-
-            if (listView.ItemFromContainer(container) is not PhotoListItem item || !item.IsFolder)
-            {
-                continue;
-            }
-
-            target = item;
-            return true;
-        }
-
-        return false;
-    }
-
-    private bool TryGetBreadcrumbTarget(BreadcrumbBar breadcrumbBar, DragEventArgs e, out BreadcrumbSegment target)
-    {
-        target = null!;
-        var point = e.GetPosition(RootGrid);
-        var elements = Microsoft.UI.Xaml.Media.VisualTreeHelper.FindElementsInHostCoordinates(point, RootGrid);
-        foreach (var element in elements)
-        {
-            var container = element as BreadcrumbBarItem ?? FindAncestor<BreadcrumbBarItem>(element);
-            if (container is null)
-            {
-                continue;
-            }
-
-            if (!IsDescendantOf(container, breadcrumbBar))
-            {
-                continue;
-            }
-
-            if (container.DataContext is not BreadcrumbSegment segment)
-            {
-                continue;
-            }
-
-            target = segment;
-            return true;
-        }
-
-        return false;
-    }
     private static T? FindAncestor<T>(DependencyObject? source) where T : DependencyObject
     {
         var current = source;
@@ -1456,22 +1148,6 @@ internal sealed partial class FileBrowserPaneView : UserControl
         }
 
         return null;
-    }
-
-    private static bool IsDescendantOf(DependencyObject? child, DependencyObject ancestor)
-    {
-        var current = child;
-        while (current is not null)
-        {
-            if (ReferenceEquals(current, ancestor))
-            {
-                return true;
-            }
-
-            current = Microsoft.UI.Xaml.Media.VisualTreeHelper.GetParent(current);
-        }
-
-        return false;
     }
 
     private async Task OpenFolderPickerAsync()


### PR DESCRIPTION
## 要約

#150 Phase 1（`FileBrowserPaneView.xaml.cs` の分割）の第2弾。ドラッグ＆ドロップ処理を View コードビハインドから新設の View 層ヘルパー `Panes/FileBrowser/FileBrowserDragDropHandler.cs`（`internal sealed`）へ分離した。

移動した責務:
- ファイル一覧: `OnFileListDragOver` / `OnFileListDrop` / `OnFileItemsDragStarting`（StorageItems 遅延提供によるドラッグアウト）/ `OnFileItemsDragCompleted`（Move 完了後リフレッシュ）
- ブレッドクラム: `OnBreadcrumbDragOver` / `OnBreadcrumbDrop`
- ヒットテスト: `IsInternalDrag` / `TryGetDropTargetFolder` / `TryGetBreadcrumbTarget`
- ドラッグ状態: `_dragItems` / `_wasInternalDrop` / `InternalDragKey`、および D&D 専用の `IsDescendantOf`

`FileBrowserPaneView.xaml.cs`: 1,515 行 → 1,191 行（**−324 行**）。

## 理由

D&D 処理はビジュアルツリー操作・`DataPackage` 操作を伴う独立性の高い純粋 View 責務であり、View コードビハインドに約300行存在していた。#156（`FileBrowserDialogs`）と同じく View 層ヘルパーへ切り出すことでコードビハインドの肥大化を抑える（MVVM ガードレール準拠 — ViewModel ではなく View 層へ）。

## 設計方針

- ハンドラはコンストラクタでヒットテスト用ルート要素（`RootGrid`）・ViewModel アクセサ（`Func<FileBrowserPaneViewModel?>`）・`FileBrowserDialogs` を受け取る
- XAML のイベント結線（`DragOver` / `Drop` / `DragItemsStarting` / `DragItemsCompleted`）は x:Class 上に存在する必要があるため、View に薄い委譲ハンドラとして残し、処理本体をハンドラへ移譲（表示・操作挙動は不変）
- `FindAncestor<T>` はコンテキストメニュー等 View の他箇所（#158 範囲）でも使用するため View に残し、結合方向を View → Handler の一方向に保つためハンドラ内には小さな static コピーを持たせた。D&D でのみ使う `IsDescendantOf` は完全移動
- 移動に伴い未使用化した `using`（`System.IO` / `System.Runtime.InteropServices` / `Windows.Storage`）を View から削除（`AnalysisMode=AllEnabledByDefault` で IDE0005 がエラー扱いのため）

## 検証

- `dotnet build PhotoGeoExplorer.sln -c Release -p:Platform=x64`: 成功（0 警告 / 0 エラー）
- `dotnet test PhotoGeoExplorer.sln -c Release -p:Platform=x64`: 608 件合格 / 0 失敗（E2E 3 件はスキップ）
- `dotnet format --verify-no-changes`: 差分なし
- pre-commit / pre-push フック（build・format・test）すべて通過

挙動は不変のためスクリーンショットなし。手動 D&D シナリオ（内部 Move / Ctrl+Copy、フォルダ項目へのドロップ、ブレッドクラムへのドロップ、外部ファイル/フォルダ受け入れ、Explorer へのドラッグアウト）は受け入れ条件として維持。

Closes #157