### PR TITLE
refactor: FileBrowserPaneView のコンテキストメニュー・フライアウト構築を専用ビルダーに分離 (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 ## [Unreleased]
 
 ### リファクタリング
+- コンテキストメニュー・フライアウト構築を `FileBrowserPaneView` コードビハインドから `FileBrowserMenuBuilder` へ分離 (#158)
+  - ファイル一覧のコンテキストメニュー（`BuildFileContextFlyout`）、詳細表示の列トグルメニュー（構築・キャッシュ・表示前同期・トグル反映）、ブレッドクラムの子フォルダ一覧フライアウト（`ShowBreadcrumbChildrenFlyout`）を `Panes/FileBrowser/FileBrowserMenuBuilder.cs`（internal sealed）へ移動
+  - メニュー構築は純粋な View 責務のため ViewModel ではなく View 層ヘルパーとして分離（MVVM ガードレール準拠）。ビルダーはコンストラクタで ViewModel アクセサと、コンテキストメニュー各項目のクリックハンドラ群（`FileContextMenuHandlers` レコード）を受け取る。ダイアログ・ピッカー操作を伴うクリック処理は View 責務のため実装は View に残す
+  - 列トグルは `Tag` 文字列定数（`DetailsColumnModifiedTag` 等）＋ `switch` による VM プロパティ更新を、`(ToggleMenuFlyoutItem, getter, setter)` の対応表へ整理し、`SyncDetailsColumnsFlyout` の逐次代入と `OnDetailsColumnMenuItemClicked` の分岐を排除
+  - ブレッドクラム子フォルダフライアウト表示中の誤ナビゲーション抑止フラグ（旧 `_suppressBreadcrumbNavigation`）はフライアウト寿命と連動するためビルダーが所有し、`SuppressBreadcrumbNavigation` プロパティで公開。View の `OnBreadcrumbItemClicked` はこれを参照（表示・操作挙動は不変）
+  - XAML のイベント結線（`Drop`/右クリック/列メニュー/ブレッドクラム）は View に薄い委譲ハンドラとして残し、処理本体をビルダーへ移譲。未使用化した `using Microsoft.UI.Xaml.Automation` を削除
+  - `FileBrowserPaneView.xaml.cs` を 1,191 行から 805 行へ削減（−386 行）
 - ドラッグ＆ドロップ処理を `FileBrowserPaneView` コードビハインドから `FileBrowserDragDropHandler` へ分離 (#157)
   - 内部項目の移動/コピー（`OnFileListDragOver` / `OnFileListDrop`）、Explorer 等へのドラッグアウト（`OnFileItemsDragStarting` の StorageItems 遅延提供・`OnFileItemsDragCompleted` の Move 完了後リフレッシュ）、外部ファイル/フォルダの受け入れ、ブレッドクラムへのドロップ（`OnBreadcrumbDragOver` / `OnBreadcrumbDrop`）、ヒットテスト（`IsInternalDrag` / `TryGetDropTargetFolder` / `TryGetBreadcrumbTarget`）、ドラッグ状態（`_dragItems` / `_wasInternalDrop` / `InternalDragKey`）を `Panes/FileBrowser/FileBrowserDragDropHandler.cs`（internal sealed）へ移動
   - D&D はビジュアルツリー操作・`DataPackage` 操作を伴う純粋な View 責務のため、ViewModel ではなく View 層ヘルパーとして分離（MVVM ガードレール準拠）。ハンドラはコンストラクタでヒットテスト用ルート要素（RootGrid）・ViewModel アクセサ・`FileBrowserDialogs` を受け取る

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserMenuBuilder.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserMenuBuilder.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Controls;
+using PhotoGeoExplorer.Models;
+using PhotoGeoExplorer.Services;
+using PhotoGeoExplorer.ViewModels;
+
+namespace PhotoGeoExplorer.Panes.FileBrowser;
+
+/// <summary>
+/// FileBrowser ペインのコンテキストメニュー・列トグルメニュー・ブレッドクラム子フォルダ
+/// フライアウトの構築を担う View 層ヘルパー。宣言的な組み立てコードを View コードビハインドから
+/// 切り出して View を薄く保つ（メニュー構築は純粋な View 責務）。コンテキストメニュー項目の
+/// クリック処理はダイアログ操作を伴う View 責務のため、ハンドラを受け取り View 側に残す。
+/// </summary>
+internal sealed class FileBrowserMenuBuilder
+{
+    private readonly Func<FileBrowserPaneViewModel?> _viewModelAccessor;
+    private readonly FileContextMenuHandlers _contextMenuHandlers;
+
+    private MenuFlyout? _detailsColumnsFlyout;
+    private IReadOnlyList<DetailsColumnToggle>? _detailsColumnToggles;
+
+    public FileBrowserMenuBuilder(
+        Func<FileBrowserPaneViewModel?> viewModelAccessor,
+        FileContextMenuHandlers contextMenuHandlers)
+    {
+        _viewModelAccessor = viewModelAccessor;
+        _contextMenuHandlers = contextMenuHandlers;
+    }
+
+    private FileBrowserPaneViewModel? ViewModel => _viewModelAccessor();
+
+    /// <summary>
+    /// ブレッドクラム子フォルダフライアウトの表示中は true。BreadcrumbBar の ItemClicked による
+    /// 誤ナビゲーションを抑止するため View 側から参照する。
+    /// </summary>
+    public bool SuppressBreadcrumbNavigation { get; private set; }
+
+    public MenuFlyout BuildFileContextFlyout()
+    {
+        var viewModel = ViewModel;
+        var flyout = new MenuFlyout();
+        if (viewModel is null)
+        {
+            return flyout;
+        }
+
+        var createFolder = new MenuFlyoutItem
+        {
+            Text = LocalizationService.GetString("Menu.NewFolder"),
+            Icon = new SymbolIcon(Symbol.Folder),
+            IsEnabled = viewModel.CanCreateFolder
+        };
+        createFolder.Click += _contextMenuHandlers.CreateFolder;
+
+        var openInExplorerItem = new MenuFlyoutItem
+        {
+            Text = LocalizationService.GetString("Menu.OpenInExplorer"),
+            Icon = new SymbolIcon(Symbol.Document),
+            IsEnabled = viewModel.CanModifySelection
+        };
+        openInExplorerItem.Click += _contextMenuHandlers.OpenInExplorer;
+
+        var openFolderInExplorerItem = new MenuFlyoutItem
+        {
+            Text = LocalizationService.GetString("Menu.OpenFolderInExplorer"),
+            Icon = new SymbolIcon(Symbol.OpenWith),
+            IsEnabled = viewModel.CanOpenInExplorer
+        };
+        openFolderInExplorerItem.Click += _contextMenuHandlers.OpenFolderInExplorer;
+
+        var copyPathItem = new MenuFlyoutItem
+        {
+            Text = LocalizationService.GetString("Menu.CopyPath"),
+            Icon = new SymbolIcon(Symbol.Copy),
+            IsEnabled = viewModel.CanModifySelection
+        };
+        copyPathItem.Click += _contextMenuHandlers.CopyPath;
+
+        var openInGoogleMapsItem = new MenuFlyoutItem
+        {
+            Text = LocalizationService.GetString("Menu.OpenInGoogleMaps"),
+            Icon = new SymbolIcon(Symbol.Map),
+            IsEnabled = viewModel.CanOpenInGoogleMaps
+        };
+        openInGoogleMapsItem.Click += _contextMenuHandlers.OpenInGoogleMaps;
+
+        var renameItem = new MenuFlyoutItem
+        {
+            Text = LocalizationService.GetString("Menu.Rename"),
+            Icon = new SymbolIcon(Symbol.Edit),
+            IsEnabled = viewModel.CanRenameSelection
+        };
+        renameItem.Click += _contextMenuHandlers.Rename;
+
+        var moveItem = new MenuFlyoutItem
+        {
+            Text = LocalizationService.GetString("Menu.Move"),
+            Icon = new SymbolIcon(Symbol.Forward),
+            IsEnabled = viewModel.CanModifySelection
+        };
+        moveItem.Click += _contextMenuHandlers.Move;
+
+        var moveParentItem = new MenuFlyoutItem
+        {
+            Text = LocalizationService.GetString("Menu.MoveToParent"),
+            Icon = new SymbolIcon(Symbol.Up),
+            IsEnabled = viewModel.CanMoveToParentSelection
+        };
+        moveParentItem.Click += _contextMenuHandlers.MoveToParent;
+
+        var copyItem = new MenuFlyoutItem
+        {
+            Text = LocalizationService.GetString("Menu.Copy"),
+            Icon = new SymbolIcon(Symbol.Copy),
+            IsEnabled = viewModel.CanCopySelection
+        };
+        copyItem.Click += _contextMenuHandlers.Copy;
+
+        var deleteItem = new MenuFlyoutItem
+        {
+            Text = LocalizationService.GetString("Menu.Delete"),
+            Icon = new SymbolIcon(Symbol.Delete),
+            IsEnabled = viewModel.CanModifySelection
+        };
+        deleteItem.Click += _contextMenuHandlers.Delete;
+
+        var editExifItem = new MenuFlyoutItem
+        {
+            Text = LocalizationService.GetString("Menu.EditExif"),
+            Icon = new SymbolIcon(Symbol.Edit),
+            Command = viewModel.EditExifCommand,
+            IsEnabled = viewModel.CanEditExif
+        };
+        AutomationProperties.SetAutomationId(editExifItem, "FileBrowser.EditExifMenuItem");
+
+        flyout.Items.Add(createFolder);
+        flyout.Items.Add(new MenuFlyoutSeparator());
+        flyout.Items.Add(openInExplorerItem);
+        flyout.Items.Add(openFolderInExplorerItem);
+        flyout.Items.Add(copyPathItem);
+        flyout.Items.Add(openInGoogleMapsItem);
+        flyout.Items.Add(new MenuFlyoutSeparator());
+        flyout.Items.Add(renameItem);
+        flyout.Items.Add(moveItem);
+        flyout.Items.Add(moveParentItem);
+        flyout.Items.Add(copyItem);
+        flyout.Items.Add(new MenuFlyoutSeparator());
+        flyout.Items.Add(editExifItem);
+        flyout.Items.Add(new MenuFlyoutSeparator());
+        flyout.Items.Add(deleteItem);
+
+        return flyout;
+    }
+
+    public void ShowDetailsColumnsFlyout(FrameworkElement anchor)
+    {
+        var viewModel = ViewModel;
+        if (viewModel is null)
+        {
+            return;
+        }
+
+        _detailsColumnsFlyout ??= BuildDetailsColumnsFlyout();
+        SyncDetailsColumnsFlyout(viewModel);
+        _detailsColumnsFlyout.ShowAt(anchor);
+    }
+
+    public void ShowBreadcrumbChildrenFlyout(FrameworkElement anchor, BreadcrumbSegment segment)
+    {
+        if (segment.Children.Count == 0)
+        {
+            return;
+        }
+
+        var flyout = new MenuFlyout();
+        foreach (var child in segment.Children)
+        {
+            var item = new MenuFlyoutItem
+            {
+                Text = child.Name,
+                Tag = child.FullPath
+            };
+            item.Click += OnBreadcrumbChildClicked;
+            flyout.Items.Add(item);
+        }
+
+        SuppressBreadcrumbNavigation = true;
+        flyout.Closed += (_, _) => SuppressBreadcrumbNavigation = false;
+        flyout.ShowAt(anchor);
+    }
+
+    private MenuFlyout BuildDetailsColumnsFlyout()
+    {
+        _detailsColumnToggles = new[]
+        {
+            CreateDetailsColumnToggle(
+                "DetailsColumnMenu.Modified",
+                static vm => vm.ShowDetailsModifiedColumn,
+                static (vm, isChecked) => vm.ShowDetailsModifiedColumn = isChecked),
+            CreateDetailsColumnToggle(
+                "DetailsColumnMenu.Resolution",
+                static vm => vm.ShowDetailsResolutionColumn,
+                static (vm, isChecked) => vm.ShowDetailsResolutionColumn = isChecked),
+            CreateDetailsColumnToggle(
+                "DetailsColumnMenu.Size",
+                static vm => vm.ShowDetailsSizeColumn,
+                static (vm, isChecked) => vm.ShowDetailsSizeColumn = isChecked),
+            CreateDetailsColumnToggle(
+                "DetailsColumnMenu.TakenAt",
+                static vm => vm.ShowDetailsTakenAtColumn,
+                static (vm, isChecked) => vm.ShowDetailsTakenAtColumn = isChecked),
+            CreateDetailsColumnToggle(
+                "DetailsColumnMenu.Location",
+                static vm => vm.ShowDetailsLocationColumn,
+                static (vm, isChecked) => vm.ShowDetailsLocationColumn = isChecked),
+        };
+
+        var flyout = new MenuFlyout();
+        foreach (var toggle in _detailsColumnToggles)
+        {
+            flyout.Items.Add(toggle.Item);
+        }
+
+        return flyout;
+    }
+
+    private DetailsColumnToggle CreateDetailsColumnToggle(
+        string textResourceKey,
+        Func<FileBrowserPaneViewModel, bool> getter,
+        Action<FileBrowserPaneViewModel, bool> setter)
+    {
+        var item = new ToggleMenuFlyoutItem
+        {
+            Text = LocalizationService.GetString(textResourceKey)
+        };
+        item.Click += OnDetailsColumnMenuItemClicked;
+        return new DetailsColumnToggle(item, getter, setter);
+    }
+
+    private void SyncDetailsColumnsFlyout(FileBrowserPaneViewModel viewModel)
+    {
+        if (_detailsColumnToggles is null)
+        {
+            return;
+        }
+
+        foreach (var toggle in _detailsColumnToggles)
+        {
+            toggle.Item.IsChecked = toggle.Getter(viewModel);
+        }
+    }
+
+    private void OnDetailsColumnMenuItemClicked(object sender, RoutedEventArgs e)
+    {
+        var viewModel = ViewModel;
+        if (viewModel is null
+            || _detailsColumnToggles is null
+            || sender is not ToggleMenuFlyoutItem item)
+        {
+            return;
+        }
+
+        foreach (var toggle in _detailsColumnToggles)
+        {
+            if (ReferenceEquals(toggle.Item, item))
+            {
+                toggle.Setter(viewModel, item.IsChecked);
+                return;
+            }
+        }
+    }
+
+    private async void OnBreadcrumbChildClicked(object sender, RoutedEventArgs e)
+    {
+        if (ViewModel is null || sender is not MenuFlyoutItem item || item.Tag is not string folderPath)
+        {
+            return;
+        }
+
+        await ViewModel.LoadFolderAsync(folderPath).ConfigureAwait(true);
+    }
+
+    private sealed record DetailsColumnToggle(
+        ToggleMenuFlyoutItem Item,
+        Func<FileBrowserPaneViewModel, bool> Getter,
+        Action<FileBrowserPaneViewModel, bool> Setter);
+}
+
+/// <summary>
+/// ファイル一覧コンテキストメニュー各項目のクリックハンドラ群。ダイアログ表示・ピッカー操作を
+/// 伴うため View に実装を残し、メニュー構築時に <see cref="FileBrowserMenuBuilder"/> へ注入する。
+/// </summary>
+internal sealed record FileContextMenuHandlers(
+    RoutedEventHandler CreateFolder,
+    RoutedEventHandler OpenInExplorer,
+    RoutedEventHandler OpenFolderInExplorer,
+    RoutedEventHandler CopyPath,
+    RoutedEventHandler OpenInGoogleMaps,
+    RoutedEventHandler Rename,
+    RoutedEventHandler Move,
+    RoutedEventHandler MoveToParent,
+    RoutedEventHandler Copy,
+    RoutedEventHandler Delete);

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
@@ -21,24 +20,13 @@ namespace PhotoGeoExplorer.Panes.FileBrowser;
 
 internal sealed partial class FileBrowserPaneView : UserControl
 {
-    private const string DetailsColumnModifiedTag = "Modified";
-    private const string DetailsColumnResolutionTag = "Resolution";
-    private const string DetailsColumnSizeTag = "Size";
-    private const string DetailsColumnTakenAtTag = "TakenAt";
-    private const string DetailsColumnLocationTag = "Location";
-    private bool _suppressBreadcrumbNavigation;
     private bool _fileListInputHandlersRegistered;
     private bool _suppressSelectionChangedForRightTap;
     private IReadOnlyList<PhotoListItem> _selectionBeforeChange = Array.Empty<PhotoListItem>();
     private FileBrowserPaneViewModel? _previousViewModel;
-    private MenuFlyout? _detailsColumnsFlyout;
-    private ToggleMenuFlyoutItem? _detailsModifiedColumnMenuItem;
-    private ToggleMenuFlyoutItem? _detailsResolutionColumnMenuItem;
-    private ToggleMenuFlyoutItem? _detailsSizeColumnMenuItem;
-    private ToggleMenuFlyoutItem? _detailsTakenAtColumnMenuItem;
-    private ToggleMenuFlyoutItem? _detailsLocationColumnMenuItem;
     private readonly FileBrowserDialogs _dialogs;
     private readonly FileBrowserDragDropHandler _dragDropHandler;
+    private readonly FileBrowserMenuBuilder _menuBuilder;
 
     public FileBrowserPaneView()
     {
@@ -46,6 +34,19 @@ internal sealed partial class FileBrowserPaneView : UserControl
 
         _dialogs = new FileBrowserDialogs(RootGrid, () => HostWindow);
         _dragDropHandler = new FileBrowserDragDropHandler(RootGrid, () => ViewModel, _dialogs);
+        _menuBuilder = new FileBrowserMenuBuilder(
+            () => ViewModel,
+            new FileContextMenuHandlers(
+                OnCreateFolderClicked,
+                OnOpenInExplorerClicked,
+                OnOpenFolderInExplorerClicked,
+                OnCopyPathClicked,
+                OnOpenInGoogleMapsClicked,
+                OnRenameClicked,
+                OnMoveClicked,
+                OnMoveToParentClicked,
+                OnCopyClicked,
+                OnDeleteClicked));
 
         OpenFolderCommand = new RelayCommand(async () => await OpenFolderAsync().ConfigureAwait(false));
         CreateFolderCommand = new RelayCommand(async () => await CreateFolderAsync().ConfigureAwait(false), () => ViewModel?.CanCreateFolder ?? false);
@@ -260,14 +261,10 @@ internal sealed partial class FileBrowserPaneView : UserControl
 
     private void OnDetailsColumnsClicked(object sender, RoutedEventArgs e)
     {
-        if (ViewModel is null || sender is not FrameworkElement anchor)
+        if (sender is FrameworkElement anchor)
         {
-            return;
+            _menuBuilder.ShowDetailsColumnsFlyout(anchor);
         }
-
-        _detailsColumnsFlyout ??= BuildDetailsColumnsFlyout();
-        SyncDetailsColumnsFlyout();
-        _detailsColumnsFlyout.ShowAt(anchor);
     }
 
     private async void OnStatusPrimaryActionClicked(object sender, RoutedEventArgs e)
@@ -313,7 +310,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
 
     private async void OnBreadcrumbItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
     {
-        if (_suppressBreadcrumbNavigation)
+        if (_menuBuilder.SuppressBreadcrumbNavigation)
         {
             return;
         }
@@ -352,42 +349,8 @@ internal sealed partial class FileBrowserPaneView : UserControl
             return;
         }
 
-        ShowBreadcrumbChildrenFlyout(container, segment);
+        _menuBuilder.ShowBreadcrumbChildrenFlyout(container, segment);
         e.Handled = true;
-    }
-
-    private async void OnBreadcrumbChildClicked(object sender, RoutedEventArgs e)
-    {
-        if (ViewModel is null || sender is not MenuFlyoutItem item || item.Tag is not string folderPath)
-        {
-            return;
-        }
-
-        await ViewModel.LoadFolderAsync(folderPath).ConfigureAwait(true);
-    }
-
-    private void ShowBreadcrumbChildrenFlyout(FrameworkElement anchor, BreadcrumbSegment segment)
-    {
-        if (segment.Children.Count == 0)
-        {
-            return;
-        }
-
-        var flyout = new MenuFlyout();
-        foreach (var child in segment.Children)
-        {
-            var item = new MenuFlyoutItem
-            {
-                Text = child.Name,
-                Tag = child.FullPath
-            };
-            item.Click += OnBreadcrumbChildClicked;
-            flyout.Items.Add(item);
-        }
-
-        _suppressBreadcrumbNavigation = true;
-        flyout.Closed += (_, _) => _suppressBreadcrumbNavigation = false;
-        flyout.ShowAt(anchor);
     }
 
     private void OnBreadcrumbDragOver(object sender, DragEventArgs e)
@@ -486,7 +449,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
             }
         }
 
-        var flyout = BuildFileContextFlyout();
+        var flyout = _menuBuilder.BuildFileContextFlyout();
         flyout.ShowAt(listView, e.GetPosition(listView));
         e.Handled = true;
     }
@@ -913,225 +876,6 @@ internal sealed partial class FileBrowserPaneView : UserControl
         }
 
         ViewModel.ToggleSort(column);
