### PR TITLE
test(codecov): View 層 UI 構築ヘルパーを ignore に追加し codecov/patch の構造的 fail を解消 (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+### テスト
+- View 層 UI 構築ヘルパーを codecov のカバレッジ集計対象から除外し、`codecov/patch` の構造的 fail を解消 (#171)
+  - #156/#157/#158 で `*View.xaml.cs`（既に `codecov.yml` で ignore 済み）から分離した `FileBrowserDialogs` / `FileBrowserDragDropHandler` / `FileBrowserMenuBuilder` は、`MenuFlyout` / `ContentDialog` / `DataPackage` 等の WinRT 型を直接生成する単体テスト不能な View 責務（MVVM ガードレール準拠）。同種コードが ignore 対象外に移ったため patch coverage が常時 0% で fail していた
+  - 当該 3 ファイルのみを `codecov.yml` の `ignore` に追加。テスト可能な純粋関数（`FileBrowserDialogErrorMap`）・ViewModel・Service はカバレッジ集計対象として維持（ブランケット除外はしない）
+
 ### リファクタリング
 - コンテキストメニュー・フライアウト構築を `FileBrowserPaneView` コードビハインドから `FileBrowserMenuBuilder` へ分離 (#158)
   - ファイル一覧のコンテキストメニュー（`BuildFileContextFlyout`）、詳細表示の列トグルメニュー（構築・キャッシュ・表示前同期・トグル反映）、ブレッドクラムの子フォルダ一覧フライアウト（`ShowBreadcrumbChildrenFlyout`）を `Panes/FileBrowser/FileBrowserMenuBuilder.cs`（internal sealed）へ移動

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,9 +9,13 @@ ignore:
   - "PhotoGeoExplorer.Tests/**"
   - "PhotoGeoExplorer.E2E/**"
   - "PhotoGeoExplorer/Panes/**/*View.xaml.cs"
-  # View 層 UI 構築ヘルパー（WinRT 型を直接生成し単体テスト不能。MVVM ガードレール上 View 責務）。
-  # *View.xaml.cs から分離した同種コードのため除外する。テスト可能な純粋関数
-  # （FileBrowserDialogErrorMap 等）・ViewModel・Service は対象外として集計を維持する（ブランケット除外はしない）。詳細: #171
+  # View-layer UI construction helpers (create WinRT types directly;
+  # not unit-testable; View responsibility per MVVM guardrails).
+  # Split out from *View.xaml.cs, so exclude them too. Testable pure
+  # functions (FileBrowserDialogErrorMap), ViewModels and Services
+  # stay tracked (no blanket exclusion). Details: #171
+  # NOTE: keep this file ASCII-only -- the Codecov CLI fails to decode
+  # non-ASCII bytes on the Windows runner.
   - "PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDialogs.cs"
   - "PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDragDropHandler.cs"
   - "PhotoGeoExplorer/Panes/FileBrowser/FileBrowserMenuBuilder.cs"

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,3 +9,9 @@ ignore:
   - "PhotoGeoExplorer.Tests/**"
   - "PhotoGeoExplorer.E2E/**"
   - "PhotoGeoExplorer/Panes/**/*View.xaml.cs"
+  # View 層 UI 構築ヘルパー（WinRT 型を直接生成し単体テスト不能。MVVM ガードレール上 View 責務）。
+  # *View.xaml.cs から分離した同種コードのため除外する。テスト可能な純粋関数
+  # （FileBrowserDialogErrorMap 等）・ViewModel・Service は対象外として集計を維持する（ブランケット除外はしない）。詳細: #171
+  - "PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDialogs.cs"
+  - "PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDragDropHandler.cs"
+  - "PhotoGeoExplorer/Panes/FileBrowser/FileBrowserMenuBuilder.cs"


### PR DESCRIPTION
## 要約

#156/#157/#158 で `FileBrowserPaneView.xaml.cs` から分離した **テスト不能な View 層 UI 構築ヘルパー** 3 ファイルを `codecov.yml` の `ignore` に追加し、`codecov/patch` の構造的 fail を解消する。

## 理由

`codecov.yml` の `ignore` は従来 `PhotoGeoExplorer/Panes/**/*View.xaml.cs` のみを除外していた。一連の View 分割リファクタで、`*View.xaml.cs` 内にあった `MenuFlyout` / `ContentDialog` / `DataPackage` 等の **WinRT 型を直接生成する単体テスト不能な UI 構築コード**（MVVM ガードレール上 View 責務）を新設ヘルパーへ移したため、同種コードが ignore 対象外となり、新規追加行の patch coverage が常時 0% で `codecov/patch` が fail していた。

## 変更内容

`codecov.yml` の `ignore` に以下 3 ファイルを追加（理由をコメントで記載）:

- `PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDialogs.cs`（#156）
- `PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDragDropHandler.cs`（#157）
- `PhotoGeoExplorer/Panes/FileBrowser/FileBrowserMenuBuilder.cs`（#158）

## 設計判断

- **選択的除外（案A）を採用**。`Panes/FileBrowser/**` のブランケット除外はしない。#167 で純粋関数化した `FileBrowserDialogErrorMap.cs`・`FileBrowserPaneViewModel`・`FileBrowserPaneService` 等の **テスト可能コードはカバレッジ集計対象として維持** する。
- 命名規約 + glob による除外（既存ファイルのリネームを伴う）は最小限実装のスコープ外とし、方針は `codecov.yml` のコメントに記録した。今後同種ヘルパーが増えた場合の方針は #171 に記載。

## 検証

- pre-commit フック（agent-docs / build / format）すべて通過（build: 0 警告 / 0 エラー）
- pre-push フック（test）通過: 608 件合格 / 0 失敗（E2E 3 件はスキップ）
- `codecov.yml` はカバレッジ計測設定のみの変更で、アプリ挙動・ビルド成果物に影響なし

Closes #171
