### PR TITLE
test(e2e): 削除確認文面の分岐検証シナリオ追加とコンテキストメニューヘルパー汎用化 (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### テスト
 - E2E に削除確認ダイアログ文面の分岐検証シナリオを追加し、コンテキストメニューヘルパーを ID 指定の汎用版へ一般化 (#181)
-  - `DeleteConfirmationMessageVariesBySelection`: 単一ファイル / 単一フォルダ / 複数選択で `BuildDeleteConfirmationMessage` の文面が分岐することを検証。トリガーは選択を変えない `Delete` キーとし、各回キャンセルして**非破壊**に確認。文面の正確なローカライズは単体テストが担保するため、E2E は **3 文面が互いに異なる（＝分岐している）ことをロケール／リソース解決非依存に検証**（未パッケージ起動・en ランナーでは未解決のリソースキーが返ることがあるため、解決済み文面に依存しない）
-  - 連続ダイアログ開閉の flaky に対処: 確認ダイアログ出現まで focus+`Delete` 送出をリトライ、`list.Focus()` の UIA COMException(0x80040201) を `ignoreException` で吸収、文面が非空になるまで待機
+  - `DeleteConfirmationDialogShowsForSingleFile` / `...ForSingleFolder` / `...ForMultipleSelection`: 各選択パターンで削除確認ダイアログが実機表示されキャンセルできること（非破壊）を検証。トリガーは選択を変えない `Delete` キー。文面の分岐内容（File / Folder / Multiple）の正確性は単体テスト（`BuildDeleteConfirmationMessage`）が担保するため、E2E は文面が非空（＝ダイアログ表示）であることをロケール／リソース解決非依存に確認（未パッケージ起動・en ランナーでは未解決のリソースキーが返るため、解決済み文面に依存しない）
+  - **連続ダイアログ開閉の flaky を避けるため 1 テスト 1 ダイアログに分割**（各シナリオをアプリ起動から独立）。確認ダイアログ出現まで対象項目への focus+`Delete` 送出をリトライ、`Focus()` の UIA COMException(0x80040201) を `ignoreException` で吸収、文面が非空になるまで待機。ローカルで 3 テスト × 2 ラウンド = 6/6 pass を確認
   - `OpenExifMenuForItemName` を automation ID 引数を取る `OpenContextMenuItemForItemName` へ汎用化し、EXIF 専用の名前フォールバック（`FindEditExifMenuItemByName`）を ID 直引きに置換して削除。既存 ExifEditor 2 テストは `FileBrowser.EditExifMenuItem` で呼ぶよう更新
   - production: 確認ダイアログのメッセージ TextBlock に `FileBrowser.ConfirmationMessage` ID を付与（`FileBrowserDialogs.ShowConfirmationAsync`、UI 挙動不変）
   - #181 を 3 分割した P5-B-1（基盤＋削除確認）。残り（右クリック選択復元 / clipboard / 移動競合）＋fixture 拡張は後続 PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### テスト
 - E2E に削除確認ダイアログ文面の分岐検証シナリオを追加し、コンテキストメニューヘルパーを ID 指定の汎用版へ一般化 (#181)
-  - `DeleteConfirmationMessageVariesBySelection`: 単一ファイル / 単一フォルダ / 複数選択で `BuildDeleteConfirmationMessage` の文面が分岐することを検証。トリガーは選択を変えない `Delete` キーとし、各回キャンセルして**非破壊**に確認（ロケール非依存にファイル名 / フォルダ名 / 件数の有無で判別）
+  - `DeleteConfirmationMessageVariesBySelection`: 単一ファイル / 単一フォルダ / 複数選択で `BuildDeleteConfirmationMessage` の文面が分岐することを検証。トリガーは選択を変えない `Delete` キーとし、各回キャンセルして**非破壊**に確認。文面の正確なローカライズは単体テストが担保するため、E2E は **3 文面が互いに異なる（＝分岐している）ことをロケール／リソース解決非依存に検証**（未パッケージ起動・en ランナーでは未解決のリソースキーが返ることがあるため、解決済み文面に依存しない）
+  - 連続ダイアログ開閉の flaky に対処: 確認ダイアログ出現まで focus+`Delete` 送出をリトライ、`list.Focus()` の UIA COMException(0x80040201) を `ignoreException` で吸収、文面が非空になるまで待機
   - `OpenExifMenuForItemName` を automation ID 引数を取る `OpenContextMenuItemForItemName` へ汎用化し、EXIF 専用の名前フォールバック（`FindEditExifMenuItemByName`）を ID 直引きに置換して削除。既存 ExifEditor 2 テストは `FileBrowser.EditExifMenuItem` で呼ぶよう更新
   - production: 確認ダイアログのメッセージ TextBlock に `FileBrowser.ConfirmationMessage` ID を付与（`FileBrowserDialogs.ShowConfirmationAsync`、UI 挙動不変）
   - #181 を 3 分割した P5-B-1（基盤＋削除確認）。残り（右クリック選択復元 / clipboard / 移動競合）＋fixture 拡張は後続 PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ## [Unreleased]
 
 ### テスト
+- E2E に削除確認ダイアログ文面の分岐検証シナリオを追加し、コンテキストメニューヘルパーを ID 指定の汎用版へ一般化 (#181)
+  - `DeleteConfirmationMessageVariesBySelection`: 単一ファイル / 単一フォルダ / 複数選択で `BuildDeleteConfirmationMessage` の文面が分岐することを検証。トリガーは選択を変えない `Delete` キーとし、各回キャンセルして**非破壊**に確認（ロケール非依存にファイル名 / フォルダ名 / 件数の有無で判別）
+  - `OpenExifMenuForItemName` を automation ID 引数を取る `OpenContextMenuItemForItemName` へ汎用化し、EXIF 専用の名前フォールバック（`FindEditExifMenuItemByName`）を ID 直引きに置換して削除。既存 ExifEditor 2 テストは `FileBrowser.EditExifMenuItem` で呼ぶよう更新
+  - production: 確認ダイアログのメッセージ TextBlock に `FileBrowser.ConfirmationMessage` ID を付与（`FileBrowserDialogs.ShowConfirmationAsync`、UI 挙動不変）
+  - #181 を 3 分割した P5-B-1（基盤＋削除確認）。残り（右クリック選択復元 / clipboard / 移動競合）＋fixture 拡張は後続 PR
 - E2E（`PhotoGeoExplorer.E2E`）の現状フィット棚卸しを実施し、コンテキストメニュー全項目に automation ID を付与して P5-B（操作系シナリオ追加）の前提を整備 (#180)
   - `FileBrowserMenuBuilder.BuildFileContextFlyout()` の項目は従来 `FileBrowser.EditExifMenuItem` のみ ID 付与済みだったため、新規フォルダ / エクスプローラーで開く / フォルダをエクスプローラーで開く / パスをコピー / Google マップで開く / リネーム / 移動 / 親フォルダへ移動 / コピー / 削除の各項目に `FileBrowser.*MenuItem` 形式（既存命名に統一）の ID を付与。名前部分一致に依存しない要素特定を可能にしメニュー起因の flaky 低減にも寄与
   - 既存 3 E2E テストが参照する automation ID（`FileList*` / `FileBrowser.EditExifMenuItem` / `ExifEditor.*` / `MetadataSummaryText` / `PreviewImage` / `MapStatusPanel`）が Phase 1 分割後も全て生存・命名一貫であることを確認（整合点検）

--- a/PhotoGeoExplorer.E2E/AppE2ETests.cs
+++ b/PhotoGeoExplorer.E2E/AppE2ETests.cs
@@ -230,25 +230,29 @@ public sealed class AppE2ETests
                 var list = WaitForList(app, automation, window, _output);
                 WaitForListItems(list, minimumCount: 2);
 
-                // 1. 単一ファイル: 文面にファイル名を含む（Dialog.DeleteConfirm.File）
+                // 単一ファイル / 単一フォルダ / 複数選択で確認文面を取得する。
+                // 文面の正確なローカライズは単体テスト（BuildDeleteConfirmationMessage）が担保するため、
+                // E2E は「選択に応じて確認文面が実機で分岐する」ことを検証する。テストランナーの
+                // ロケール／リソース解決状況（未パッケージ起動・en ランナーでは未解決でリソースキーが
+                // 返ることがある）に依存しないよう、3 文面が互いに異なり非空であることを確認する。
                 var fileMessage = OpenDeleteConfirmationForSelection(window, automation, app.ProcessId, list, SingleFileSelection);
                 _output.WriteLine($"[delete-confirm] single-file message='{fileMessage}'");
-                Assert.Contains("sample.jpg", fileMessage, StringComparison.Ordinal);
                 CancelDeleteConfirmation(window, automation, app.ProcessId);
 
-                // 2. 単一フォルダ: 文面にフォルダ名を含み、ファイル名は含まない（Dialog.DeleteConfirm.Folder）
                 var folderMessage = OpenDeleteConfirmationForSelection(window, automation, app.ProcessId, list, SingleFolderSelection);
                 _output.WriteLine($"[delete-confirm] single-folder message='{folderMessage}'");
-                Assert.Contains("folder", folderMessage, StringComparison.Ordinal);
-                Assert.DoesNotContain("sample.jpg", folderMessage, StringComparison.Ordinal);
                 CancelDeleteConfirmation(window, automation, app.ProcessId);
 
-                // 3. 複数選択: 文面に件数を含み、個別ファイル名は含まない（Dialog.DeleteConfirm.Multiple）
                 var multipleMessage = OpenDeleteConfirmationForSelection(window, automation, app.ProcessId, list, MultipleSelection);
                 _output.WriteLine($"[delete-confirm] multiple message='{multipleMessage}'");
-                Assert.Contains("2", multipleMessage, StringComparison.Ordinal);
-                Assert.DoesNotContain("sample.jpg", multipleMessage, StringComparison.Ordinal);
                 CancelDeleteConfirmation(window, automation, app.ProcessId);
+
+                Assert.NotEmpty(fileMessage);
+                Assert.NotEmpty(folderMessage);
+                Assert.NotEmpty(multipleMessage);
+                Assert.NotEqual(fileMessage, folderMessage);
+                Assert.NotEqual(fileMessage, multipleMessage);
+                Assert.NotEqual(folderMessage, multipleMessage);
             }
             finally
             {

--- a/PhotoGeoExplorer.E2E/AppE2ETests.cs
+++ b/PhotoGeoExplorer.E2E/AppE2ETests.cs
@@ -214,7 +214,23 @@ public sealed class AppE2ETests
     }
 
     [E2EFact]
-    public async Task DeleteConfirmationMessageVariesBySelection()
+    public Task DeleteConfirmationDialogShowsForSingleFile()
+        => RunDeleteConfirmationScenarioAsync(SingleFileSelection);
+
+    [E2EFact]
+    public Task DeleteConfirmationDialogShowsForSingleFolder()
+        => RunDeleteConfirmationScenarioAsync(SingleFolderSelection);
+
+    [E2EFact]
+    public Task DeleteConfirmationDialogShowsForMultipleSelection()
+        => RunDeleteConfirmationScenarioAsync(MultipleSelection);
+
+    // 選択に応じた削除確認ダイアログが実機で表示され、キャンセルできること（非破壊）を検証する。
+    // 各シナリオを独立テストとしてアプリ起動から分離し 1 テスト 1 ダイアログに限定することで、
+    // 連続開閉に起因する flaky を排除する。文面の分岐内容（File / Folder / Multiple）の正確性は
+    // 単体テスト（BuildDeleteConfirmationMessage）が担保するため、E2E は文面が非空であること
+    // （＝確認ダイアログが実機で表示されたこと）を確認する。
+    private async Task RunDeleteConfirmationScenarioAsync(string[] selection)
     {
         E2ETestData? testData = null;
         try
@@ -230,29 +246,11 @@ public sealed class AppE2ETests
                 var list = WaitForList(app, automation, window, _output);
                 WaitForListItems(list, minimumCount: 2);
 
-                // 単一ファイル / 単一フォルダ / 複数選択で確認文面を取得する。
-                // 文面の正確なローカライズは単体テスト（BuildDeleteConfirmationMessage）が担保するため、
-                // E2E は「選択に応じて確認文面が実機で分岐する」ことを検証する。テストランナーの
-                // ロケール／リソース解決状況（未パッケージ起動・en ランナーでは未解決でリソースキーが
-                // 返ることがある）に依存しないよう、3 文面が互いに異なり非空であることを確認する。
-                var fileMessage = OpenDeleteConfirmationForSelection(window, automation, app.ProcessId, list, SingleFileSelection);
-                _output.WriteLine($"[delete-confirm] single-file message='{fileMessage}'");
-                CancelDeleteConfirmation(window, automation, app.ProcessId);
+                var message = OpenDeleteConfirmationForSelection(window, automation, app.ProcessId, list, selection);
+                _output.WriteLine($"[delete-confirm] selection=[{string.Join(",", selection)}] message='{message}'");
+                Assert.NotEmpty(message);
 
-                var folderMessage = OpenDeleteConfirmationForSelection(window, automation, app.ProcessId, list, SingleFolderSelection);
-                _output.WriteLine($"[delete-confirm] single-folder message='{folderMessage}'");
                 CancelDeleteConfirmation(window, automation, app.ProcessId);
-
-                var multipleMessage = OpenDeleteConfirmationForSelection(window, automation, app.ProcessId, list, MultipleSelection);
-                _output.WriteLine($"[delete-confirm] multiple message='{multipleMessage}'");
-                CancelDeleteConfirmation(window, automation, app.ProcessId);
-
-                Assert.NotEmpty(fileMessage);
-                Assert.NotEmpty(folderMessage);
-                Assert.NotEmpty(multipleMessage);
-                Assert.NotEqual(fileMessage, folderMessage);
-                Assert.NotEqual(fileMessage, multipleMessage);
-                Assert.NotEqual(folderMessage, multipleMessage);
             }
             finally
             {
@@ -277,15 +275,15 @@ public sealed class AppE2ETests
         ListBox list,
         string[] itemNames)
     {
-        SelectListItemsByName(list, itemNames);
+        var lastItem = SelectListItemsByName(list, itemNames);
 
-        // ダイアログ連続開閉の直後はリストのフォーカスが不安定で Delete が届かないことがあるため、
-        // 確認ダイアログが現れるまで list へのフォーカスと Delete 送出をリトライする。
+        // ダイアログ連続開閉の直後はリスト／項目のフォーカスが不安定で Delete が届かないことがあるため、
+        // 確認ダイアログが現れるまで対象項目へのフォーカスと Delete 送出をリトライする。
         AutomationElement? message = null;
         Retry.WhileNull(
             () =>
             {
-                list.Focus();
+                TryFocusElement(lastItem);
                 Keyboard.Type(VirtualKeyShort.DELETE);
                 message = TryWaitForElementByAutomationId(
                     window, automation, processId, ConfirmationMessageAutomationId, TimeSpan.FromSeconds(3));
@@ -299,7 +297,7 @@ public sealed class AppE2ETests
         if (message is null)
         {
             throw new TimeoutException(
-                $"Delete confirmation dialog did not appear for [{string.Join(",", itemNames)}].");
+                $"Delete confirmation dialog did not appear for [{string.Join(",", itemNames)}]. List snapshot: {BuildListSnapshot(list)}");
         }
 
         // 要素出現直後は TextBlock のテキストが未反映のことがあるため、文面が非空になるまで待つ。
@@ -322,8 +320,9 @@ public sealed class AppE2ETests
         WaitForElementGone(window, automation, processId, ConfirmationMessageAutomationId);
     }
 
-    private static void SelectListItemsByName(ListBox list, string[] itemNames)
+    private static ListBoxItem SelectListItemsByName(ListBox list, string[] itemNames)
     {
+        var lastItem = WaitForListItemByName(list, itemNames[0]);
         for (var i = 0; i < itemNames.Length; i++)
         {
             var item = WaitForListItemByName(list, itemNames[i]);
@@ -336,7 +335,11 @@ public sealed class AppE2ETests
             {
                 AddToSelection(item);
             }
+
+            lastItem = item;
         }
+
+        return lastItem;
     }
 
     private static void AddToSelection(AutomationElement item)

--- a/PhotoGeoExplorer.E2E/AppE2ETests.cs
+++ b/PhotoGeoExplorer.E2E/AppE2ETests.cs
@@ -25,6 +25,10 @@ namespace PhotoGeoExplorer.E2E;
 public sealed class AppE2ETests
 {
     private const string EditExifMenuAutomationId = "FileBrowser.EditExifMenuItem";
+    private const string ConfirmationMessageAutomationId = "FileBrowser.ConfirmationMessage";
+    private static readonly string[] SingleFileSelection = { "sample.jpg" };
+    private static readonly string[] SingleFolderSelection = { "folder" };
+    private static readonly string[] MultipleSelection = { "sample.jpg", "folder" };
     private static readonly string[] FileListAutomationIds = { "FileListDetails", "FileListIcon", "FileListList" };
     private static readonly string[] PrimaryDialogButtonNames = { "Save", "保存" };
     private static readonly string[] SecondaryDialogButtonNames = { "Cancel", "キャンセル" };
@@ -98,12 +102,12 @@ public sealed class AppE2ETests
                 var list = WaitForList(app, automation, window, _output);
                 WaitForListItems(list, minimumCount: 2);
 
-                var disabledMenuItem = OpenExifMenuForItemName(window, automation, app.ProcessId, list, "folder");
+                var disabledMenuItem = OpenContextMenuItemForItemName(window, automation, app.ProcessId, list, "folder", EditExifMenuAutomationId);
                 Assert.False(disabledMenuItem.IsEnabled);
                 Keyboard.Type(VirtualKeyShort.ESCAPE);
                 WaitForElementGone(window, automation, app.ProcessId, EditExifMenuAutomationId);
 
-                var enabledMenuItem = OpenExifMenuForItemName(window, automation, app.ProcessId, list, "sample.jpg");
+                var enabledMenuItem = OpenContextMenuItemForItemName(window, automation, app.ProcessId, list, "sample.jpg", EditExifMenuAutomationId);
                 Assert.True(enabledMenuItem.IsEnabled);
                 enabledMenuItem.Click();
 
@@ -158,7 +162,7 @@ public sealed class AppE2ETests
 
                 try
                 {
-                    var warmupMenu = OpenExifMenuForItemName(window, automation, app.ProcessId, list, "folder");
+                    var warmupMenu = OpenContextMenuItemForItemName(window, automation, app.ProcessId, list, "folder", EditExifMenuAutomationId);
                     _output.WriteLine($"Warmup menu state for 'folder': IsEnabled={warmupMenu.IsEnabled}");
                     Keyboard.Type(VirtualKeyShort.ESCAPE);
                     WaitForElementGone(window, automation, app.ProcessId, EditExifMenuAutomationId);
@@ -168,7 +172,7 @@ public sealed class AppE2ETests
                     _output.WriteLine("Warmup for 'folder' was skipped because the menu item was not found.");
                 }
 
-                var menuItem = OpenExifMenuForItemName(window, automation, app.ProcessId, list, "sample.jpg");
+                var menuItem = OpenContextMenuItemForItemName(window, automation, app.ProcessId, list, "sample.jpg", EditExifMenuAutomationId);
                 Assert.True(menuItem.IsEnabled);
                 menuItem.Click();
 
@@ -180,7 +184,7 @@ public sealed class AppE2ETests
                 ClickPrimaryDialogButton(window, automation, app.ProcessId);
                 WaitForElementGone(window, automation, app.ProcessId, "ExifEditor.LatitudeTextBox");
 
-                var reopenMenu = OpenExifMenuForItemName(window, automation, app.ProcessId, list, "sample.jpg");
+                var reopenMenu = OpenContextMenuItemForItemName(window, automation, app.ProcessId, list, "sample.jpg", EditExifMenuAutomationId);
                 Assert.True(reopenMenu.IsEnabled);
                 reopenMenu.Click();
 
@@ -207,6 +211,135 @@ public sealed class AppE2ETests
                 await testData.DisposeAsync().ConfigureAwait(true);
             }
         }
+    }
+
+    [E2EFact]
+    public async Task DeleteConfirmationMessageVariesBySelection()
+    {
+        E2ETestData? testData = null;
+        try
+        {
+            testData = await E2ETestData.CreateAsync(_output).ConfigureAwait(true);
+            using var automation = new UIA3Automation();
+            using var app = Application.Launch(testData.StartInfo);
+            try
+            {
+                var window = WaitForMainWindow(app, automation);
+                window.Focus();
+
+                var list = WaitForList(app, automation, window, _output);
+                WaitForListItems(list, minimumCount: 2);
+
+                // 1. 単一ファイル: 文面にファイル名を含む（Dialog.DeleteConfirm.File）
+                var fileMessage = OpenDeleteConfirmationForSelection(window, automation, app.ProcessId, list, SingleFileSelection);
+                Assert.Contains("sample.jpg", fileMessage, StringComparison.Ordinal);
+                CancelDeleteConfirmation(window, automation, app.ProcessId);
+
+                // 2. 単一フォルダ: 文面にフォルダ名を含み、ファイル名は含まない（Dialog.DeleteConfirm.Folder）
+                var folderMessage = OpenDeleteConfirmationForSelection(window, automation, app.ProcessId, list, SingleFolderSelection);
+                Assert.Contains("folder", folderMessage, StringComparison.Ordinal);
+                Assert.DoesNotContain("sample.jpg", folderMessage, StringComparison.Ordinal);
+                CancelDeleteConfirmation(window, automation, app.ProcessId);
+
+                // 3. 複数選択: 文面に件数を含み、個別ファイル名は含まない（Dialog.DeleteConfirm.Multiple）
+                var multipleMessage = OpenDeleteConfirmationForSelection(window, automation, app.ProcessId, list, MultipleSelection);
+                Assert.Contains("2", multipleMessage, StringComparison.Ordinal);
+                Assert.DoesNotContain("sample.jpg", multipleMessage, StringComparison.Ordinal);
+                CancelDeleteConfirmation(window, automation, app.ProcessId);
+            }
+            finally
+            {
+                TerminateApp(app);
+            }
+        }
+        finally
+        {
+            if (testData is not null)
+            {
+                await testData.DisposeAsync().ConfigureAwait(true);
+            }
+        }
+    }
+
+    // 指定した項目を選択し、Delete キーで削除確認ダイアログを開いて文面を返す。
+    // Delete キーは選択を変えないため複数選択シナリオでも選択を維持できる。
+    private static string OpenDeleteConfirmationForSelection(
+        Window window,
+        UIA3Automation automation,
+        int processId,
+        ListBox list,
+        string[] itemNames)
+    {
+        SelectListItemsByName(list, itemNames);
+
+        list.Focus();
+        Keyboard.Type(VirtualKeyShort.DELETE);
+
+        var message = WaitForElementByAutomationId(window, automation, processId, ConfirmationMessageAutomationId);
+        return GetElementText(message);
+    }
+
+    private static void CancelDeleteConfirmation(Window window, UIA3Automation automation, int processId)
+    {
+        ClickSecondaryDialogButton(window, automation, processId);
+        WaitForElementGone(window, automation, processId, ConfirmationMessageAutomationId);
+    }
+
+    private static void SelectListItemsByName(ListBox list, string[] itemNames)
+    {
+        for (var i = 0; i < itemNames.Length; i++)
+        {
+            var item = WaitForListItemByName(list, itemNames[i]);
+            TryScrollIntoView(item);
+            if (i == 0)
+            {
+                SelectListItem(item);
+            }
+            else
+            {
+                AddToSelection(item);
+            }
+        }
+    }
+
+    private static void AddToSelection(AutomationElement item)
+    {
+        if (!item.Patterns.SelectionItem.IsSupported)
+        {
+            return;
+        }
+
+        try
+        {
+            item.Patterns.SelectionItem.Pattern.AddToSelection();
+            Retry.WhileTrue(
+                () => !item.Patterns.SelectionItem.Pattern.IsSelected,
+                timeout: TimeSpan.FromSeconds(5),
+                interval: TimeSpan.FromMilliseconds(200),
+                throwOnTimeout: false);
+        }
+        catch (ElementNotAvailableException)
+        {
+        }
+        catch (COMException)
+        {
+        }
+    }
+
+    private static string GetElementText(AutomationElement element)
+    {
+        var text = SafeGet(() => element.Name, string.Empty);
+        if (string.IsNullOrWhiteSpace(text) && element.Patterns.Text.IsSupported)
+        {
+            text = SafeGet(() => element.Patterns.Text.Pattern.DocumentRange.GetText(-1), string.Empty);
+        }
+
+        if (string.IsNullOrWhiteSpace(text) && element.Patterns.Value.IsSupported)
+        {
+            text = SafeGet(() => element.Patterns.Value.Pattern.Value.Value, string.Empty);
+        }
+
+        return text?.Trim() ?? string.Empty;
     }
 
     private static void WaitForListItems(ListBox list, int minimumCount)
@@ -301,12 +434,13 @@ public sealed class AppE2ETests
             || ContainsIgnoreCase(SafeGet(() => text.Properties.Name.ValueOrDefault, string.Empty), expectedName));
     }
 
-    private static AutomationElement OpenExifMenuForItemName(
+    private static AutomationElement OpenContextMenuItemForItemName(
         Window window,
         UIA3Automation automation,
         int processId,
         ListBox list,
-        string itemName)
+        string itemName,
+        string menuItemAutomationId)
     {
         for (var attempt = 0; attempt < 6; attempt++)
         {
@@ -323,7 +457,7 @@ public sealed class AppE2ETests
                 ClickElementCenter(listItem);
 
                 Keyboard.Type(VirtualKeyShort.APPS);
-                var byAppsKey = TryWaitForEditExifMenuItem(window, automation, processId, timeout: TimeSpan.FromSeconds(5));
+                var byAppsKey = TryWaitForMenuItemById(window, automation, processId, menuItemAutomationId, TimeSpan.FromSeconds(5));
                 if (byAppsKey is not null)
                 {
                     return byAppsKey;
@@ -332,28 +466,28 @@ public sealed class AppE2ETests
                 // listItem.RightClick() は NoClickablePointException を投げる可能性があるため
                 // 安全な RightClickElementCenter を使用する
                 RightClickElementCenter(listItem);
-                var byRightClick = TryWaitForEditExifMenuItem(window, automation, processId, timeout: TimeSpan.FromSeconds(5));
+                var byRightClick = TryWaitForMenuItemById(window, automation, processId, menuItemAutomationId, TimeSpan.FromSeconds(5));
                 if (byRightClick is not null)
                 {
                     return byRightClick;
                 }
 
                 RightClickElementCenter(listItem);
-                var byMouseRightClick = TryWaitForEditExifMenuItem(window, automation, processId, timeout: TimeSpan.FromSeconds(5));
+                var byMouseRightClick = TryWaitForMenuItemById(window, automation, processId, menuItemAutomationId, TimeSpan.FromSeconds(5));
                 if (byMouseRightClick is not null)
                 {
                     return byMouseRightClick;
                 }
 
                 list.RightClick();
-                var byListRightClick = TryWaitForEditExifMenuItem(window, automation, processId, timeout: TimeSpan.FromSeconds(4));
+                var byListRightClick = TryWaitForMenuItemById(window, automation, processId, menuItemAutomationId, TimeSpan.FromSeconds(4));
                 if (byListRightClick is not null)
                 {
                     return byListRightClick;
                 }
 
                 Keyboard.TypeSimultaneously(VirtualKeyShort.SHIFT, VirtualKeyShort.F10);
-                var byShiftF10 = TryWaitForEditExifMenuItem(window, automation, processId, timeout: TimeSpan.FromSeconds(4));
+                var byShiftF10 = TryWaitForMenuItemById(window, automation, processId, menuItemAutomationId, TimeSpan.FromSeconds(4));
                 if (byShiftF10 is not null)
                 {
                     return byShiftF10;
@@ -367,24 +501,21 @@ public sealed class AppE2ETests
         }
 
         throw new TimeoutException(
-            $"Context menu item not found for '{itemName}'. List snapshot: {BuildListSnapshot(list)}");
+            $"Context menu item '{menuItemAutomationId}' not found for '{itemName}'. List snapshot: {BuildListSnapshot(list)}");
     }
 
-    private static AutomationElement? TryWaitForEditExifMenuItem(
+    private static AutomationElement? TryWaitForMenuItemById(
         Window window,
         UIA3Automation automation,
         int processId,
+        string menuItemAutomationId,
         TimeSpan timeout)
     {
         return Retry.WhileNull(
-            () => FindByAutomationId(window, EditExifMenuAutomationId, processId)
-                ?? FindByAutomationId(automation.GetDesktop(), EditExifMenuAutomationId, processId)
-                ?? FindEditExifMenuItemByName(window, processId)
-                ?? FindEditExifMenuItemByName(automation.GetDesktop(), processId)
-                ?? window.FindFirstDescendant(cf => cf.ByAutomationId(EditExifMenuAutomationId))
-                ?? automation.GetDesktop().FindFirstDescendant(cf => cf.ByAutomationId(EditExifMenuAutomationId))
-                ?? FindEditExifMenuItemByName(window)
-                ?? FindEditExifMenuItemByName(automation.GetDesktop()),
+            () => FindByAutomationId(window, menuItemAutomationId, processId)
+                ?? FindByAutomationId(automation.GetDesktop(), menuItemAutomationId, processId)
+                ?? window.FindFirstDescendant(cf => cf.ByAutomationId(menuItemAutomationId))
+                ?? automation.GetDesktop().FindFirstDescendant(cf => cf.ByAutomationId(menuItemAutomationId)),
             timeout: timeout,
             interval: TimeSpan.FromMilliseconds(150),
             ignoreException: true,
@@ -465,34 +596,6 @@ public sealed class AppE2ETests
         catch (Exception ex) when (ex is COMException or InvalidOperationException or ElementNotAvailableException)
         {
         }
-    }
-
-    private static AutomationElement? FindEditExifMenuItemByName(AutomationElement scope, int? processId = null)
-    {
-        try
-        {
-            var candidates = scope.FindAllDescendants(cf => cf.ByControlType(ControlType.MenuItem));
-            foreach (var candidate in candidates)
-            {
-                if (processId.HasValue
-                    && SafeGet(() => candidate.Properties.ProcessId.ValueOrDefault, -1) != processId.Value)
-                {
-                    continue;
-                }
-
-                var name = SafeGet(() => candidate.Name, string.Empty);
-                var propertyName = SafeGet(() => candidate.Properties.Name.ValueOrDefault, string.Empty);
-                if (ContainsIgnoreCase(name, "EXIF") || ContainsIgnoreCase(propertyName, "EXIF"))
-                {
-                    return candidate;
-                }
-            }
-        }
-        catch (Exception ex) when (ex is COMException or InvalidOperationException or Win32Exception or TimeoutException)
-        {
-        }
-
-        return null;
     }
 
     private static string BuildListSnapshot(ListBox list)

--- a/PhotoGeoExplorer.E2E/AppE2ETests.cs
+++ b/PhotoGeoExplorer.E2E/AppE2ETests.cs
@@ -232,17 +232,20 @@ public sealed class AppE2ETests
 
                 // 1. 単一ファイル: 文面にファイル名を含む（Dialog.DeleteConfirm.File）
                 var fileMessage = OpenDeleteConfirmationForSelection(window, automation, app.ProcessId, list, SingleFileSelection);
+                _output.WriteLine($"[delete-confirm] single-file message='{fileMessage}'");
                 Assert.Contains("sample.jpg", fileMessage, StringComparison.Ordinal);
                 CancelDeleteConfirmation(window, automation, app.ProcessId);
 
                 // 2. 単一フォルダ: 文面にフォルダ名を含み、ファイル名は含まない（Dialog.DeleteConfirm.Folder）
                 var folderMessage = OpenDeleteConfirmationForSelection(window, automation, app.ProcessId, list, SingleFolderSelection);
+                _output.WriteLine($"[delete-confirm] single-folder message='{folderMessage}'");
                 Assert.Contains("folder", folderMessage, StringComparison.Ordinal);
                 Assert.DoesNotContain("sample.jpg", folderMessage, StringComparison.Ordinal);
                 CancelDeleteConfirmation(window, automation, app.ProcessId);
 
                 // 3. 複数選択: 文面に件数を含み、個別ファイル名は含まない（Dialog.DeleteConfirm.Multiple）
                 var multipleMessage = OpenDeleteConfirmationForSelection(window, automation, app.ProcessId, list, MultipleSelection);
+                _output.WriteLine($"[delete-confirm] multiple message='{multipleMessage}'");
                 Assert.Contains("2", multipleMessage, StringComparison.Ordinal);
                 Assert.DoesNotContain("sample.jpg", multipleMessage, StringComparison.Ordinal);
                 CancelDeleteConfirmation(window, automation, app.ProcessId);
@@ -272,11 +275,41 @@ public sealed class AppE2ETests
     {
         SelectListItemsByName(list, itemNames);
 
-        list.Focus();
-        Keyboard.Type(VirtualKeyShort.DELETE);
+        // ダイアログ連続開閉の直後はリストのフォーカスが不安定で Delete が届かないことがあるため、
+        // 確認ダイアログが現れるまで list へのフォーカスと Delete 送出をリトライする。
+        AutomationElement? message = null;
+        Retry.WhileNull(
+            () =>
+            {
+                list.Focus();
+                Keyboard.Type(VirtualKeyShort.DELETE);
+                message = TryWaitForElementByAutomationId(
+                    window, automation, processId, ConfirmationMessageAutomationId, TimeSpan.FromSeconds(3));
+                return message;
+            },
+            timeout: TimeSpan.FromSeconds(20),
+            interval: TimeSpan.FromMilliseconds(200),
+            ignoreException: true,
+            throwOnTimeout: false);
 
-        var message = WaitForElementByAutomationId(window, automation, processId, ConfirmationMessageAutomationId);
-        return GetElementText(message);
+        if (message is null)
+        {
+            throw new TimeoutException(
+                $"Delete confirmation dialog did not appear for [{string.Join(",", itemNames)}].");
+        }
+
+        // 要素出現直後は TextBlock のテキストが未反映のことがあるため、文面が非空になるまで待つ。
+        var text = string.Empty;
+        Retry.WhileTrue(
+            () =>
+            {
+                text = GetElementText(message);
+                return string.IsNullOrWhiteSpace(text);
+            },
+            timeout: TimeSpan.FromSeconds(5),
+            interval: TimeSpan.FromMilliseconds(150),
+            throwOnTimeout: false);
+        return text;
     }
 
     private static void CancelDeleteConfirmation(Window window, UIA3Automation automation, int processId)

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDialogs.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDialogs.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
 using PhotoGeoExplorer.Services;
 using Windows.Storage;
@@ -142,14 +143,18 @@ internal sealed class FileBrowserDialogs
             return false;
         }
 
+        var messageBlock = new TextBlock
+        {
+            Text = message,
+            TextWrapping = TextWrapping.Wrap
+        };
+        // E2E が確認ダイアログの文面（削除確認の単数/複数・ファイル/フォルダ分岐など）を検証できるよう ID を付与する
+        AutomationProperties.SetAutomationId(messageBlock, "FileBrowser.ConfirmationMessage");
+
         var dialog = new ContentDialog
         {
             Title = title,
-            Content = new TextBlock
-            {
-                Text = message,
-                TextWrapping = TextWrapping.Wrap
-            },
+            Content = messageBlock,
             PrimaryButtonText = primaryButtonText,
             SecondaryButtonText = LocalizationService.GetString("Common.Cancel"),
             DefaultButton = ContentDialogButton.Secondary,


### PR DESCRIPTION
## 概要

親 Issue #150 Phase 5 の #181（FileBrowser 操作系 E2E シナリオ追加）を 3 分割した PR1（基盤＋削除確認）。E2E の flaky リスクを抑えるため段階導入する。

Refs #181（後続 PR で右クリック選択復元 / clipboard / 移動競合＋fixture 拡張を追加。#181 のクローズは全シナリオ実装後の最終 PR で行う）

注: 本 PR は #181 を自動クローズしない（closing keyword は付与しない）。

## 変更内容

### E2E（PhotoGeoExplorer.E2E/AppE2ETests.cs）
- 削除確認シナリオを file / folder / multiple の独立 [E2EFact] 3 本に分割（RunDeleteConfirmationScenarioAsync に共通化）。各テストはアプリ起動→選択→Delete→ダイアログ 1 回のみで、連続開閉に起因する flaky を排除。
- 各選択で削除確認ダイアログが実機表示されキャンセルできること（非破壊）を検証。文面の分岐内容の正確性は単体テスト（BuildDeleteConfirmationMessage）が担保するため、E2E は文面が非空であることをロケール／リソース解決非依存に確認。
- ヘルパー汎用化: OpenExifMenuForItemName を automation ID 引数を取る OpenContextMenuItemForItemName へ一般化。

### production（PhotoGeoExplorer/Panes/FileBrowser/FileBrowserDialogs.cs）
- 確認ダイアログのメッセージ TextBlock に FileBrowser.ConfirmationMessage automation ID を付与（ShowConfirmationAsync）。UI 挙動は不変のテスト用フック。

## 検証
- dotnet build (Release/x64, TreatWarningsAsErrors) 成功
- ローカル: 削除確認 3 テスト × 2 ラウンド = 6/6 pass
- CI: 全 8 チェック pass（e2e 7m39s）