### PR TITLE
refactor: FileBrowserPaneView の残存操作ロジックを VM/Service へ移し MVVM 境界を是正 (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   - #156/#157/#158 で `*View.xaml.cs`（既に `codecov.yml` で ignore 済み）から分離した `FileBrowserDialogs` / `FileBrowserDragDropHandler` / `FileBrowserMenuBuilder` は、`MenuFlyout` / `ContentDialog` / `DataPackage` 等の WinRT 型を直接生成する単体テスト不能な View 責務（MVVM ガードレール準拠）。同種コードが ignore 対象外に移ったため patch coverage が常時 0% で fail していた
   - 当該 3 ファイルのみを `codecov.yml` の `ignore` に追加。テスト可能な純粋関数（`FileBrowserDialogErrorMap`）・ViewModel・Service はカバレッジ集計対象として維持（ブランケット除外はしない）
 
+### ドキュメント
+- FileBrowser ゴッドクラス解体 Phase 1（#150 / 子 issue #152〜#159）の成果を `docs/Architecture/FileBrowserDecomposition-Phase1-Summary.md` にモジュール行数で集計（View `1,941→908`・ViewModel `2,089→1,263`、責務別モジュール 9 件を新設）(#159)
+
 ### リファクタリング
 - `FileBrowserPaneView` に残存していた操作判断ロジックを ViewModel / Service へ移し MVVM 境界を是正 (#159)
   - エラーダイアログ表示要否の判定を `FileOperationSummary.HasReportableFailures`（キャンセルを除く失敗の有無）へ集約し、move/copy/delete/paste/drop で散在していた `HasFailures && Failures.Any(... != Cancelled)` と素の `HasFailures` の不統一を解消（ユーザーキャンセル時はエラーダイアログを表示しない挙動へ統一）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
   - 当該 3 ファイルのみを `codecov.yml` の `ignore` に追加。テスト可能な純粋関数（`FileBrowserDialogErrorMap`）・ViewModel・Service はカバレッジ集計対象として維持（ブランケット除外はしない）
 
 ### リファクタリング
+- `FileBrowserPaneView` に残存していた操作判断ロジックを ViewModel / Service へ移し MVVM 境界を是正 (#159)
+  - エラーダイアログ表示要否の判定を `FileOperationSummary.HasReportableFailures`（キャンセルを除く失敗の有無）へ集約し、move/copy/delete/paste/drop で散在していた `HasFailures && Failures.Any(... != Cancelled)` と素の `HasFailures` の不統一を解消（ユーザーキャンセル時はエラーダイアログを表示しない挙動へ統一）
+  - 「単一フォルダ選択なら移動ではなく開く」判断を VM `IsSingleFolderSelected` へ、削除確認メッセージ（単数/複数・ファイル/フォルダ分岐）の組み立てを VM `BuildDeleteConfirmationMessage()` へ、Ctrl+C/X の選択有無判定を VM `CopySelectionToClipboard()` / `CutSelectionToClipboard()` へ、右クリック時の選択復元対象の決定を VM `ResolveRightTapSelection()` へ移動。View はダイアログ/ピッカー表示・ListView 操作・キーイベント解釈のみに限定
+  - VM へ移したロジックと `HasReportableFailures` にパラメータ化単体テストを追加（計 21 ケース）。VM へ移動した削除メッセージ組み立ては `FileBrowserDialogs.BuildDeleteMessage` を削除して一本化
+  - #156/#157/#158 完了後の #150 Phase 1 最終タスク。挙動はキャンセル時のダイアログ抑止統一を除き不変
 - コンテキストメニュー・フライアウト構築を `FileBrowserPaneView` コードビハインドから `FileBrowserMenuBuilder` へ分離 (#158)
   - ファイル一覧のコンテキストメニュー（`BuildFileContextFlyout`）、詳細表示の列トグルメニュー（構築・キャッシュ・表示前同期・トグル反映）、ブレッドクラムの子フォルダ一覧フライアウト（`ShowBreadcrumbChildrenFlyout`）を `Panes/FileBrowser/FileBrowserMenuBuilder.cs`（internal sealed）へ移動
   - メニュー構築は純粋な View 責務のため ViewModel ではなく View 層ヘルパーとして分離（MVVM ガードレール準拠）。ビルダーはコンストラクタで ViewModel アクセサと、コンテキストメニュー各項目のクリックハンドラ群（`FileContextMenuHandlers` レコード）を受け取る。ダイアログ・ピッカー操作を伴うクリック処理は View 責務のため実装は View に残す

--- a/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
@@ -1453,6 +1453,175 @@ public class FileBrowserPaneViewModelTests
     }
 
     // =========================================================
+    // MVVM 境界是正（#159）: View から VM へ移譲した判定ロジック
+    // =========================================================
+
+    [Theory]
+    [InlineData(1, true, true)]   // 単一フォルダ → true
+    [InlineData(1, false, false)] // 単一ファイル → false
+    [InlineData(2, true, false)]  // 複数フォルダ → false
+    [InlineData(0, true, false)]  // 選択なし → false
+    public void IsSingleFolderSelected_ReturnsExpected(int count, bool isFolder, bool expected)
+    {
+        using var vm = CreateViewModelWithFakes(out _, out _);
+        var items = new List<PhotoListItem>();
+        for (var i = 0; i < count; i++)
+        {
+            items.Add(isFolder ? CreateFolderListItem($"folder{i}") : CreatePhotoListItem($"file{i}.jpg"));
+        }
+
+        vm.UpdateSelection(items);
+
+        Assert.Equal(expected, vm.IsSingleFolderSelected);
+    }
+
+    [Fact]
+    public void BuildDeleteConfirmationMessage_SingleFile_UsesFileKey()
+    {
+        using var vm = CreateViewModelWithFakes(out _, out _);
+        vm.UpdateSelection(new[] { CreatePhotoListItem("photo.jpg") });
+
+        // テストホストではローカライズ未解決のためリソースキーがそのまま返り、分岐選択を検証できる。
+        Assert.Equal("Dialog.DeleteConfirm.File", vm.BuildDeleteConfirmationMessage());
+    }
+
+    [Fact]
+    public void BuildDeleteConfirmationMessage_SingleFolder_UsesFolderKey()
+    {
+        using var vm = CreateViewModelWithFakes(out _, out _);
+        vm.UpdateSelection(new[] { CreateFolderListItem("folder") });
+
+        Assert.Equal("Dialog.DeleteConfirm.Folder", vm.BuildDeleteConfirmationMessage());
+    }
+
+    [Fact]
+    public void BuildDeleteConfirmationMessage_MultipleItems_UsesMultipleKey()
+    {
+        using var vm = CreateViewModelWithFakes(out _, out _);
+        vm.UpdateSelection(new[] { CreatePhotoListItem("a.jpg"), CreatePhotoListItem("b.jpg") });
+
+        Assert.Equal("Dialog.DeleteConfirm.Multiple", vm.BuildDeleteConfirmationMessage());
+    }
+
+    [Fact]
+    public async Task CopySelectionToClipboard_WithSelection_SetsCopyClipboard()
+    {
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            using var vm = CreateViewModelWithFakes(out _, out _);
+            await vm.LoadFolderAsync(tempDir);
+            vm.UpdateSelection(new[] { CreatePhotoListItem("photo.jpg") });
+
+            vm.CopySelectionToClipboard();
+
+            Assert.True(vm.CanPasteSelection);
+            Assert.False(vm.IsCutClipboard);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public async Task CutSelectionToClipboard_WithSelection_SetsCutClipboard()
+    {
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            using var vm = CreateViewModelWithFakes(out _, out _);
+            await vm.LoadFolderAsync(tempDir);
+            vm.UpdateSelection(new[] { CreatePhotoListItem("photo.jpg") });
+
+            vm.CutSelectionToClipboard();
+
+            Assert.True(vm.CanPasteSelection);
+            Assert.True(vm.IsCutClipboard);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public async Task CopySelectionToClipboard_WithoutSelection_DoesNotSetClipboard()
+    {
+        var tempDir = CreateTempTestDirectory();
+        try
+        {
+            using var vm = CreateViewModelWithFakes(out _, out _);
+            await vm.LoadFolderAsync(tempDir);
+            vm.UpdateSelection(Array.Empty<PhotoListItem>());
+
+            vm.CopySelectionToClipboard();
+
+            Assert.False(vm.CanPasteSelection);
+        }
+        finally
+        {
+            CleanupTempDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public void ResolveRightTapSelection_CurrentMultiSelectionContainsItem_ReturnsCurrent()
+    {
+        using var vm = CreateViewModelWithFakes(out _, out _);
+        var a = CreatePhotoListItem("a.jpg");
+        var b = CreatePhotoListItem("b.jpg");
+        vm.UpdateSelection(new[] { a, b });
+
+        var result = vm.ResolveRightTapSelection(a, Array.Empty<PhotoListItem>());
+
+        Assert.Equal(new[] { a, b }, result);
+    }
+
+    [Fact]
+    public void ResolveRightTapSelection_CurrentSingle_PriorMultiContainsItem_ReturnsPrior()
+    {
+        using var vm = CreateViewModelWithFakes(out _, out _);
+        var a = CreatePhotoListItem("a.jpg");
+        var b = CreatePhotoListItem("b.jpg");
+        vm.UpdateSelection(new[] { a });
+        var prior = new[] { a, b };
+
+        var result = vm.ResolveRightTapSelection(a, prior);
+
+        Assert.Equal(prior, result);
+    }
+
+    [Fact]
+    public void ResolveRightTapSelection_CurrentMultiWithoutItem_PriorMultiWithItem_ReturnsPrior()
+    {
+        using var vm = CreateViewModelWithFakes(out _, out _);
+        var a = CreatePhotoListItem("a.jpg");
+        var b = CreatePhotoListItem("b.jpg");
+        var c = CreatePhotoListItem("c.jpg");
+        vm.UpdateSelection(new[] { b, c });
+        var prior = new[] { a, b };
+
+        var result = vm.ResolveRightTapSelection(a, prior);
+
+        Assert.Equal(prior, result);
+    }
+
+    [Fact]
+    public void ResolveRightTapSelection_NeitherContainsItem_ReturnsItemOnly()
+    {
+        using var vm = CreateViewModelWithFakes(out _, out _);
+        var a = CreatePhotoListItem("a.jpg");
+        var other = CreatePhotoListItem("other.jpg");
+        vm.UpdateSelection(new[] { other });
+
+        var result = vm.ResolveRightTapSelection(a, Array.Empty<PhotoListItem>());
+
+        Assert.Single(result);
+        Assert.Same(a, result[0]);
+    }
+
+    // =========================================================
     // Execute* 系テスト用ヘルパー
     // =========================================================
 

--- a/PhotoGeoExplorer.Tests/FileOperationSummaryTests.cs
+++ b/PhotoGeoExplorer.Tests/FileOperationSummaryTests.cs
@@ -1,0 +1,61 @@
+using System;
+using PhotoGeoExplorer.Services;
+using Xunit;
+
+namespace PhotoGeoExplorer.Tests;
+
+/// <summary>
+/// <see cref="FileOperationSummary"/> の派生プロパティ（特に #159 で追加した
+/// <see cref="FileOperationSummary.HasReportableFailures"/>）の判定を固定する。
+/// </summary>
+public class FileOperationSummaryTests
+{
+    [Fact]
+    public void HasReportableFailures_NoFailures_IsFalse()
+    {
+        var summary = new FileOperationSummary(1, 0, Array.Empty<FileOperationFailure>());
+
+        Assert.False(summary.HasFailures);
+        Assert.False(summary.HasReportableFailures);
+    }
+
+    [Fact]
+    public void HasReportableFailures_OnlyCancelled_IsFalse()
+    {
+        var summary = new FileOperationSummary(0, 0, new[]
+        {
+            new FileOperationFailure("/a", "a.jpg", FileOperationError.Cancelled),
+        });
+
+        Assert.True(summary.HasFailures);
+        Assert.False(summary.HasReportableFailures);
+    }
+
+    [Theory]
+    [InlineData(nameof(FileOperationError.Unauthorized))]
+    [InlineData(nameof(FileOperationError.AlreadyExists))]
+    [InlineData(nameof(FileOperationError.IoError))]
+    [InlineData(nameof(FileOperationError.DescendantPath))]
+    public void HasReportableFailures_NonCancelledFailure_IsTrue(string errorName)
+    {
+        var error = Enum.Parse<FileOperationError>(errorName);
+        var summary = new FileOperationSummary(0, 0, new[]
+        {
+            new FileOperationFailure("/a", "a.jpg", error),
+        });
+
+        Assert.True(summary.HasReportableFailures);
+    }
+
+    [Fact]
+    public void HasReportableFailures_MixedCancelledAndReal_IsTrue()
+    {
+        var summary = new FileOperationSummary(0, 0, new[]
+        {
+            new FileOperationFailure("/a", "a.jpg", FileOperationError.Cancelled),
+            new FileOperationFailure("/b", "b.jpg", FileOperationError.Unauthorized),
+        });
+
+        Assert.True(summary.HasReportableFailures);
+    }
+}

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDialogs.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDialogs.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using PhotoGeoExplorer.Services;
-using PhotoGeoExplorer.ViewModels;
 using Windows.Storage;
 using Windows.Storage.Pickers;
 using WinRT.Interop;
@@ -49,13 +48,6 @@ internal sealed class FileBrowserDialogs
         => ShowMessageAsync(
             LocalizationService.GetString(keys.TitleKey),
             LocalizationService.GetString(keys.MessageKey));
-
-    public static string BuildDeleteMessage(PhotoListItem item)
-    {
-        return item.IsFolder
-            ? LocalizationService.Format("Dialog.DeleteConfirm.Folder", item.FileName)
-            : LocalizationService.Format("Dialog.DeleteConfirm.File", item.FileName);
-    }
 
     public async Task<StorageFolder?> PickFolderAsync(PickerLocationId startLocation)
     {

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDragDropHandler.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDragDropHandler.cs
@@ -94,7 +94,7 @@ internal sealed class FileBrowserDragDropHandler
         _wasInternalDrop = true;
         var items = _dragItems ?? ViewModel.SelectedItems;
         var summary = await ViewModel.ExecuteMoveItemsToFolderAsync(items, target.FullPath).ConfigureAwait(true);
-        if (summary.HasFailures)
+        if (summary.HasReportableFailures)
         {
             await _dialogs.ShowMoveOperationErrorAsync(summary).ConfigureAwait(true);
         }
@@ -169,7 +169,7 @@ internal sealed class FileBrowserDragDropHandler
                     summary = await ViewModel.ExecuteCopyItemsToFolderAsync(
                         selectedItems, targetFolder.FilePath, _dialogs.ShowCopyConflictAsync)
                         .ConfigureAwait(true);
-                    if (summary.HasFailures && summary.Failures.Any(f => f.Error != FileOperationError.Cancelled))
+                    if (summary.HasReportableFailures)
                     {
                         await _dialogs.ShowCopyOperationErrorAsync(summary).ConfigureAwait(true);
                     }
@@ -178,7 +178,7 @@ internal sealed class FileBrowserDragDropHandler
                 {
                     summary = await ViewModel.ExecuteMoveItemsToFolderAsync(selectedItems, targetFolder.FilePath)
                         .ConfigureAwait(true);
-                    if (summary.HasFailures)
+                    if (summary.HasReportableFailures)
                     {
                         await _dialogs.ShowMoveOperationErrorAsync(summary).ConfigureAwait(true);
                     }

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneView.xaml.cs
@@ -387,24 +387,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
             if (container is not null
                 && listView.ItemFromContainer(container) is PhotoListItem item)
             {
-                var currentSelection = ViewModel.SelectedItems.ToList();
-
-                // 複数選択を維持すべきかを判定する:
-                // ① ViewModel が複数のまま（SelectionChanged なし）→ currentSelection を使用
-                // ② ViewModel が単数に変化（SelectionChanged あり）→ priorSelection を使用
-                IReadOnlyList<PhotoListItem> selectionToRestore;
-                if (currentSelection.Count > 1 && currentSelection.Contains(item))
-                {
-                    selectionToRestore = currentSelection;
-                }
-                else if (priorSelection.Count > 1 && priorSelection.Contains(item))
-                {
-                    selectionToRestore = priorSelection;
-                }
-                else
-                {
-                    selectionToRestore = Array.Empty<PhotoListItem>();
-                }
+                var toRestore = ViewModel.ResolveRightTapSelection(item, priorSelection);
 
                 ViewModel.BeginBatchSelectionUpdate();
                 _suppressSelectionChangedForRightTap = true;
@@ -416,7 +399,6 @@ internal sealed partial class FileBrowserPaneView : UserControl
                     // 後続の ViewModel.SelectedItem=item は SetProperty が false を返すため
                     // TwoWay が再発火せず SelectedItems が単数に上書きされない。
                     listView.SelectedItems.Add(item);
-                    var toRestore = selectionToRestore.Count > 0 ? selectionToRestore : (IReadOnlyList<PhotoListItem>)new[] { item };
                     foreach (var savedItem in toRestore)
                     {
                         if (!object.ReferenceEquals(savedItem, item))
@@ -556,17 +538,11 @@ internal sealed partial class FileBrowserPaneView : UserControl
                 break;
             case VirtualKey.C when ctrl:
                 e.Handled = true;
-                if (ViewModel.SelectedItems.Count > 0)
-                {
-                    ViewModel.SetClipboard(ViewModel.SelectedItems, ClipboardOperation.Copy);
-                }
+                ViewModel.CopySelectionToClipboard();
                 break;
             case VirtualKey.X when ctrl:
                 e.Handled = true;
-                if (ViewModel.SelectedItems.Count > 0)
-                {
-                    ViewModel.SetClipboard(ViewModel.SelectedItems, ClipboardOperation.Cut);
-                }
+                ViewModel.CutSelectionToClipboard();
                 break;
             case VirtualKey.V when ctrl:
                 e.Handled = true;
@@ -607,7 +583,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
         var summary = await ViewModel.ExecutePasteAsync(
             resolveMoveConflictAsync: isCut ? _dialogs.ShowMoveConflictAsync : null,
             resolveCopyConflictAsync: isCut ? null : _dialogs.ShowCopyConflictAsync).ConfigureAwait(true);
-        if (summary.HasFailures && summary.Failures.Any(f => f.Error != FileOperationError.Cancelled))
+        if (summary.HasReportableFailures)
         {
             if (isCut)
             {
@@ -699,7 +675,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
             return;
         }
 
-        if (ViewModel.SelectedItems.Count == 1 && ViewModel.SelectedItems[0].IsFolder)
+        if (ViewModel.IsSingleFolderSelected)
         {
             await ViewModel.LoadFolderAsync(ViewModel.SelectedItems[0].FilePath).ConfigureAwait(true);
             return;
@@ -714,7 +690,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
         var summary = await ViewModel.ExecuteMoveItemsToFolderAsync(
             ViewModel.SelectedItems, destination.Path, _dialogs.ShowMoveConflictAsync)
             .ConfigureAwait(true);
-        if (summary.Failures.Any(f => f.Error != FileOperationError.Cancelled))
+        if (summary.HasReportableFailures)
         {
             await _dialogs.ShowMoveOperationErrorAsync(summary).ConfigureAwait(true);
         }
@@ -733,7 +709,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
         }
 
         var summary = await ViewModel.ExecuteMoveToParentAsync().ConfigureAwait(true);
-        if (summary.HasFailures)
+        if (summary.HasReportableFailures)
         {
             await _dialogs.ShowMoveOperationErrorAsync(summary).ConfigureAwait(true);
         }
@@ -751,12 +727,9 @@ internal sealed partial class FileBrowserPaneView : UserControl
             return;
         }
 
-        var message = ViewModel.SelectedItems.Count == 1
-            ? FileBrowserDialogs.BuildDeleteMessage(ViewModel.SelectedItems[0])
-            : LocalizationService.Format("Dialog.DeleteConfirm.Multiple", ViewModel.SelectedItems.Count);
         var confirmed = await _dialogs.ShowConfirmationAsync(
             LocalizationService.GetString("Dialog.DeleteConfirm.Title"),
-            message,
+            ViewModel.BuildDeleteConfirmationMessage(),
             LocalizationService.GetString("Common.Delete")).ConfigureAwait(true);
         if (!confirmed)
         {
@@ -765,7 +738,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
 
         var itemsToDelete = ViewModel.SelectedItems.ToList();
         var summary = await ViewModel.ExecuteDeleteItemsAsync(itemsToDelete).ConfigureAwait(true);
-        if (summary.HasFailures)
+        if (summary.HasReportableFailures)
         {
             await _dialogs.ShowDeleteOperationErrorAsync(summary).ConfigureAwait(true);
         }
@@ -857,7 +830,7 @@ internal sealed partial class FileBrowserPaneView : UserControl
 
         var summary = await ViewModel.ExecuteCopyItemsToFolderAsync(ViewModel.SelectedItems, destination.Path)
             .ConfigureAwait(true);
-        if (summary.HasFailures)
+        if (summary.HasReportableFailures)
         {
             await _dialogs.ShowCopyOperationErrorAsync(summary).ConfigureAwait(true);
         }

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -446,6 +446,12 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     public bool CanOpenInExplorer => !string.IsNullOrWhiteSpace(CurrentFolderPath);
     public bool CanOpenInGoogleMaps => SelectedCount == 1 && SelectedItem?.HasLocation == true;
 
+    /// <summary>
+    /// 選択が単一フォルダか。移動操作の起点（ピッカーで移動先を選ぶ）ではなく
+    /// 当該フォルダを開くべき分岐を View から委譲して判定する。
+    /// </summary>
+    public bool IsSingleFolderSelected => SelectedItems.Count == 1 && SelectedItems[0].IsFolder;
+
     public string NameSortIndicator => GetSortIndicator(FileSortColumn.Name);
     public string TakenAtSortIndicator => GetSortIndicator(FileSortColumn.TakenAt);
     public string ModifiedSortIndicator => GetSortIndicator(FileSortColumn.ModifiedAt);
@@ -562,6 +568,69 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
     internal void SetClipboard(IReadOnlyList<PhotoListItem> items, ClipboardOperation operation)
     {
         _operationCoordinator.SetClipboard(items, operation);
+    }
+
+    /// <summary>選択がある場合のみ、現在の選択をコピーとしてクリップボードへ載せる。</summary>
+    internal void CopySelectionToClipboard()
+    {
+        if (SelectedItems.Count > 0)
+        {
+            SetClipboard(SelectedItems, ClipboardOperation.Copy);
+        }
+    }
+
+    /// <summary>選択がある場合のみ、現在の選択を切り取りとしてクリップボードへ載せる。</summary>
+    internal void CutSelectionToClipboard()
+    {
+        if (SelectedItems.Count > 0)
+        {
+            SetClipboard(SelectedItems, ClipboardOperation.Cut);
+        }
+    }
+
+    /// <summary>
+    /// 削除確認ダイアログのメッセージを組み立てる。単数（ファイル/フォルダ）と複数で文面を分岐する。
+    /// View はダイアログ表示のみを担い、文面決定ロジックは VM 側で検証可能にする。
+    /// </summary>
+    internal string BuildDeleteConfirmationMessage()
+    {
+        if (SelectedItems.Count == 1)
+        {
+            var item = SelectedItems[0];
+            return item.IsFolder
+                ? LocalizationService.Format("Dialog.DeleteConfirm.Folder", item.FileName)
+                : LocalizationService.Format("Dialog.DeleteConfirm.File", item.FileName);
+        }
+
+        return LocalizationService.Format("Dialog.DeleteConfirm.Multiple", SelectedItems.Count);
+    }
+
+    /// <summary>
+    /// 右クリック時に復元すべき選択集合を決定する。WinUI3 が右クリックで選択を単数化する場合に
+    /// 複数選択を維持するための判定で、ListView 操作（View 責務）と切り離してテスト可能にする。
+    /// </summary>
+    /// <param name="item">右クリックされた項目。</param>
+    /// <param name="priorSelection">右クリック直前（SelectionChanged 発生前）の選択スナップショット。</param>
+    internal IReadOnlyList<PhotoListItem> ResolveRightTapSelection(
+        PhotoListItem item,
+        IReadOnlyList<PhotoListItem> priorSelection)
+    {
+        var currentSelection = SelectedItems.ToList();
+
+        // ① ViewModel が複数選択のまま（SelectionChanged が発生していない）→ 現在の選択を維持
+        if (currentSelection.Count > 1 && currentSelection.Contains(item))
+        {
+            return currentSelection;
+        }
+
+        // ② ViewModel が単数に変化（右クリックで SelectionChanged 発生）→ 直前の選択を復元
+        if (priorSelection.Count > 1 && priorSelection.Contains(item))
+        {
+            return priorSelection;
+        }
+
+        // ③ それ以外は右クリックした項目のみを選択対象とする
+        return new[] { item };
     }
 
     internal async Task<FileOperationSummary> ExecutePasteAsync(

--- a/PhotoGeoExplorer/Services/FileOperationSummary.cs
+++ b/PhotoGeoExplorer/Services/FileOperationSummary.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace PhotoGeoExplorer.Services;
 
@@ -8,5 +9,12 @@ internal sealed record FileOperationSummary(int SuccessCount, int SkipCount, IRe
 {
     public int FailureCount => Failures.Count;
     public bool HasFailures => Failures.Count > 0;
+
+    /// <summary>
+    /// ユーザーへエラーダイアログで通知すべき失敗（キャンセルを除く）が存在するか。
+    /// 競合ダイアログでの取り消しや CancellationToken によるキャンセルはエラー通知の対象外とする。
+    /// </summary>
+    public bool HasReportableFailures => Failures.Any(f => f.Error != FileOperationError.Cancelled);
+
     public bool IsAllSuccess => Failures.Count == 0;
 }

--- a/docs/Architecture/FileBrowserDecomposition-Phase1-Summary.md
+++ b/docs/Architecture/FileBrowserDecomposition-Phase1-Summary.md
@@ -1,0 +1,77 @@
+# FileBrowser ゴッドクラス解体 Phase 1 成果サマリー
+
+> 対象: Issue #150「モジュール棚卸しとゴッドクラス解体計画」の **Phase 1**（子 issue #152〜#159）
+> 集計時点: PR #173（#159）適用後の状態。行数は `wc -l` 実測値。
+
+## 概要
+
+`FileBrowserPaneView.xaml.cs`（View）と `FileBrowserPaneViewModel.cs`（ViewModel）の 2 つのゴッドクラスを、責務単位の独立モジュールへ段階的に分割した。View 側は AGENTS.md の MVVM 責務ガードレールに従い「UI 表示・入力受付のみ」へ、ViewModel 側はファイルシステム等の副作用を Service へ委譲する構成へ整理した。
+
+## ゴッドクラスの行数推移
+
+| ファイル | 着手前 | Phase 1 後 | 差分 |
+| --- | ---: | ---: | ---: |
+| `FileBrowserPaneView.xaml.cs` | 1,941 | 908 | **−1,033（−53%）** |
+| `FileBrowserPaneViewModel.cs` | 2,089 | 1,263 | **−826（−40%）** |
+| 合計 | 4,030 | 2,171 | **−1,859（−46%）** |
+
+着手前ベースラインは Phase 1 最初のコミット `490008e`（#152）の親。
+
+## Phase 1 で新設したモジュール
+
+分割で抽出した責務別モジュール（いずれも単体テスト可能な単位）。行数は現在値。
+
+### ViewModel 側（`FileBrowserPaneViewModel.cs` から抽出）
+
+| モジュール | 行数 | 責務 | Issue / PR |
+| --- | ---: | --- | --- |
+| `Services/IUiDispatcher.cs` | 55 | UI スレッドディスパッチ抽象 | #152 / PR #160 |
+| `Services/UiDispatcher.cs` | 140 | UI スレッドディスパッチ実装 | #152 / PR #160 |
+| `ThumbnailGenerationCoordinator.cs` | 425 | サムネイル生成の調停 | #153 / PR #161 |
+| `FileOperationCoordinator.cs` | 311 | ファイル操作・進捗・クリップボード管理 | #154 / PR #162 |
+| `FileBrowserStatusViewModel.cs` | 398 | ステータス表示＋メタデータロード | #155 / PR #163 |
+
+### View 側（`FileBrowserPaneView.xaml.cs` から抽出）
+
+| モジュール | 行数 | 責務 | Issue / PR |
+| --- | ---: | --- | --- |
+| `FileBrowserDialogs.cs` | 311 | ダイアログ・ピッカー表示（WinRT/HWND Interop 含む） | #156 / PR #166 |
+| `FileBrowserDialogErrorMap.cs` | 57 | 操作エラー → リソースキー対応（純粋関数） | #167 / PR #168 |
+| `FileBrowserDragDropHandler.cs` | 404 | ドラッグ＆ドロップ処理 | #157 / PR #169 |
+| `FileBrowserMenuBuilder.cs` | 307 | コンテキストメニュー・フライアウト構築 | #158 / PR #170 |
+
+新設モジュール合計: **2,408 行**（ViewModel 側 1,329 / View 側 1,079）。
+
+> 総行数は増えるが、これは責務分離に伴うインターフェース・コンストラクタ・DI 配線・XML ドキュメントの追加によるもので、想定どおり。価値は LOC 削減ではなく、各責務の独立性・テスト容易性・保守性の向上にある。
+
+### #159（PR #173）— MVVM 境界是正（新規ファイルなし）
+
+View に残っていた操作判断ロジックを既存クラスへ移動して Phase 1 を締めくくった。
+
+- `FileOperationSummary.HasReportableFailures`（Service 派生プロパティ）を追加し、エラーダイアログ表示要否（キャンセル除外）を集約・統一。
+- 単一フォルダ判定 / 削除確認メッセージ組み立て / Ctrl+C・X の選択判定 / 右クリック選択復元の決定ロジックを ViewModel へ移動。
+
+## 品質・テスト
+
+- 分割した責務はいずれも単体テストで固定。Phase 1 後のテストは **629 件合格 / 0 失敗**（E2E 3 件はスキップ）。
+- View 層 UI 構築ヘルパー（`FileBrowserDialogs` / `FileBrowserDragDropHandler` / `FileBrowserMenuBuilder`）は WinRT 型を直接生成する単体テスト不能コードのため、`codecov.yml` の `ignore` に選択的追加して `codecov/patch` の構造的 fail を解消（#171 / PR #172）。テスト可能な純粋関数・ViewModel・Service はカバレッジ集計対象として維持。
+
+## 関連 Issue / PR 一覧
+
+| Issue | 内容 | PR | 状態 |
+| --- | --- | --- | --- |
+| #150 | 親 issue（Phase 1〜3） | — | 進行中 |
+| #152 | UI スレッドディスパッチ抽出 | #160 | 完了 |
+| #153 | サムネイル生成分離 | #161 | 完了 |
+| #154 | ファイル操作・進捗・クリップボード分離 | #162 | 完了 |
+| #155 | ステータス表示＋メタデータロード分離 | #163 | 完了 |
+| #156 | ダイアログ表示分離 | #166 | 完了 |
+| #167 | エラーマッピングの純粋関数化（#156 フォロー） | #168 | 完了 |
+| #157 | ドラッグ＆ドロップ分離 | #169 | 完了 |
+| #158 | メニュー・フライアウト構築分離 | #170 | 完了 |
+| #159 | MVVM 境界是正 | #173 | レビュー中 |
+| #164 | LoadFolderAsync 並行実行の CTS race 修正（Phase 1 中の関連修正） | #165 | 完了 |
+| #171 | codecov/patch 構造的 fail 解消 | #172 | 完了 |
+| #174 | VM 単体テストの実 FolderWatcherService 起因クラッシュ（#159 フォローアップ） | — | 未着手 |
+
+#159（PR #173）のマージをもって Phase 1 は完了見込み。


### PR DESCRIPTION
@
## 要約

#150 Phase 1（`FileBrowserPaneView.xaml.cs` 分割）の最終弾。#156/#157/#158 で View が薄くなった後に残っていた操作判断ロジックを ViewModel / Service へ移し、AGENTS.md の MVVM 責務ガードレール（「ViewModel の単体テストで検証できるか」基準）に適合させる。

## 変更内容

### Service 層
- `FileOperationSummary.HasReportableFailures`（キャンセルを除く失敗の有無）を追加。エラーダイアログ表示要否の判定を集約。

### ViewModel へ移動した判断ロジック
- `IsSingleFolderSelected`: 「単一フォルダ選択なら移動ではなく開く」分岐（旧 `MoveSelectionAsyncCore`）
- `BuildDeleteConfirmationMessage()`: 削除確認メッセージの組み立て（単数/複数・ファイル/フォルダ分岐。旧 `DeleteSelectionAsyncCore` ＋ `FileBrowserDialogs.BuildDeleteMessage`）
- `CopySelectionToClipboard()` / `CutSelectionToClipboard()`: Ctrl+C/X の選択有無判定（旧 `OnFileListKeyDown`）
- `ResolveRightTapSelection(item, priorSelection)`: 右クリック時の選択復元対象の決定（旧 `OnFileListRightTapped` 内のインライン分岐）

### View（`FileBrowserPaneView.xaml.cs` / `FileBrowserDragDropHandler.cs`）
- 上記ロジックを VM 呼び出しへ置換。View はダイアログ/ピッカー表示・ListView 操作（Clear/Add/ScrollIntoView）・キーイベント解釈のみに限定。
- `move`/`copy`/`delete`/`paste`/`drop` で散在していたエラーダイアログ表示判定を `HasReportableFailures` に統一。
- `FileBrowserDialogs.BuildDeleteMessage` は VM へ一本化して削除（未使用化した `using PhotoGeoExplorer.ViewModels` も除去）。

## 設計判断

- **エラーダイアログ表示判定を全操作で統一**。従来 `paste`/`move`/`drop(copy)` は「Cancelled 以外の失敗時のみ表示」、`copy`/`delete`/`move-to-parent` は「全失敗で表示（Cancelled 含む）」と不統一だった。`HasReportableFailures` に統一し、**ユーザーがキャンセルした際はエラーダイアログを表示しない**挙動へ揃えた（UX 改善・一貫性向上。これ以外の挙動は不変）。

## テスト

- VM へ移したロジックと `HasReportableFailures` にパラメータ化単体テストを追加（計 21 ケース）。
  - `FileOperationSummaryTests`（新設、7 ケース）
  - `FileBrowserPaneViewModelTests` に `IsSingleFolderSelected` / `BuildDeleteConfirmationMessage` / `Copy|CutSelectionToClipboard` / `ResolveRightTapSelection`（14 ケース）

## 検証

- `dotnet build`（Release/x64・警告エラー扱い）: 0 警告 / 0 エラー
- `dotnet test`（Release/x64）: 629 件合格 / 0 失敗（E2E 3 件はスキップ）
- `dotnet format --verify-no-changes`: 差分なし

Closes #159
@