### PR TITLE
fix(vm): リネーム・フォルダ作成後の COMException (RPC_E_WRONG_THREAD) を修正 (#188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+### バグ修正
+- リネーム・フォルダ作成・外部ファイルドロップ後に `COMException (0x8001010E: RPC_E_WRONG_THREAD)` でクラッシュする問題を修正 (#188)
+  - `ExecuteRenameAsync` / `ExecuteCreateFolderAsync` / `HandleExternalFileDropAsync` で `await RefreshAsync().ConfigureAwait(false)` 後に UIスレッド外から `SelectedItem` セッター（WinRT PropertyChanged 通知）を呼んでいたため
+  - `SelectItemByPath` の呼び出しを `_uiDispatcher.RunAsync` でラップし、`SelectedItem` への代入を UIスレッド上で実行するよう修正
+
 ### テスト
 - E2E に削除確認ダイアログ文面の分岐検証シナリオを追加し、コンテキストメニューヘルパーを ID 指定の汎用版へ一般化 (#181)
   - `DeleteConfirmationDialogShowsForSingleFile` / `...ForSingleFolder` / `...ForMultipleSelection`: 各選択パターンで削除確認ダイアログが実機表示されキャンセルできること（非破壊）を検証。トリガーは選択を変えない `Delete` キー。文面の分岐内容（File / Folder / Multiple）の正確性は単体テスト（`BuildDeleteConfirmationMessage`）が担保するため、E2E は文面が非空（＝ダイアログ表示）であることをロケール／リソース解決非依存に確認（未パッケージ起動・en ランナーでは未解決のリソースキーが返るため、解決済み文面に依存しない）

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserPaneViewModel.cs
@@ -505,7 +505,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
             await RefreshAsync().ConfigureAwait(false);
             if (result.ResultPath is not null)
             {
-                SelectItemByPath(result.ResultPath);
+                await _uiDispatcher.RunAsync(() => SelectItemByPath(result.ResultPath)).ConfigureAwait(false);
             }
         }
 
@@ -520,7 +520,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         if (result.IsSuccess && result.ResultPath is not null)
         {
             await RefreshAsync().ConfigureAwait(false);
-            SelectItemByPath(result.ResultPath);
+            await _uiDispatcher.RunAsync(() => SelectItemByPath(result.ResultPath)).ConfigureAwait(false);
         }
 
         return result;
@@ -696,7 +696,7 @@ internal sealed class FileBrowserPaneViewModel : PaneViewModelBase, IDisposable
         }
 
         await LoadFolderAsync(directory).ConfigureAwait(false);
-        SelectItemByPath(filePath);
+        await _uiDispatcher.RunAsync(() => SelectItemByPath(filePath)).ConfigureAwait(false);
     }
 
     public async Task LoadFolderAsync(string folderPath, bool updateHistory = true)


### PR DESCRIPTION
## 概要

ISSUE#188 で報告された `COMException (0x8001010E: RPC_E_WRONG_THREAD)` クラッシュを修正する。

## 原因

`ExecuteRenameAsync` 等で `await RefreshAsync().ConfigureAwait(false)` の後、UIスレッドに戻らないまま `SelectItemByPath` → `SelectedItem = match` を呼んでいた。`SelectedItem` セッターは `INotifyPropertyChanged` の PropertyChanged イベントを WinRT バインディングシステムへ通知するため UIスレッドを要求するが、`ConfigureAwait(false)` で手放した後のバックグラウンドスレッドから呼ぶと `RPC_E_WRONG_THREAD` で例外が発生する。

## 修正内容

`SelectItemByPath` の呼び出し箇所3ヶ所を `_uiDispatcher.RunAsync` でラップし、UIスレッド上で実行するよう変更：

- `ExecuteRenameAsync`（ISSUE#188 のスタックトレースで確認）
- `ExecuteCreateFolderAsync`（同一パターン）
- `HandleExternalFileDropAsync`（同一パターン）

`IUiDispatcher.RunAsync` はテスト環境（DispatcherQueue 未取得）では同期実行にフォールバックするため、既存テストへの影響なし。

## 検証

```
dotnet build PhotoGeoExplorer.sln -c Release -p:Platform=x64
→ 0 警告、0 エラー

dotnet test PhotoGeoExplorer.sln -c Release -p:Platform=x64
→ 合格: 629、失敗: 0
```

Closes #188