### PR TITLE
test(e2e): コンテキストメニューに automation ID を付与し E2E 現状フィット棚卸しを実施 (#180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ## [Unreleased]
 
 ### テスト
+- E2E（`PhotoGeoExplorer.E2E`）の現状フィット棚卸しを実施し、コンテキストメニュー全項目に automation ID を付与して P5-B（操作系シナリオ追加）の前提を整備 (#180)
+  - `FileBrowserMenuBuilder.BuildFileContextFlyout()` の項目は従来 `FileBrowser.EditExifMenuItem` のみ ID 付与済みだったため、新規フォルダ / エクスプローラーで開く / フォルダをエクスプローラーで開く / パスをコピー / Google マップで開く / リネーム / 移動 / 親フォルダへ移動 / コピー / 削除の各項目に `FileBrowser.*MenuItem` 形式（既存命名に統一）の ID を付与。名前部分一致に依存しない要素特定を可能にしメニュー起因の flaky 低減にも寄与
+  - 既存 3 E2E テストが参照する automation ID（`FileList*` / `FileBrowser.EditExifMenuItem` / `ExifEditor.*` / `MetadataSummaryText` / `PreviewImage` / `MapStatusPanel`）が Phase 1 分割後も全て生存・命名一貫であることを確認（整合点検）
+  - #174（テストホスト内の実 watcher クラッシュ、PR #183 で解消）と E2E flaky は別系統であることを切り分け（E2E は別プロセスのアプリを起動しアプリ終了後に temp 削除するため watcher 競合は波及しない）。production コードの挙動変更なし（ID 付与のみ）
 - 単体テストが `FileBrowserPaneViewModel` 経由で実 `FolderWatcherService`（実 `FileSystemWatcher` ＋ `System.Threading.Timer`）を起動しないよう no-op フェイクを注入し、テストホストの非決定的クラッシュ要因を解消 (#174)
   - `LoadFolderAsync` が temp ディレクトリを実監視し、ディレクトリ削除と debounce タイマー発火が競合してテストホストが途中終了し得る問題（#159/PR #173 で観測）への対処
   - `NoOpFolderWatcherService` を `TestUtilities.cs` の共有ヘルパー（`internal sealed` ＋ static `Shared`）へ昇格し、`PhotoGeoExplorer.Tests` アセンブリ内の **全 `FileBrowserPaneViewModel` 生成箇所**に注入。`FileBrowserPaneViewModelTests`（`CreateViewModelWithFakes` ＋ インライン生成）に加え、`StartupCoordinatorTests` / `SettingsCoordinatorTests` / `SettingsPaneViewModelTests` の生成箇所も網羅
@@ -15,6 +19,7 @@
   - 当該 3 ファイルのみを `codecov.yml` の `ignore` に追加。テスト可能な純粋関数（`FileBrowserDialogErrorMap`）・ViewModel・Service はカバレッジ集計対象として維持（ブランケット除外はしない）
 
 ### ドキュメント
+- E2E 現状フィット棚卸し結果（automation ID 一覧・操作系 ID ギャップと対応・テストデータ拡張要件・#174 との関連・E2E 安定化方針・P5-B 着手前提）を `docs/Architecture/E2E-Phase5-Audit.md` に整理 (#180)
 - FileBrowser ゴッドクラス解体 Phase 1（#150 / 子 issue #152〜#159）の成果を `docs/Architecture/FileBrowserDecomposition-Phase1-Summary.md` にモジュール行数で集計（View `1,941→908`・ViewModel `2,089→1,263`、責務別モジュール 9 件を新設）(#159)
 
 ### リファクタリング

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserMenuBuilder.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserMenuBuilder.cs
@@ -55,6 +55,7 @@ internal sealed class FileBrowserMenuBuilder
             IsEnabled = viewModel.CanCreateFolder
         };
         createFolder.Click += _contextMenuHandlers.CreateFolder;
+        AutomationProperties.SetAutomationId(createFolder, "FileBrowser.NewFolderMenuItem");
 
         var openInExplorerItem = new MenuFlyoutItem
         {
@@ -63,6 +64,7 @@ internal sealed class FileBrowserMenuBuilder
             IsEnabled = viewModel.CanModifySelection
         };
         openInExplorerItem.Click += _contextMenuHandlers.OpenInExplorer;
+        AutomationProperties.SetAutomationId(openInExplorerItem, "FileBrowser.OpenInExplorerMenuItem");
 
         var openFolderInExplorerItem = new MenuFlyoutItem
         {
@@ -71,6 +73,7 @@ internal sealed class FileBrowserMenuBuilder
             IsEnabled = viewModel.CanOpenInExplorer
         };
         openFolderInExplorerItem.Click += _contextMenuHandlers.OpenFolderInExplorer;
+        AutomationProperties.SetAutomationId(openFolderInExplorerItem, "FileBrowser.OpenFolderInExplorerMenuItem");
 
         var copyPathItem = new MenuFlyoutItem
         {
@@ -79,6 +82,7 @@ internal sealed class FileBrowserMenuBuilder
             IsEnabled = viewModel.CanModifySelection
         };
         copyPathItem.Click += _contextMenuHandlers.CopyPath;
+        AutomationProperties.SetAutomationId(copyPathItem, "FileBrowser.CopyPathMenuItem");
 
         var openInGoogleMapsItem = new MenuFlyoutItem
         {
@@ -87,6 +91,7 @@ internal sealed class FileBrowserMenuBuilder
             IsEnabled = viewModel.CanOpenInGoogleMaps
         };
         openInGoogleMapsItem.Click += _contextMenuHandlers.OpenInGoogleMaps;
+        AutomationProperties.SetAutomationId(openInGoogleMapsItem, "FileBrowser.OpenInGoogleMapsMenuItem");
 
         var renameItem = new MenuFlyoutItem
         {
@@ -95,6 +100,7 @@ internal sealed class FileBrowserMenuBuilder
             IsEnabled = viewModel.CanRenameSelection
         };
         renameItem.Click += _contextMenuHandlers.Rename;
+        AutomationProperties.SetAutomationId(renameItem, "FileBrowser.RenameMenuItem");
 
         var moveItem = new MenuFlyoutItem
         {
@@ -103,6 +109,7 @@ internal sealed class FileBrowserMenuBuilder
             IsEnabled = viewModel.CanModifySelection
         };
         moveItem.Click += _contextMenuHandlers.Move;
+        AutomationProperties.SetAutomationId(moveItem, "FileBrowser.MoveMenuItem");
 
         var moveParentItem = new MenuFlyoutItem
         {
@@ -111,6 +118,7 @@ internal sealed class FileBrowserMenuBuilder
             IsEnabled = viewModel.CanMoveToParentSelection
         };
         moveParentItem.Click += _contextMenuHandlers.MoveToParent;
+        AutomationProperties.SetAutomationId(moveParentItem, "FileBrowser.MoveToParentMenuItem");
 
         var copyItem = new MenuFlyoutItem
         {
@@ -119,6 +127,7 @@ internal sealed class FileBrowserMenuBuilder
             IsEnabled = viewModel.CanCopySelection
         };
         copyItem.Click += _contextMenuHandlers.Copy;
+        AutomationProperties.SetAutomationId(copyItem, "FileBrowser.CopyMenuItem");
 
         var deleteItem = new MenuFlyoutItem
         {
@@ -127,6 +136,7 @@ internal sealed class FileBrowserMenuBuilder
             IsEnabled = viewModel.CanModifySelection
         };
         deleteItem.Click += _contextMenuHandlers.Delete;
+        AutomationProperties.SetAutomationId(deleteItem, "FileBrowser.DeleteMenuItem");
 
         var editExifItem = new MenuFlyoutItem
         {

--- a/docs/Architecture/E2E-Phase5-Audit.md
+++ b/docs/Architecture/E2E-Phase5-Audit.md
@@ -1,0 +1,88 @@
+# E2E 現状フィット棚卸し（Phase 5 / #180）
+
+> 親 Issue #150 Phase 5（テスト基盤・E2E 整備）の起点。Phase 1（#152〜#159）の `FileBrowserPaneView` 大規模分割後に、既存 E2E（`PhotoGeoExplorer.E2E`）が現状フィットしているかを再確認し、後続 P5-B（#181 操作系シナリオ追加）/ P5-C（#182 実行時間短縮）の前提を整える。
+
+## 1. 既存 E2E の構成
+
+- テスト（`AppE2ETests.cs`、FlaUI UIA3、3 本）:
+  1. `LaunchOpenFolderPreviewMetadataAndMap` — 起動→フォルダ→プレビュー→メタデータ→地図
+  2. `ExifEditorContextMenuAndDateToggleWorks` — EXIF エディタ コンテキストメニュー＋日付トグル
+  3. `ExifEditorSaveAndReopenKeepsCoordinates` — EXIF エディタ 保存→再オープンで座標保持
+- 実行ゲート: `[E2EFact]`（`PHOTO_GEO_EXPLORER_RUN_E2E=1` 未設定時は Skip）。
+- CI（`.github/workflows/e2e.yml`）: PR/push（main・develop）。windows-latest、WindowsAppRuntime 1.8 導入、1920x1080 設定、**最大 2 回リトライ＋`--blame-hang-timeout 10m`**（flaky 前提）。
+- テストデータ（`E2ETestData`）: temp に `sample.jpg`（Fujifilm/X100V、GPS・DateTimeOriginal 付与）1 枚＋空 `folder` 1 個。アプリは `--folder <temp>` 起動。終了は `TerminateApp`（Close→WaitForExit→Kill）→その後 temp 再帰削除。
+
+## 2. automation ID 整合点検（既存 3 テスト参照分）
+
+既存テストが参照する automation ID は **すべて分割後の現行コードに生存し、命名も一貫**している。整合性に問題なし。
+
+| 参照 ID | 定義場所 | 種別 |
+| --- | --- | --- |
+| `FileListList` / `FileListIcon` / `FileListDetails` | `Panes/FileBrowser/FileBrowserPaneView.xaml`（395 / 418 / 442） | XAML |
+| `FileBrowser.EditExifMenuItem` | `Panes/FileBrowser/FileBrowserMenuBuilder.cs` | コードビハインド |
+| `ExifEditor.UpdateDateCheckBox` / `UpdateFileDateCheckBox` / `TakenAtDatePicker` / `TakenAtTimePicker` / `LatitudeTextBox` / `LongitudeTextBox` | `Services/ExifEditorService.cs`（202 / 211 / 223 / 229 / 259 / 273） | コード生成 |
+| `MetadataSummaryText` / `PreviewImage` | `Panes/Preview/PreviewPaneViewControl.xaml`（31 / 100） | XAML |
+| `MapStatusPanel` | `Panes/Map/MapPaneViewControl.xaml`（101） | XAML |
+| `PrimaryButton` / `SecondaryButton` | `ContentDialog` 標準パーツ | 標準（`Save`/`Cancel` 名フォールバックあり） |
+
+### 既定義だが E2E 未使用（P5-B で利用可能）
+
+- `SearchTextBox` / `OpenFolderButton` / `ViewModeCombo` / `ShowImagesOnlyCheckBox`（FileBrowserPaneView.xaml）
+- `MapControl` / `MapStatusTitle` / `MapStatusDescription`（MapPaneViewControl.xaml）
+- `ExifEditor.GetLocationButton` / `ExifEditor.ClearLocationButton`（ExifEditorService.cs 284 / 298）
+
+## 3. 操作系 ID 棚卸しとギャップ対応（本 PR で実施）
+
+`FileBrowserMenuBuilder.BuildFileContextFlyout()` のコンテキストメニュー項目は、従来 `FileBrowser.EditExifMenuItem` の **1 項目のみ** ID 付与済みで、他は未付与だった。P5-B（#181）の操作系シナリオ（削除確認文面／右クリック選択復元／クリップボード／移動競合・キャンセル）は、メニュー項目を名前部分一致ではなく ID で一意特定する必要がある。
+
+本 PR で全項目に `FileBrowser.*MenuItem` 形式（既存 `EditExif` に統一）の ID を付与した。
+
+| メニュー項目 | 付与した AutomationId | P5-B 用途 |
+| --- | --- | --- |
+| 新規フォルダ | `FileBrowser.NewFolderMenuItem` | |
+| エクスプローラーで開く | `FileBrowser.OpenInExplorerMenuItem` | |
+| フォルダをエクスプローラーで開く | `FileBrowser.OpenFolderInExplorerMenuItem` | |
+| パスをコピー | `FileBrowser.CopyPathMenuItem` | クリップボード検証 |
+| Google マップで開く | `FileBrowser.OpenInGoogleMapsMenuItem` | |
+| リネーム | `FileBrowser.RenameMenuItem` | リネーム |
+| 移動 | `FileBrowser.MoveMenuItem` | 移動競合・キャンセル |
+| 親フォルダへ移動 | `FileBrowser.MoveToParentMenuItem` | 移動 |
+| コピー | `FileBrowser.CopyMenuItem` | クリップボード／コピー |
+| 削除 | `FileBrowser.DeleteMenuItem` | 削除確認文面 |
+| EXIF 編集 | `FileBrowser.EditExifMenuItem`（既存） | |
+
+> 補足: ID 付与は production アセンブリに入るが、UI 表示・挙動には影響しないテスト用フックである。名前ベースの脆い検索（現状 `OpenExifMenuForItemName` の `"EXIF"` 部分一致等）を ID 直引きへ置換でき、メニュー特定起因の flaky 低減にも寄与する。
+
+## 4. テストデータ／ヘルパー現状確認
+
+現状の `E2ETestData` は単一画像＋空フォルダのみで、操作系シナリオには不足。P5-B（#181）で以下の fixture 拡張が必要（本 Issue ではスコープ外、要件のみ整理）:
+
+- 複数画像（選択範囲・一括操作・カウント検証用）
+- 同名衝突を起こすための移動/コピー先フォルダ＋同名ファイル
+- 削除確認・キャンセル後の状態検証用の安定したファイル集合
+
+ヘルパー面では、`OpenExifMenuForItemName` がコンテキストメニュー汎用化されておらず EXIF 専用名で固定のため、P5-B では「項目 ID を指定してコンテキストメニューを開くヘルパー」への一般化が望ましい（本 PR の ID 付与がその前提）。
+
+## 5. #174 との関連と E2E 安定化方針
+
+### 切り分け結論：#174 と E2E flaky は別系統
+
+- **#174**（PR #183 で解消済み）は、テストホスト**プロセス内**（`PhotoGeoExplorer.Tests`）で実 `FolderWatcherService`（`FileSystemWatcher` + `System.Threading.Timer`）が動き、temp 削除と競合してテストホストごと非決定的にクラッシュする問題。
+- **E2E** は **別プロセスのアプリ**を起動して UIA 操作する。実 `FolderWatcherService` が動くのは production アプリ側として正しい挙動。E2E は `TerminateApp` でアプリを先に終了させてから temp を再帰削除する順序のため、watcher と temp 削除の競合はアプリプロセス内に閉じ、テストホストには波及しない。
+- よって E2E の flaky（リトライ 2 回・blame-hang 10m 前提）の主因は #174 とは別。主因は UIA 描画遅延・要素出現タイミング・コンテキストメニュー開閉の不安定さ（`OpenExifMenuForItemName` が AppsKey→右クリック×2→リスト右クリック→Shift+F10 と 6 通りのフォールバックを持つこと自体が証左）。
+
+### 安定化方針（実装は P5-B / #182）
+
+1. **コンテキストメニュー項目 ID 付与（本 PR で完了）** — 名前部分一致検索を ID 直引きへ置換し、メニュー特定 flaky を低減。
+2. **テスト用起動フラグでの watcher デバウンス短縮／無効化の検討** — アプリプロセス側 Timer 起因の遅延・終了時競合を抑制。production への手当てが必要なため P5-B 以降で評価。
+3. **temp 削除前のアプリ完全終了の確実化** — 現状 `TerminateApp` で対処済み。残存 `IOException` はログのうえ握り潰し。
+4. **リトライ／hang-timeout の最適化** — #182 で実行時間計測とあわせて見直し。
+
+## 6. P5-B（#181）着手前提チェック
+
+- [x] automation ID 整合点検（既存参照分はすべて生存・命名一貫）
+- [x] 操作系メニュー項目の ID ギャップを解消（全項目に付与）
+- [x] #174 との関連と E2E 安定化方針を整理
+- [ ] テストデータ／ヘルパー拡張（要件を本書 §4 に整理。実装は #181 スコープ）
+
+→ ID・方針の前提が整い、#181（操作系シナリオ追加）に着手可能。

--- a/docs/Architecture/E2E-Phase5-Audit.md
+++ b/docs/Architecture/E2E-Phase5-Audit.md
@@ -33,7 +33,9 @@
 
 ## 3. 操作系 ID 棚卸しとギャップ対応（本 PR で実施）
 
-`FileBrowserMenuBuilder.BuildFileContextFlyout()` のコンテキストメニュー項目は、従来 `FileBrowser.EditExifMenuItem` の **1 項目のみ** ID 付与済みで、他は未付与だった。P5-B（#181）の操作系シナリオ（削除確認文面／右クリック選択復元／クリップボード／移動競合・キャンセル）は、メニュー項目を名前部分一致ではなく ID で一意特定する必要がある。
+`FileBrowserMenuBuilder.BuildFileContextFlyout()` のコンテキストメニュー項目は、従来 `FileBrowser.EditExifMenuItem` の **1 項目のみ** ID 付与済みで、他は未付与だった。P5-B（#181）の**メニュー起点**シナリオ（削除確認文面／右クリック選択復元／移動競合・キャンセル）は、メニュー項目を名前部分一致ではなく ID で一意特定する必要がある。
+
+> なお #181 の「クリップボード」シナリオはコンテキストメニューではなくキーボード操作（`Ctrl+C` / `Ctrl+X` → `Ctrl+V`）経由で VM を駆動するため、メニュー ID では対象経路を駆動できない。検証方法は §4 で別途整理する。
 
 本 PR で全項目に `FileBrowser.*MenuItem` 形式（既存 `EditExif` に統一）の ID を付与した。
 
@@ -42,12 +44,12 @@
 | 新規フォルダ | `FileBrowser.NewFolderMenuItem` | |
 | エクスプローラーで開く | `FileBrowser.OpenInExplorerMenuItem` | |
 | フォルダをエクスプローラーで開く | `FileBrowser.OpenFolderInExplorerMenuItem` | |
-| パスをコピー | `FileBrowser.CopyPathMenuItem` | クリップボード検証 |
+| パスをコピー | `FileBrowser.CopyPathMenuItem` | パス文字列の OS クリップボード設定（#181 clipboard シナリオとは別経路） |
 | Google マップで開く | `FileBrowser.OpenInGoogleMapsMenuItem` | |
 | リネーム | `FileBrowser.RenameMenuItem` | リネーム |
 | 移動 | `FileBrowser.MoveMenuItem` | 移動競合・キャンセル |
 | 親フォルダへ移動 | `FileBrowser.MoveToParentMenuItem` | 移動 |
-| コピー | `FileBrowser.CopyMenuItem` | クリップボード／コピー |
+| コピー | `FileBrowser.CopyMenuItem` | FolderPicker 経由の直接コピー（#181 clipboard シナリオとは別経路） |
 | 削除 | `FileBrowser.DeleteMenuItem` | 削除確認文面 |
 | EXIF 編集 | `FileBrowser.EditExifMenuItem`（既存） | |
 
@@ -55,11 +57,13 @@
 
 ## 4. テストデータ／ヘルパー現状確認
 
-現状の `E2ETestData` は単一画像＋空フォルダのみで、操作系シナリオには不足。P5-B（#181）で以下の fixture 拡張が必要（本 Issue ではスコープ外、要件のみ整理）:
+現状の `E2ETestData` は単一画像＋空フォルダのみで、操作系シナリオには不足。**本 Issue（#180）のスコープは fixture 拡張要件の整理までで、実 fixture 実装は #181 の責務**とする（#180/#181 双方の受け入れ条件・依存記述に反映済み）。#181 で必要な拡張:
 
 - 複数画像（選択範囲・一括操作・カウント検証用）
 - 同名衝突を起こすための移動/コピー先フォルダ＋同名ファイル
 - 削除確認・キャンセル後の状態検証用の安定したファイル集合
+
+**clipboard シナリオ（#181）の検証方法**: コンテキストメニューではなくキーボード操作 `Ctrl+C` / `Ctrl+X` → `Ctrl+V` で VM の `CopySelectionToClipboard` / `CutSelectionToClipboard` / `PasteSelectionAsyncCore` を駆動し、貼り付け先への項目出現で結果を確認する。`CopyPathMenuItem`（パス文字列の OS クリップボード設定）・`CopyMenuItem`（FolderPicker 経由の直接コピー）はいずれも clipboard シナリオの対象経路ではないため、メニュー ID では駆動できない。
 
 ヘルパー面では、`OpenExifMenuForItemName` がコンテキストメニュー汎用化されておらず EXIF 専用名で固定のため、P5-B では「項目 ID を指定してコンテキストメニューを開くヘルパー」への一般化が望ましい（本 PR の ID 付与がその前提）。
 
@@ -83,6 +87,6 @@
 - [x] automation ID 整合点検（既存参照分はすべて生存・命名一貫）
 - [x] 操作系メニュー項目の ID ギャップを解消（全項目に付与）
 - [x] #174 との関連と E2E 安定化方針を整理
-- [ ] テストデータ／ヘルパー拡張（要件を本書 §4 に整理。実装は #181 スコープ）
+- [x] テストデータ／ヘルパー**拡張要件の整理**（§4）。実 fixture 実装は #181 の責務として #180/#181 の受け入れ条件・依存に反映済み
 
-→ ID・方針の前提が整い、#181（操作系シナリオ追加）に着手可能。
+→ ID・方針・テストデータ要件の前提が整い、#181（操作系シナリオ追加＋fixture 実装）に着手可能。


### PR DESCRIPTION
## 概要

親 Issue #150 Phase 5（テスト基盤・E2E 整備）の起点 **#180**。Phase 1（#152〜#159）の `FileBrowserPaneView` 大規模分割後に、既存 E2E（`PhotoGeoExplorer.E2E`）が現状フィットしているかを棚卸しし、後続 P5-B（#181 操作系シナリオ追加）の前提（automation ID・テストデータ要件・安定化方針）を整える。主に調査＋軽微な ID 付与。

Closes #180

## 背景

`FileBrowserMenuBuilder.BuildFileContextFlyout()` のコンテキストメニュー項目は、従来 `FileBrowser.EditExifMenuItem` の **1 項目のみ** automation ID 付与済みで、移動/コピー/削除/リネーム等は未付与だった。P5-B の操作系シナリオ（削除確認文面／右クリック選択復元／クリップボード／移動競合・キャンセル）は、メニュー項目を名前部分一致ではなく ID で一意特定する必要がある。

## 変更内容

- **automation ID 付与**（`FileBrowserMenuBuilder.cs`）: コンテキストメニュー全項目に `FileBrowser.*MenuItem` 形式（既存命名に統一）の ID を付与。新規フォルダ / エクスプローラーで開く / フォルダをエクスプローラーで開く / パスをコピー / Google マップで開く / リネーム / 移動 / 親フォルダへ移動 / コピー / 削除。
  - UI 表示・挙動には影響しないテスト用フック。名前ベースの脆い検索を ID 直引きへ置換でき、メニュー特定起因の flaky 低減にも寄与。**production の挙動変更なし**。
- **棚卸しドキュメント**（`docs/Architecture/E2E-Phase5-Audit.md` 新規）: automation ID 一覧・操作系 ID ギャップと対応・テストデータ拡張要件・#174 との関連・E2E 安定化方針・P5-B 着手前提を整理。
- **CHANGELOG.md** 更新（テスト／ドキュメント）。

## 棚卸し結論（要点）

- **整合点検**: 既存 3 E2E テストが参照する automation ID（`FileList*` / `FileBrowser.EditExifMenuItem` / `ExifEditor.*` / `MetadataSummaryText` / `PreviewImage` / `MapStatusPanel`）は Phase 1 分割後も**すべて生存・命名一貫**。
- **#174 切り分け**: #174（テストホスト**プロセス内**の実 watcher クラッシュ、PR #183 で解消）と E2E flaky は**別系統**。E2E は別プロセスのアプリを起動し、アプリ終了後に temp 削除する順序のため watcher 競合は波及しない。E2E flaky の主因は UIA 描画遅延・メニュー開閉の不安定さ。

## 検証

- `dotnet build PhotoGeoExplorer/PhotoGeoExplorer.csproj -c Release -p:Platform=x64 -p:TreatWarningsAsErrors=true` → 成功（警告 0・エラー 0）
- `dotnet format --verify-no-changes`（対象ファイル）→ 差分なし
- pre-push: `PhotoGeoExplorer.Tests` 629 件合格・E2E 3 件スキップ（`PHOTO_GEO_EXPLORER_RUN_E2E` 未設定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)