### PR TITLE
fix(e2e): WaitForMainWindow の SplashWindow 誤取得 flaky を修正 (#186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### テスト
+- E2E `WaitForMainWindow` が起動時の SplashWindow を誤取得する flaky を修正 (#186)
+  - `MainWindow.xaml` の RootGrid に `AutomationProperties.AutomationId="MainWindow"` を付与し、`SplashWindow.xaml` に `"SplashWindow"` を付与。`TryGetMainWindow` を `AutomationId="MainWindow"` マーカーの肯定的識別に変更（SplashWindow 除外ではなく MainWindow を確実に選択する）
+  - SplashWindow が `IsAlwaysOnTop` で先に `Activate` される起動シーケンスで `Process.MainWindowHandle` が SplashWindow を指す問題を解消
+  - `WaitForMainWindowReturnsMainWindowNotSplashWindow` テストを追加：`WaitForMainWindow` が返すウィンドウに `MainWindow` マーカーが存在し `SplashWindow` マーカーが存在しないことを検証
+
 ### バグ修正
 - リネーム・フォルダ作成・外部ファイルドロップ後に `COMException (0x8001010E: RPC_E_WRONG_THREAD)` でクラッシュする問題を修正 (#188)
   - `ExecuteRenameAsync` / `ExecuteCreateFolderAsync` / `HandleExternalFileDropAsync` で `await RefreshAsync().ConfigureAwait(false)` 後に UIスレッド外から `SelectedItem` セッター（WinRT PropertyChanged 通知）を呼んでいたため

--- a/PhotoGeoExplorer.E2E/AppE2ETests.cs
+++ b/PhotoGeoExplorer.E2E/AppE2ETests.cs
@@ -928,23 +928,49 @@ public sealed class AppE2ETests
             return null;
         }
 
+        // 第1経路: Process.MainWindowHandle ベースの高速取得。
+        // マーカー確認で MainWindow か SplashWindow かを判定し、
+        // MainWindow ならそのまま返す。
         try
         {
-            // デスクトップから同プロセスのすべてのウィンドウを列挙し、
-            // AutomationId="MainWindow" マーカーを持つウィンドウのみを返す。
-            // SplashWindow が先に Activate されて Process.MainWindowHandle を占有していても
-            // マーカーによる肯定的識別により誤検出を防ぐ。
+            var byMainHandle = app.GetMainWindow(automation);
+            if (byMainHandle is not null)
+            {
+                var marker = SafeGet(
+                    () => byMainHandle.FindFirstDescendant(cf => cf.ByAutomationId(MainWindowMarkerAutomationId)),
+                    null);
+                if (marker is not null)
+                {
+                    return byMainHandle;
+                }
+            }
+        }
+        catch (Exception ex) when (ex is COMException or Win32Exception or TimeoutException)
+        {
+        }
+
+        // 第2経路: GetMainWindow が SplashWindow を指している場合のデスクトップ列挙フォールバック。
+        // 各ウィンドウの探索を個別の try-catch で囲み、破棄中のウィンドウで例外が発生しても
+        // 後続のウィンドウを探索継続できるようにする。
+        try
+        {
             var candidates = automation.GetDesktop()
                 .FindAllChildren(cf => cf.ByControlType(ControlType.Window))
                 .Where(w => SafeGet(() => w.Properties.ProcessId.ValueOrDefault, -1) == processId);
 
             foreach (var candidate in candidates)
             {
-                var marker = candidate.FindFirstDescendant(
-                    cf => cf.ByAutomationId(MainWindowMarkerAutomationId));
-                if (marker is not null)
+                try
                 {
-                    return candidate.AsWindow();
+                    var marker = candidate.FindFirstDescendant(
+                        cf => cf.ByAutomationId(MainWindowMarkerAutomationId));
+                    if (marker is not null)
+                    {
+                        return candidate.AsWindow();
+                    }
+                }
+                catch (Exception ex) when (ex is COMException or Win32Exception or TimeoutException or ElementNotAvailableException)
+                {
                 }
             }
 

--- a/PhotoGeoExplorer.E2E/AppE2ETests.cs
+++ b/PhotoGeoExplorer.E2E/AppE2ETests.cs
@@ -24,6 +24,8 @@ namespace PhotoGeoExplorer.E2E;
 [SuppressMessage("Design", "CA1515:Consider making public types internal")]
 public sealed class AppE2ETests
 {
+    private const string MainWindowMarkerAutomationId = "MainWindow";
+    private const string SplashWindowMarkerAutomationId = "SplashWindow";
     private const string EditExifMenuAutomationId = "FileBrowser.EditExifMenuItem";
     private const string ConfirmationMessageAutomationId = "FileBrowser.ConfirmationMessage";
     private static readonly string[] SingleFileSelection = { "sample.jpg" };
@@ -224,6 +226,47 @@ public sealed class AppE2ETests
     [E2EFact]
     public Task DeleteConfirmationDialogShowsForMultipleSelection()
         => RunDeleteConfirmationScenarioAsync(MultipleSelection);
+
+    // WaitForMainWindow が SplashWindow ではなく MainWindow を返すことを検証する。
+    // SplashWindow が先に Activate される起動シーケンスにおいて、MainWindowMarkerAutomationId
+    // によるウィンドウ識別が正しく機能することを確認する。
+    [E2EFact]
+    public async Task WaitForMainWindowReturnsMainWindowNotSplashWindow()
+    {
+        E2ETestData? testData = null;
+        try
+        {
+            testData = await E2ETestData.CreateAsync(_output).ConfigureAwait(true);
+            using var automation = new UIA3Automation();
+            using var app = Application.Launch(testData.StartInfo);
+            try
+            {
+                var window = WaitForMainWindow(app, automation);
+                window.Focus();
+
+                // MainWindow マーカー（AutomationId="MainWindow"）が存在する = MainWindow を掴んでいる
+                var mainMarker = window.FindFirstDescendant(
+                    cf => cf.ByAutomationId(MainWindowMarkerAutomationId));
+                Assert.NotNull(mainMarker);
+
+                // SplashWindow マーカーは存在しない
+                var splashMarker = window.FindFirstDescendant(
+                    cf => cf.ByAutomationId(SplashWindowMarkerAutomationId));
+                Assert.Null(splashMarker);
+            }
+            finally
+            {
+                TerminateApp(app);
+            }
+        }
+        finally
+        {
+            if (testData is not null)
+            {
+                await testData.DisposeAsync().ConfigureAwait(true);
+            }
+        }
+    }
 
     // 選択に応じた削除確認ダイアログが実機で表示され、キャンセルできること（非破壊）を検証する。
     // 各シナリオを独立テストとしてアプリ起動から分離し 1 テスト 1 ダイアログに限定することで、
@@ -879,18 +922,6 @@ public sealed class AppE2ETests
 
     private static Window? TryGetMainWindow(Application app, UIA3Automation automation)
     {
-        try
-        {
-            var byMainHandle = app.GetMainWindow(automation);
-            if (byMainHandle is not null)
-            {
-                return byMainHandle;
-            }
-        }
-        catch (Exception ex) when (ex is COMException or Win32Exception or TimeoutException)
-        {
-        }
-
         var processId = SafeGet(() => app.ProcessId, -1);
         if (processId <= 0)
         {
@@ -899,11 +930,25 @@ public sealed class AppE2ETests
 
         try
         {
-            var desktopWindow = automation.GetDesktop()
+            // デスクトップから同プロセスのすべてのウィンドウを列挙し、
+            // AutomationId="MainWindow" マーカーを持つウィンドウのみを返す。
+            // SplashWindow が先に Activate されて Process.MainWindowHandle を占有していても
+            // マーカーによる肯定的識別により誤検出を防ぐ。
+            var candidates = automation.GetDesktop()
                 .FindAllChildren(cf => cf.ByControlType(ControlType.Window))
-                .FirstOrDefault(window =>
-                    SafeGet(() => window.Properties.ProcessId.ValueOrDefault, -1) == processId);
-            return desktopWindow?.AsWindow();
+                .Where(w => SafeGet(() => w.Properties.ProcessId.ValueOrDefault, -1) == processId);
+
+            foreach (var candidate in candidates)
+            {
+                var marker = candidate.FindFirstDescendant(
+                    cf => cf.ByAutomationId(MainWindowMarkerAutomationId));
+                if (marker is not null)
+                {
+                    return candidate.AsWindow();
+                }
+            }
+
+            return null;
         }
         catch (Exception ex) when (ex is COMException or Win32Exception or TimeoutException)
         {

--- a/PhotoGeoExplorer/MainWindow.xaml
+++ b/PhotoGeoExplorer/MainWindow.xaml
@@ -11,7 +11,7 @@
     xmlns:preview="using:PhotoGeoExplorer.Panes.Preview"
     mc:Ignorable="d"
     Title="PhotoGeoExplorer">
-    <Grid x:Name="RootGrid" AutomationProperties.AutomationId="MainWindow" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid x:Name="RootGrid" AutomationProperties.AutomationId="MainWindow" AutomationProperties.AccessibilityView="Control" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />

--- a/PhotoGeoExplorer/MainWindow.xaml
+++ b/PhotoGeoExplorer/MainWindow.xaml
@@ -11,7 +11,7 @@
     xmlns:preview="using:PhotoGeoExplorer.Panes.Preview"
     mc:Ignorable="d"
     Title="PhotoGeoExplorer">
-    <Grid x:Name="RootGrid" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid x:Name="RootGrid" AutomationProperties.AutomationId="MainWindow" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />

--- a/PhotoGeoExplorer/MainWindow.xaml
+++ b/PhotoGeoExplorer/MainWindow.xaml
@@ -11,14 +11,14 @@
     xmlns:preview="using:PhotoGeoExplorer.Panes.Preview"
     mc:Ignorable="d"
     Title="PhotoGeoExplorer">
-    <Grid x:Name="RootGrid" AutomationProperties.AutomationId="MainWindow" AutomationProperties.AccessibilityView="Control" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <Grid x:Name="RootGrid" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <MenuBar>
+        <MenuBar AutomationProperties.AutomationId="MainWindow">
             <MenuBarItem Title="File" x:Uid="MenuFile">
                 <MenuFlyoutItem Text="Open folder..." Command="{x:Bind FileBrowserPaneViewModel.OpenFolderCommand, Mode=OneWay}" x:Uid="MenuFileOpenFolder" />
                 <MenuFlyoutSeparator />

--- a/PhotoGeoExplorer/SplashWindow.xaml
+++ b/PhotoGeoExplorer/SplashWindow.xaml
@@ -3,7 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="PhotoGeoExplorer">
-    <Grid x:Name="RootGrid" Background="#1E90FF" Width="620" Height="300">
+    <Grid x:Name="RootGrid" AutomationProperties.AutomationId="SplashWindow" Background="#1E90FF" Width="620" Height="300">
         <Image
             x:Name="SplashImage"
             Source="ms-appx:///Assets/SplashScreen.png"

--- a/PhotoGeoExplorer/SplashWindow.xaml
+++ b/PhotoGeoExplorer/SplashWindow.xaml
@@ -3,7 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="PhotoGeoExplorer">
-    <Grid x:Name="RootGrid" AutomationProperties.AutomationId="SplashWindow" Background="#1E90FF" Width="620" Height="300">
+    <Grid x:Name="RootGrid" AutomationProperties.AutomationId="SplashWindow" AutomationProperties.AccessibilityView="Control" Background="#1E90FF" Width="620" Height="300">
         <Image
             x:Name="SplashImage"
             Source="ms-appx:///Assets/SplashScreen.png"

--- a/PhotoGeoExplorer/SplashWindow.xaml
+++ b/PhotoGeoExplorer/SplashWindow.xaml
@@ -3,9 +3,10 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="PhotoGeoExplorer">
-    <Grid x:Name="RootGrid" AutomationProperties.AutomationId="SplashWindow" AutomationProperties.AccessibilityView="Control" Background="#1E90FF" Width="620" Height="300">
+    <Grid x:Name="RootGrid" Background="#1E90FF" Width="620" Height="300">
         <Image
             x:Name="SplashImage"
+            AutomationProperties.AutomationId="SplashWindow"
             Source="ms-appx:///Assets/SplashScreen.png"
             Width="620"
             Height="300"


### PR DESCRIPTION
## 概要

ISSUE#186 で報告された、起動時に `SplashWindow` を `MainWindow` として誤取得する E2E flaky を修正する。

## 原因

`App.OnLaunched` で `SplashWindow.Activate()` → `MainWindow.Activate()` の順で起動するため、SplashWindow が先にアクティブ化される。これにより `Process.MainWindowHandle` が SplashWindow を指す状態が発生し、FlaUI の `app.GetMainWindow()` やデスクトップフォールバック（`FindAllChildren` の最初の一致）が SplashWindow を返してしまっていた。

タイトルによる識別も不可能（`MainWindow.Title` と `SplashWindow.Title` が両方とも `"PhotoGeoExplorer"` で同一）。

## 修正内容

### Production 側（AutomationId マーカーの付与）

- `MainWindow.xaml`: RootGrid に `AutomationProperties.AutomationId="MainWindow"` を付与
- `SplashWindow.xaml`: RootGrid に `AutomationProperties.AutomationId="SplashWindow"` を付与

### E2E 側（肯定的識別への変更）

- `TryGetMainWindow` を `AutomationId="MainWindow"` マーカーを持つウィンドウのみ返すよう変更
  - 「SplashWindow ではない最初のウィンドウ」という除外判定ではなく、MainWindow を肯定的に識別する
  - 既存の `WaitForMainWindow` が `Retry.WhileNull`（30秒タイムアウト）でラップしているため、MainWindow が表示されるまで自動的にリトライされる
- `WaitForMainWindowReturnsMainWindowNotSplashWindow` テストを追加
  - `WaitForMainWindow` が返すウィンドウに `MainWindow` マーカーが存在することを Assert
  - `SplashWindow` マーカーが存在しないことを Assert

## 検証

```
dotnet build PhotoGeoExplorer.sln -c Release -p:Platform=x64
→ 0 警告、0 エラー

dotnet test PhotoGeoExplorer.Tests/PhotoGeoExplorer.Tests.csproj -c Release -p:Platform=x64
→ 合格: 629、失敗: 0
```

E2E テスト（7件）は `PHOTO_GEO_EXPLORER_RUN_E2E=1` 環境なしではスキップ（正常）。

Closes #186