-    }
-
-    private MenuFlyout BuildDetailsColumnsFlyout()
-    {
-        var flyout = new MenuFlyout();
-
-        _detailsModifiedColumnMenuItem = CreateDetailsColumnToggleItem(
-            LocalizationService.GetString("DetailsColumnMenu.Modified"),
-            DetailsColumnModifiedTag);
-        _detailsResolutionColumnMenuItem = CreateDetailsColumnToggleItem(
-            LocalizationService.GetString("DetailsColumnMenu.Resolution"),
-            DetailsColumnResolutionTag);
-        _detailsSizeColumnMenuItem = CreateDetailsColumnToggleItem(
-            LocalizationService.GetString("DetailsColumnMenu.Size"),
-            DetailsColumnSizeTag);
-        _detailsTakenAtColumnMenuItem = CreateDetailsColumnToggleItem(
-            LocalizationService.GetString("DetailsColumnMenu.TakenAt"),
-            DetailsColumnTakenAtTag);
-        _detailsLocationColumnMenuItem = CreateDetailsColumnToggleItem(
-            LocalizationService.GetString("DetailsColumnMenu.Location"),
-            DetailsColumnLocationTag);
-
-        flyout.Items.Add(_detailsModifiedColumnMenuItem);
-        flyout.Items.Add(_detailsResolutionColumnMenuItem);
-        flyout.Items.Add(_detailsSizeColumnMenuItem);
-        flyout.Items.Add(_detailsTakenAtColumnMenuItem);
-        flyout.Items.Add(_detailsLocationColumnMenuItem);
-
-        return flyout;
-    }
-
-    private ToggleMenuFlyoutItem CreateDetailsColumnToggleItem(string text, string tag)
-    {
-        var item = new ToggleMenuFlyoutItem
-        {
-            Text = text,
-            Tag = tag
-        };
-        item.Click += OnDetailsColumnMenuItemClicked;
-        return item;
-    }
-
-    private void SyncDetailsColumnsFlyout()
-    {
-        if (ViewModel is null)
-        {
-            return;
-        }
-
-        if (_detailsModifiedColumnMenuItem is not null)
-        {
-            _detailsModifiedColumnMenuItem.IsChecked = ViewModel.ShowDetailsModifiedColumn;
-        }
-
-        if (_detailsResolutionColumnMenuItem is not null)
-        {
-            _detailsResolutionColumnMenuItem.IsChecked = ViewModel.ShowDetailsResolutionColumn;
-        }
-
-        if (_detailsSizeColumnMenuItem is not null)
-        {
-            _detailsSizeColumnMenuItem.IsChecked = ViewModel.ShowDetailsSizeColumn;
-        }
-
-        if (_detailsTakenAtColumnMenuItem is not null)
-        {
-            _detailsTakenAtColumnMenuItem.IsChecked = ViewModel.ShowDetailsTakenAtColumn;
-        }
-
-        if (_detailsLocationColumnMenuItem is not null)
-        {
-            _detailsLocationColumnMenuItem.IsChecked = ViewModel.ShowDetailsLocationColumn;
-        }
-    }
-
-    private void OnDetailsColumnMenuItemClicked(object sender, RoutedEventArgs e)
-    {
-        if (ViewModel is null
-            || sender is not ToggleMenuFlyoutItem item
-            || item.Tag is not string tag)
-        {
-            return;
-        }
-
-        switch (tag)
-        {
-            case DetailsColumnModifiedTag:
-                ViewModel.ShowDetailsModifiedColumn = item.IsChecked;
-                break;
-            case DetailsColumnResolutionTag:
-                ViewModel.ShowDetailsResolutionColumn = item.IsChecked;
-                break;
-            case DetailsColumnSizeTag:
-                ViewModel.ShowDetailsSizeColumn = item.IsChecked;
-                break;
-            case DetailsColumnTakenAtTag:
-                ViewModel.ShowDetailsTakenAtColumn = item.IsChecked;
-                break;
-            case DetailsColumnLocationTag:
-                ViewModel.ShowDetailsLocationColumn = item.IsChecked;
-                break;
-        }
-    }
-
-    private MenuFlyout BuildFileContextFlyout()
-    {
-        var viewModel = ViewModel;
-        var flyout = new MenuFlyout();
-        if (viewModel is null)
-        {
-            return flyout;
-        }
-
-        var createFolder = new MenuFlyoutItem
-        {
-            Text = LocalizationService.GetString("Menu.NewFolder"),
-            Icon = new SymbolIcon(Symbol.Folder),
-            IsEnabled = viewModel.CanCreateFolder
-        };
-        createFolder.Click += OnCreateFolderClicked;
-
-        var openInExplorerItem = new MenuFlyoutItem
-        {
-            Text = LocalizationService.GetString("Menu.OpenInExplorer"),
-            Icon = new SymbolIcon(Symbol.Document),
-            IsEnabled = viewModel.CanModifySelection
-        };
-        openInExplorerItem.Click += OnOpenInExplorerClicked;
-
-        var openFolderInExplorerItem = new MenuFlyoutItem
-        {
-            Text = LocalizationService.GetString("Menu.OpenFolderInExplorer"),
-            Icon = new SymbolIcon(Symbol.OpenWith),
-            IsEnabled = viewModel.CanOpenInExplorer
-        };
-        openFolderInExplorerItem.Click += OnOpenFolderInExplorerClicked;
-
-        var copyPathItem = new MenuFlyoutItem
-        {
-            Text = LocalizationService.GetString("Menu.CopyPath"),
-            Icon = new SymbolIcon(Symbol.Copy),
-            IsEnabled = viewModel.CanModifySelection
-        };
-        copyPathItem.Click += OnCopyPathClicked;
-
-        var openInGoogleMapsItem = new MenuFlyoutItem
-        {
-            Text = LocalizationService.GetString("Menu.OpenInGoogleMaps"),
-            Icon = new SymbolIcon(Symbol.Map),
-            IsEnabled = viewModel.CanOpenInGoogleMaps
-        };
-        openInGoogleMapsItem.Click += OnOpenInGoogleMapsClicked;
-
-        var renameItem = new MenuFlyoutItem
-        {
-            Text = LocalizationService.GetString("Menu.Rename"),
-            Icon = new SymbolIcon(Symbol.Edit),
-            IsEnabled = viewModel.CanRenameSelection
-        };
-        renameItem.Click += OnRenameClicked;
-
-        var moveItem = new MenuFlyoutItem
-        {
-            Text = LocalizationService.GetString("Menu.Move"),
-            Icon = new SymbolIcon(Symbol.Forward),
-            IsEnabled = viewModel.CanModifySelection
-        };
-        moveItem.Click += OnMoveClicked;
-
-        var moveParentItem = new MenuFlyoutItem
-        {
-            Text = LocalizationService.GetString("Menu.MoveToParent"),
-            Icon = new SymbolIcon(Symbol.Up),
-            IsEnabled = viewModel.CanMoveToParentSelection
-        };
-        moveParentItem.Click += OnMoveToParentClicked;
-
-        var copyItem = new MenuFlyoutItem
-        {
-            Text = LocalizationService.GetString("Menu.Copy"),
-            Icon = new SymbolIcon(Symbol.Copy),
-            IsEnabled = viewModel.CanCopySelection
-        };
-        copyItem.Click += OnCopyClicked;
-
-        var deleteItem = new MenuFlyoutItem
-        {
-            Text = LocalizationService.GetString("Menu.Delete"),
-            Icon = new SymbolIcon(Symbol.Delete),
-            IsEnabled = viewModel.CanModifySelection
-        };
-        deleteItem.Click += OnDeleteClicked;
-
-        var editExifItem = new MenuFlyoutItem
-        {
-            Text = LocalizationService.GetString("Menu.EditExif"),
-            Icon = new SymbolIcon(Symbol.Edit),
-            Command = viewModel.EditExifCommand,
-            IsEnabled = viewModel.CanEditExif
-        };
-        AutomationProperties.SetAutomationId(editExifItem, "FileBrowser.EditExifMenuItem");
-
-        flyout.Items.Add(createFolder);
-        flyout.Items.Add(new MenuFlyoutSeparator());
-        flyout.Items.Add(openInExplorerItem);
-        flyout.Items.Add(openFolderInExplorerItem);
-        flyout.Items.Add(copyPathItem);
-        flyout.Items.Add(openInGoogleMapsItem);
-        flyout.Items.Add(new MenuFlyoutSeparator());
-        flyout.Items.Add(renameItem);
-        flyout.Items.Add(moveItem);
-        flyout.Items.Add(moveParentItem);
-        flyout.Items.Add(copyItem);
-        flyout.Items.Add(new MenuFlyoutSeparator());
-        flyout.Items.Add(editExifItem);
-        flyout.Items.Add(new MenuFlyoutSeparator());
-        flyout.Items.Add(deleteItem);
-
-        return flyout;
     }
 
     private static T? FindAncestor<T>(DependencyObject? source) where T : DependencyObject


