### PR TITLE
test: VM 単体テストに no-op IFolderWatcherService を注入しテストホスト非決定的クラッシュを解消 (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 ## [Unreleased]
 
 ### テスト
-- `FileBrowserPaneViewModel` の単体テストが実 `FolderWatcherService`（実 `FileSystemWatcher` ＋ `System.Threading.Timer`）を起動しないよう no-op フェイクを注入し、テストホストの非決定的クラッシュ要因を解消 (#174)
+- 単体テストが `FileBrowserPaneViewModel` 経由で実 `FolderWatcherService`（実 `FileSystemWatcher` ＋ `System.Threading.Timer`）を起動しないよう no-op フェイクを注入し、テストホストの非決定的クラッシュ要因を解消 (#174)
   - `LoadFolderAsync` が temp ディレクトリを実監視し、ディレクトリ削除と debounce タイマー発火が競合してテストホストが途中終了し得る問題（#159/PR #173 で観測）への対処
-  - 全 VM 生成箇所（`CreateViewModelWithFakes` ＋ インライン生成）に `NoOpFolderWatcherService` を注入。「VM 単体テストは実 watcher を一切起動しない」を保証して将来の再発も防止。production コードは変更なし（テストでは `UiDispatcher.TryEnqueue` が no-op のため VM 側ハンドラは元から無害）
+  - `NoOpFolderWatcherService` を `TestUtilities.cs` の共有ヘルパー（`internal sealed` ＋ static `Shared`）へ昇格し、`PhotoGeoExplorer.Tests` アセンブリ内の **全 `FileBrowserPaneViewModel` 生成箇所**に注入。`FileBrowserPaneViewModelTests`（`CreateViewModelWithFakes` ＋ インライン生成）に加え、`StartupCoordinatorTests` / `SettingsCoordinatorTests` / `SettingsPaneViewModelTests` の生成箇所も網羅
+  - 特に `StartupCoordinatorTests` の `ApplyStartupAsync*` 2 テストは `LoadFolderAsync(tempDir)` → 実 watcher 起動直後に `Dispose()` で同 tempDir を再帰削除しており、#174 と同型の latent な非決定的クラッシュを含んでいた。本注入でこれを除去し「単体テストは実 watcher を一切起動しない」をアセンブリ全体で保証
+  - production コードは変更なし（テストでは `UiDispatcher.TryEnqueue` が no-op のため VM 側ハンドラは元から無害）
 - View 層 UI 構築ヘルパーを codecov のカバレッジ集計対象から除外し、`codecov/patch` の構造的 fail を解消 (#171)
   - #156/#157/#158 で `*View.xaml.cs`（既に `codecov.yml` で ignore 済み）から分離した `FileBrowserDialogs` / `FileBrowserDragDropHandler` / `FileBrowserMenuBuilder` は、`MenuFlyout` / `ContentDialog` / `DataPackage` 等の WinRT 型を直接生成する単体テスト不能な View 責務（MVVM ガードレール準拠）。同種コードが ignore 対象外に移ったため patch coverage が常時 0% で fail していた
   - 当該 3 ファイルのみを `codecov.yml` の `ignore` に追加。テスト可能な純粋関数（`FileBrowserDialogErrorMap`）・ViewModel・Service はカバレッジ集計対象として維持（ブランケット除外はしない）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ## [Unreleased]
 
 ### テスト
+- `FileBrowserPaneViewModel` の単体テストが実 `FolderWatcherService`（実 `FileSystemWatcher` ＋ `System.Threading.Timer`）を起動しないよう no-op フェイクを注入し、テストホストの非決定的クラッシュ要因を解消 (#174)
+  - `LoadFolderAsync` が temp ディレクトリを実監視し、ディレクトリ削除と debounce タイマー発火が競合してテストホストが途中終了し得る問題（#159/PR #173 で観測）への対処
+  - 全 VM 生成箇所（`CreateViewModelWithFakes` ＋ インライン生成）に `NoOpFolderWatcherService` を注入。「VM 単体テストは実 watcher を一切起動しない」を保証して将来の再発も防止。production コードは変更なし（テストでは `UiDispatcher.TryEnqueue` が no-op のため VM 側ハンドラは元から無害）
 - View 層 UI 構築ヘルパーを codecov のカバレッジ集計対象から除外し、`codecov/patch` の構造的 fail を解消 (#171)
   - #156/#157/#158 で `*View.xaml.cs`（既に `codecov.yml` で ignore 済み）から分離した `FileBrowserDialogs` / `FileBrowserDragDropHandler` / `FileBrowserMenuBuilder` は、`MenuFlyout` / `ContentDialog` / `DataPackage` 等の WinRT 型を直接生成する単体テスト不能な View 責務（MVVM ガードレール準拠）。同種コードが ignore 対象外に移ったため patch coverage が常時 0% で fail していた
   - 当該 3 ファイルのみを `codecov.yml` の `ignore` に追加。テスト可能な純粋関数（`FileBrowserDialogErrorMap`）・ViewModel・Service はカバレッジ集計対象として維持（ブランケット除外はしない）

--- a/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
@@ -44,7 +44,7 @@ public class FileBrowserPaneViewModelTests
         var workspaceState = new WorkspaceState();
 
         // Act
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         // Assert
         Assert.NotNull(viewModel.Items);
@@ -75,7 +75,7 @@ public class FileBrowserPaneViewModelTests
         var workspaceState = new WorkspaceState();
 
         // Act
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         // Assert
         Assert.True(viewModel.ShowImagesOnly);
@@ -89,7 +89,7 @@ public class FileBrowserPaneViewModelTests
         var workspaceState = new WorkspaceState();
 
         // Act
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         // Assert
         Assert.Equal(FileViewMode.Details, viewModel.FileViewMode);
@@ -101,7 +101,7 @@ public class FileBrowserPaneViewModelTests
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
 
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         Assert.True(viewModel.ShowDetailsModifiedColumn);
         Assert.True(viewModel.ShowDetailsResolutionColumn);
@@ -118,7 +118,7 @@ public class FileBrowserPaneViewModelTests
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
 
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         viewModel.ShowDetailsModifiedColumn = false;
         viewModel.ShowDetailsTakenAtColumn = true;
@@ -135,7 +135,7 @@ public class FileBrowserPaneViewModelTests
         var workspaceState = new WorkspaceState();
 
         // Act
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         // Assert
         Assert.Equal(FileSortColumn.Name, viewModel.SortColumn);
@@ -149,7 +149,7 @@ public class FileBrowserPaneViewModelTests
         var workspaceState = new WorkspaceState();
 
         // Act
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         // Assert
         Assert.Equal(SortDirection.Ascending, viewModel.SortDirection);
@@ -161,7 +161,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         // Act
         viewModel.ToggleSort(FileSortColumn.Name);
@@ -176,7 +176,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         // Act
         viewModel.ToggleSort(FileSortColumn.Size);
@@ -191,7 +191,7 @@ public class FileBrowserPaneViewModelTests
     {
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         viewModel.ToggleSort(FileSortColumn.TakenAt);
         Assert.Equal(FileSortColumn.TakenAt, viewModel.SortColumn);
@@ -208,7 +208,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState)
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher)
         {
             SearchText = "test"
         };
@@ -226,7 +226,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState)
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher)
         {
             ShowImagesOnly = false
         };
@@ -244,7 +244,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         // Act
         viewModel.SearchText = "test";
@@ -259,7 +259,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         // Act
         viewModel.ShowImagesOnly = false;
@@ -274,7 +274,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
         var photoListItem = CreatePhotoListItem("test.jpg");
 
         // Act
@@ -292,7 +292,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
         var folderItem = CreateFolderListItem("TestFolder");
 
         // Act
@@ -308,7 +308,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
         var first = CreatePhotoListItem("first.jpg");
         var second = CreatePhotoListItem("second.jpg");
         viewModel.Items.Add(first);
@@ -330,7 +330,7 @@ public class FileBrowserPaneViewModelTests
         var tempDir = CreateTempTestDirectory();
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         try
         {
@@ -353,7 +353,7 @@ public class FileBrowserPaneViewModelTests
         var tempDir = CreateTempTestDirectory();
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         try
         {
@@ -383,7 +383,12 @@ public class FileBrowserPaneViewModelTests
                 SecondLoadResult = [CreatePhotoListItem("photo.jpg")],
             };
             using var viewModel = new FileBrowserPaneViewModel(
-                paneService, new WorkspaceState(), null, null, new StubFileOperationService());
+                paneService,
+                new WorkspaceState(),
+                null,
+                null,
+                new StubFileOperationService(),
+                folderWatcherService: SharedNoOpFolderWatcher);
 
             var firstLoad = viewModel.LoadFolderAsync(tempDir);
             await viewModel.LoadFolderAsync(tempDir, updateHistory: false).ConfigureAwait(true);
@@ -488,7 +493,7 @@ public class FileBrowserPaneViewModelTests
         var workspaceState = new WorkspaceState();
 
         // Act
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         // Assert
         Assert.False(viewModel.CanCreateFolder);
@@ -501,7 +506,7 @@ public class FileBrowserPaneViewModelTests
         var tempDir = CreateTempTestDirectory();
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         try
         {
@@ -523,7 +528,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
         var item = CreatePhotoListItem("test.jpg");
 
         // Act
@@ -539,7 +544,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         // Act
         viewModel.UpdateSelection(Array.Empty<PhotoListItem>());
@@ -554,7 +559,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
         var first = CreatePhotoListItem("test1.jpg");
         var second = CreatePhotoListItem("test2.jpg");
 
@@ -571,7 +576,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
         var item = CreatePhotoListItem("test.jpg");
 
         // Act
@@ -588,7 +593,7 @@ public class FileBrowserPaneViewModelTests
         var tempDir = CreateTempTestDirectory();
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
         var item = CreatePhotoListItem("test.jpg");
 
         try
@@ -613,7 +618,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         // Act
         viewModel.UpdateSelection(Array.Empty<PhotoListItem>());
@@ -628,7 +633,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         // Act & Assert (Should not throw)
         viewModel.Dispose();
@@ -641,7 +646,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
         var initialValue = viewModel.ShowImagesOnly;
         var expectedTextBeforeToggle = initialValue
             ? LocalizationService.GetString("MenuViewAllFiles.Text")
@@ -666,7 +671,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
 
         // Act
         viewModel.SetViewModeCommand.Execute("Icon");
@@ -681,7 +686,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
         var original = viewModel.FileViewMode;
 
         // Act
@@ -697,7 +702,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
         var original = viewModel.FileViewMode;
 
         // Act
@@ -713,7 +718,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
         var photo = CreatePhotoListItem("match.jpg");
         var folder = CreateFolderListItem("folder");
         viewModel.Items.Add(photo);
@@ -735,7 +740,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
         viewModel.Items.Add(CreatePhotoListItem("exists.jpg"));
 
         // Act
@@ -752,7 +757,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
         var invokedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         viewModel.ConfigureUiActionHandlers(
             () =>
@@ -781,7 +786,7 @@ public class FileBrowserPaneViewModelTests
         var tempDir = CreateTempTestDirectory();
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
         viewModel.ConfigureUiActionHandlers(
             null,
             () => Task.CompletedTask,
@@ -811,7 +816,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
         viewModel.ConfigureUiActionHandlers(
             null,
             null,
@@ -1631,7 +1636,35 @@ public class FileBrowserPaneViewModelTests
     {
         fakePaneService = new FakeFileBrowserPaneService();
         stubOp = new StubFileOperationService();
-        return new FileBrowserPaneViewModel(fakePaneService, new WorkspaceState(), null, null, stubOp);
+        return new FileBrowserPaneViewModel(
+            fakePaneService,
+            new WorkspaceState(),
+            null,
+            null,
+            stubOp,
+            folderWatcherService: SharedNoOpFolderWatcher);
+    }
+
+    /// <summary>
+    /// no-op な <see cref="IFolderWatcherService"/> の共有インスタンス。ステートレス（Watch/Stop/Dispose と
+    /// FolderChanged の購読が全て no-op）のため、全 VM 単体テストで安全に共有でき、毎回の生成を避ける。
+    /// </summary>
+    private static readonly NoOpFolderWatcherService SharedNoOpFolderWatcher = new();
+
+    /// <summary>
+    /// VM 単体テストで実 <see cref="FolderWatcherService"/> による実 FileSystemWatcher / Timer 起動を防ぐ no-op フェイク。
+    /// LoadFolderAsync が temp ディレクトリを監視し、ディレクトリ削除と debounce タイマー発火が競合して
+    /// テストホストが非決定的にクラッシュする問題（#174）への対処。FolderChanged は発火しない。
+    /// </summary>
+    private sealed class NoOpFolderWatcherService : IFolderWatcherService
+    {
+        public event EventHandler? FolderChanged { add { } remove { } }
+
+        public void Watch(string folderPath) { }
+
+        public void Stop() { }
+
+        public void Dispose() { }
     }
 
     private sealed class FakeFileBrowserPaneService : IFileBrowserPaneService

--- a/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/FileBrowserPaneViewModelTests.cs
@@ -44,7 +44,7 @@ public class FileBrowserPaneViewModelTests
         var workspaceState = new WorkspaceState();
 
         // Act
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         // Assert
         Assert.NotNull(viewModel.Items);
@@ -75,7 +75,7 @@ public class FileBrowserPaneViewModelTests
         var workspaceState = new WorkspaceState();
 
         // Act
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         // Assert
         Assert.True(viewModel.ShowImagesOnly);
@@ -89,7 +89,7 @@ public class FileBrowserPaneViewModelTests
         var workspaceState = new WorkspaceState();
 
         // Act
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         // Assert
         Assert.Equal(FileViewMode.Details, viewModel.FileViewMode);
@@ -101,7 +101,7 @@ public class FileBrowserPaneViewModelTests
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
 
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         Assert.True(viewModel.ShowDetailsModifiedColumn);
         Assert.True(viewModel.ShowDetailsResolutionColumn);
@@ -118,7 +118,7 @@ public class FileBrowserPaneViewModelTests
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
 
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         viewModel.ShowDetailsModifiedColumn = false;
         viewModel.ShowDetailsTakenAtColumn = true;
@@ -135,7 +135,7 @@ public class FileBrowserPaneViewModelTests
         var workspaceState = new WorkspaceState();
 
         // Act
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         // Assert
         Assert.Equal(FileSortColumn.Name, viewModel.SortColumn);
@@ -149,7 +149,7 @@ public class FileBrowserPaneViewModelTests
         var workspaceState = new WorkspaceState();
 
         // Act
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         // Assert
         Assert.Equal(SortDirection.Ascending, viewModel.SortDirection);
@@ -161,7 +161,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         // Act
         viewModel.ToggleSort(FileSortColumn.Name);
@@ -176,7 +176,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         // Act
         viewModel.ToggleSort(FileSortColumn.Size);
@@ -191,7 +191,7 @@ public class FileBrowserPaneViewModelTests
     {
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         viewModel.ToggleSort(FileSortColumn.TakenAt);
         Assert.Equal(FileSortColumn.TakenAt, viewModel.SortColumn);
@@ -208,7 +208,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher)
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared)
         {
             SearchText = "test"
         };
@@ -226,7 +226,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher)
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared)
         {
             ShowImagesOnly = false
         };
@@ -244,7 +244,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         // Act
         viewModel.SearchText = "test";
@@ -259,7 +259,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         // Act
         viewModel.ShowImagesOnly = false;
@@ -274,7 +274,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
         var photoListItem = CreatePhotoListItem("test.jpg");
 
         // Act
@@ -292,7 +292,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
         var folderItem = CreateFolderListItem("TestFolder");
 
         // Act
@@ -308,7 +308,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
         var first = CreatePhotoListItem("first.jpg");
         var second = CreatePhotoListItem("second.jpg");
         viewModel.Items.Add(first);
@@ -330,7 +330,7 @@ public class FileBrowserPaneViewModelTests
         var tempDir = CreateTempTestDirectory();
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         try
         {
@@ -353,7 +353,7 @@ public class FileBrowserPaneViewModelTests
         var tempDir = CreateTempTestDirectory();
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         try
         {
@@ -388,7 +388,7 @@ public class FileBrowserPaneViewModelTests
                 null,
                 null,
                 new StubFileOperationService(),
-                folderWatcherService: SharedNoOpFolderWatcher);
+                folderWatcherService: NoOpFolderWatcherService.Shared);
 
             var firstLoad = viewModel.LoadFolderAsync(tempDir);
             await viewModel.LoadFolderAsync(tempDir, updateHistory: false).ConfigureAwait(true);
@@ -493,7 +493,7 @@ public class FileBrowserPaneViewModelTests
         var workspaceState = new WorkspaceState();
 
         // Act
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         // Assert
         Assert.False(viewModel.CanCreateFolder);
@@ -506,7 +506,7 @@ public class FileBrowserPaneViewModelTests
         var tempDir = CreateTempTestDirectory();
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         try
         {
@@ -528,7 +528,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
         var item = CreatePhotoListItem("test.jpg");
 
         // Act
@@ -544,7 +544,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         // Act
         viewModel.UpdateSelection(Array.Empty<PhotoListItem>());
@@ -559,7 +559,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
         var first = CreatePhotoListItem("test1.jpg");
         var second = CreatePhotoListItem("test2.jpg");
 
@@ -576,7 +576,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
         var item = CreatePhotoListItem("test.jpg");
 
         // Act
@@ -593,7 +593,7 @@ public class FileBrowserPaneViewModelTests
         var tempDir = CreateTempTestDirectory();
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
         var item = CreatePhotoListItem("test.jpg");
 
         try
@@ -618,7 +618,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         // Act
         viewModel.UpdateSelection(Array.Empty<PhotoListItem>());
@@ -633,7 +633,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         // Act & Assert (Should not throw)
         viewModel.Dispose();
@@ -646,7 +646,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
         var initialValue = viewModel.ShowImagesOnly;
         var expectedTextBeforeToggle = initialValue
             ? LocalizationService.GetString("MenuViewAllFiles.Text")
@@ -671,7 +671,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
 
         // Act
         viewModel.SetViewModeCommand.Execute("Icon");
@@ -686,7 +686,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
         var original = viewModel.FileViewMode;
 
         // Act
@@ -702,7 +702,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
         var original = viewModel.FileViewMode;
 
         // Act
@@ -718,7 +718,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
         var photo = CreatePhotoListItem("match.jpg");
         var folder = CreateFolderListItem("folder");
         viewModel.Items.Add(photo);
@@ -740,7 +740,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
         viewModel.Items.Add(CreatePhotoListItem("exists.jpg"));
 
         // Act
@@ -757,7 +757,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
         var invokedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         viewModel.ConfigureUiActionHandlers(
             () =>
@@ -786,7 +786,7 @@ public class FileBrowserPaneViewModelTests
         var tempDir = CreateTempTestDirectory();
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
         viewModel.ConfigureUiActionHandlers(
             null,
             () => Task.CompletedTask,
@@ -816,7 +816,7 @@ public class FileBrowserPaneViewModelTests
         // Arrange
         var service = new FileBrowserPaneService();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: SharedNoOpFolderWatcher);
+        using var viewModel = new FileBrowserPaneViewModel(service, workspaceState, folderWatcherService: NoOpFolderWatcherService.Shared);
         viewModel.ConfigureUiActionHandlers(
             null,
             null,
@@ -1642,29 +1642,7 @@ public class FileBrowserPaneViewModelTests
             null,
             null,
             stubOp,
-            folderWatcherService: SharedNoOpFolderWatcher);
-    }
-
-    /// <summary>
-    /// no-op な <see cref="IFolderWatcherService"/> の共有インスタンス。ステートレス（Watch/Stop/Dispose と
-    /// FolderChanged の購読が全て no-op）のため、全 VM 単体テストで安全に共有でき、毎回の生成を避ける。
-    /// </summary>
-    private static readonly NoOpFolderWatcherService SharedNoOpFolderWatcher = new();
-
-    /// <summary>
-    /// VM 単体テストで実 <see cref="FolderWatcherService"/> による実 FileSystemWatcher / Timer 起動を防ぐ no-op フェイク。
-    /// LoadFolderAsync が temp ディレクトリを監視し、ディレクトリ削除と debounce タイマー発火が競合して
-    /// テストホストが非決定的にクラッシュする問題（#174）への対処。FolderChanged は発火しない。
-    /// </summary>
-    private sealed class NoOpFolderWatcherService : IFolderWatcherService
-    {
-        public event EventHandler? FolderChanged { add { } remove { } }
-
-        public void Watch(string folderPath) { }
-
-        public void Stop() { }
-
-        public void Dispose() { }
+            folderWatcherService: NoOpFolderWatcherService.Shared);
     }
 
     private sealed class FakeFileBrowserPaneService : IFileBrowserPaneService

--- a/PhotoGeoExplorer.Tests/SettingsCoordinatorTests.cs
+++ b/PhotoGeoExplorer.Tests/SettingsCoordinatorTests.cs
@@ -304,7 +304,10 @@ public sealed class SettingsCoordinatorTests : IDisposable
         var settingsService = new SettingsService(settingsPath);
         var workspaceState = new WorkspaceState();
         var shellViewModel = new MainViewModel(workspaceState);
-        var fileBrowserPaneViewModel = new FileBrowserPaneViewModel(new FileBrowserPaneService(), workspaceState);
+        var fileBrowserPaneViewModel = new FileBrowserPaneViewModel(
+            new FileBrowserPaneService(),
+            workspaceState,
+            folderWatcherService: NoOpFolderWatcherService.Shared);
         var mapPaneViewModel = new MapPaneViewModel(new MapPaneService(), workspaceState);
         var dialogService = new FakeDialogService();
         var coordinator = new SettingsCoordinator(

--- a/PhotoGeoExplorer.Tests/SettingsPaneViewModelTests.cs
+++ b/PhotoGeoExplorer.Tests/SettingsPaneViewModelTests.cs
@@ -19,7 +19,10 @@ public sealed class SettingsPaneViewModelTests : IDisposable
     public SettingsPaneViewModelTests()
     {
         _mainViewModel = new MainViewModel(_workspaceState);
-        _fileBrowserPaneViewModel = new FileBrowserPaneViewModel(new FileBrowserPaneService(), _workspaceState);
+        _fileBrowserPaneViewModel = new FileBrowserPaneViewModel(
+            new FileBrowserPaneService(),
+            _workspaceState,
+            folderWatcherService: NoOpFolderWatcherService.Shared);
     }
 
     [Fact]

--- a/PhotoGeoExplorer.Tests/StartupCoordinatorTests.cs
+++ b/PhotoGeoExplorer.Tests/StartupCoordinatorTests.cs
@@ -48,7 +48,10 @@ public sealed class StartupCoordinatorTests : IDisposable
     {
         var tempDir = CreateTempDirectory();
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(new FileBrowserPaneService(), workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(
+            new FileBrowserPaneService(),
+            workspaceState,
+            folderWatcherService: NoOpFolderWatcherService.Shared);
         using var coordinator = new StartupCoordinator(
             viewModel,
             commandLineArgsProvider: () => new[] { "PhotoGeoExplorer.exe", "--folder", tempDir },
@@ -67,7 +70,10 @@ public sealed class StartupCoordinatorTests : IDisposable
         await File.WriteAllTextAsync(startupFilePath, "test").ConfigureAwait(true);
 
         var workspaceState = new WorkspaceState();
-        using var viewModel = new FileBrowserPaneViewModel(new FileBrowserPaneService(), workspaceState);
+        using var viewModel = new FileBrowserPaneViewModel(
+            new FileBrowserPaneService(),
+            workspaceState,
+            folderWatcherService: NoOpFolderWatcherService.Shared);
         using var coordinator = new StartupCoordinator(
             viewModel,
             commandLineArgsProvider: () => DefaultCommandLineArgs,

--- a/PhotoGeoExplorer.Tests/TestUtilities.cs
+++ b/PhotoGeoExplorer.Tests/TestUtilities.cs
@@ -1,5 +1,7 @@
 using System.Globalization;
 
+using PhotoGeoExplorer.Services;
+
 namespace PhotoGeoExplorer.Tests;
 
 internal sealed class CultureScope : IDisposable
@@ -20,4 +22,24 @@ internal sealed class CultureScope : IDisposable
         CultureInfo.CurrentCulture = _originalCulture;
         CultureInfo.CurrentUICulture = _originalUiCulture;
     }
+}
+
+/// <summary>
+/// 単体テストで実 <see cref="FolderWatcherService"/> による実 FileSystemWatcher / Timer 起動を防ぐ no-op フェイク。
+/// <c>LoadFolderAsync</c> が temp ディレクトリを監視し、ディレクトリ削除と debounce タイマー発火が競合して
+/// テストホストが非決定的にクラッシュする問題（#174）への対処。<see cref="FolderChanged"/> は発火しない。
+/// ステートレス（Watch/Stop/Dispose と購読が全て no-op）のため、テストアセンブリ全体で <see cref="Shared"/>
+/// を安全に共有でき、VM 生成ごとの実インスタンス生成を避けられる。
+/// </summary>
+internal sealed class NoOpFolderWatcherService : IFolderWatcherService
+{
+    public static readonly NoOpFolderWatcherService Shared = new();
+
+    public event EventHandler? FolderChanged { add { } remove { } }
+
+    public void Watch(string folderPath) { }
+
+    public void Stop() { }
+
+    public void Dispose() { }
 }


### PR DESCRIPTION
## 概要

`FileBrowserPaneViewModel` の単体テストが実 `FolderWatcherService`（実 `FileSystemWatcher` ＋ `System.Threading.Timer`）を起動しないよう、全 VM 生成箇所に no-op フェイクを注入し、テストホストの非決定的クラッシュ要因を解消する。

Closes #174

## 背景・原因

#159（PR #173）作業中、pre-push フックの `dotnet test PhotoGeoExplorer.sln` が**非決定的にクラッシュ**（exit 1・テスト失敗 0 件・`PhotoGeoExplorer.Tests.dll` の合格数が 215/241/629 と変動）した。

- `CreateViewModelWithFakes` を含む VM 生成箇所が `IFolderWatcherService` を注入せず、コンストラクタ既定の**実 `FolderWatcherService`** にフォールバックしていた。
- `LoadFolderAsync` → `Watch()` が temp ディレクトリに実 `FileSystemWatcher`（`EnableRaisingEvents=true`）を張り、ファイル変更/ディレクトリ削除イベントが 500ms debounce の `System.Threading.Timer` を起動。テストの temp 削除とタイマー発火が競合し、テストホストごと途中終了し得た。

## 変更内容

- **テストプロジェクトのみ**（production 変更なし）。
- `NoOpFolderWatcherService`（`IFolderWatcherService` の no-op 実装。`FolderChanged` は空アクセサ、`Watch`/`Stop`/`Dispose` は no-op）を追加。ステートレスのため共有 static インスタンス `SharedNoOpFolderWatcher` として全 VM 生成箇所に注入。
- 対象は `CreateViewModelWithFakes` ＋ インライン `new FileBrowserPaneViewModel(...)`（計 39 箇所）。`ArgumentNullException` を検証する null チェック 2 箇所は対象外。
- 「VM 単体テストは実 watcher を一切起動しない」を保証し、将来 `LoadFolderAsync` を呼ぶテストが増えても再発しない。

### production を変更しない理由

テスト環境では `UiDispatcher` の `DispatcherQueue` が `null` のため `TryEnqueue` が no-op になり、VM 側 `OnFolderWatcherChanged`（→`RefreshAsync`）は元から実行されない。クラッシュ源は実 `FolderWatcherService` の OS リソースであり、フェイク注入で根本解消する。本番の fire-and-forget（`async void` ラムダ）堅牢化は #174 のスコープ外として別途検討する。

## 検証

- `dotnet build` … 0 警告 / 0 エラー（AnalysisLevel=latest・警告エラー扱い）
- `dotnet test PhotoGeoExplorer.Tests` … **629 合格 / 0 失敗を 3 回連続、合格数固定・exit 0**（従来は変動）
- `dotnet test PhotoGeoExplorer.sln` … Tests 629 合格 / E2E 3 スキップ / exit 0
- pre-commit（build/format）・pre-push（solution test）フック通過
- `dotnet format --verify-no-changes` … 差分なし

## 受け入れ条件

- [x] VM 単体テストが実 `FileSystemWatcher` / 実 `Timer` を起動しない
- [x] `dotnet test ... ` を複数回連続実行してもテストホストがクラッシュしない
- [x] 既存テストの合格数・挙動が不変（629 件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