### PR DESCRIPTION
## 要約

#150 Phase 1（`FileBrowserPaneView.xaml.cs` の分割）の第3弾。コンテキストメニュー・列トグルメニュー・ブレッドクラム子フォルダフライアウトの構築コードを、新設の View 層ヘルパー `Panes/FileBrowser/FileBrowserMenuBuilder.cs`（`internal sealed`）へ分離した。

移動した責務:
- ファイル一覧のコンテキストメニュー: `BuildFileContextFlyout`
- 詳細表示の列トグルメニュー: `BuildDetailsColumnsFlyout` / `CreateDetailsColumnToggleItem` / `SyncDetailsColumnsFlyout` / `OnDetailsColumnMenuItemClicked`、列タグ定数（`DetailsColumnModifiedTag` 等）、`ToggleMenuFlyoutItem` フィールド群、`_detailsColumnsFlyout` キャッシュ
- ブレッドクラム子フォルダ一覧: `ShowBreadcrumbChildrenFlyout` / `OnBreadcrumbChildClicked`
- 誤ナビ抑止フラグ: `_suppressBreadcrumbNavigation`

`FileBrowserPaneView.xaml.cs`: 1,191 行 → 805 行（**−386 行**）。

## 理由

メニュー構築は View の正当な責務だが、宣言的な組み立てコードが約250行存在していた。#156（`FileBrowserDialogs`）・#157（`FileBrowserDragDropHandler`）と同じく View 層ヘルパーへ切り出すことでコードビハインドの肥大化を抑える（MVVM ガードレール準拠 — ViewModel ではなく View 層へ）。

## 設計方針

- ビルダーはコンストラクタで ViewModel アクセサ（`Func<FileBrowserPaneViewModel?>`）と、コンテキストメニュー各項目のクリックハンドラ群（`FileContextMenuHandlers` レコード）を受け取る
- コンテキストメニュー項目のクリック処理（リネーム・移動・削除等）はダイアログ・ピッカー操作を伴う View 責務のため、実装は View に残し `RoutedEventHandler` として注入する
- 列トグルは `Tag` 文字列定数 + `switch` による VM プロパティ更新を、`(ToggleMenuFlyoutItem, getter, setter)` の対応表へ整理し、`SyncDetailsColumnsFlyout` の逐次代入と `OnDetailsColumnMenuItemClicked` の分岐を排除（Tag 定数は不要となり削除）
- 列トグルメニューのキャッシュ（`??=`）と表示前の同期はビルダー内に閉じ込め、View の `OnDetailsColumnsClicked` は薄い委譲に
- ブレッドクラム子フォルダフライアウト表示中の誤ナビゲーション抑止フラグはフライアウト寿命と連動するためビルダーが所有し、`SuppressBreadcrumbNavigation` プロパティで公開。View の `OnBreadcrumbItemClicked` はこれを参照
- XAML のイベント結線（右クリック / 列メニュー / ブレッドクラム）は x:Class 上に存在する必要があるため View に薄い委譲ハンドラとして残し、処理本体をビルダーへ移譲（表示・操作挙動は不変）
- 移動に伴い未使用化した `using Microsoft.UI.Xaml.Automation` を View から削除（`AnalysisMode=AllEnabledByDefault` で IDE0005 がエラー扱いのため）

## 検証

- `dotnet build PhotoGeoExplorer.sln -c Release -p:Platform=x64`: 成功（0 警告 / 0 エラー）
- `dotnet test PhotoGeoExplorer.sln -c Release -p:Platform=x64`: 608 件合格 / 0 失敗（E2E 3 件はスキップ）
- `dotnet format --verify-no-changes`: 差分なし
- pre-commit / pre-push フック（build・format・test）すべて通過

挙動は不変のためスクリーンショットなし。右クリックメニュー（項目の有効/無効）・列表示トグル（チェック状態）・ブレッドクラム子フォルダ一覧は現行どおり動作する受け入れ条件を維持。

Closes #158
