### PR TITLE
ci(e2e): matrix分割とNuGetキャッシュでE2E総実行時間を短縮 (#182)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,11 +31,13 @@ jobs:
 
       # packages.lock.json を導入せずに NuGet パッケージキャッシュのみ短縮する。
       # setup-dotnet 標準の cache 入力はロックファイル前提のため、csproj/global.json の
-      # ハッシュをキーにした actions/cache を直接使う。
-      - name: Cache NuGet packages
-        uses: actions/cache@v4
+      # ハッシュをキーにした actions/cache を直接使う。パスは Windows でも `~/...`
+      # （フォワードスラッシュ）が公式に推奨される表記（`~\...` は tilde 展開の実装依存を招く）。
+      - name: Restore NuGet cache
+        id: nuget-cache
+        uses: actions/cache/restore@v6
         with:
-          path: ~\.nuget\packages
+          path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'global.json') }}
           restore-keys: |
             nuget-${{ runner.os }}-
@@ -45,6 +47,15 @@ jobs:
 
       - name: Build
         run: dotnet build PhotoGeoExplorer.sln -c Release -p:Platform=x64 -p:TreatWarningsAsErrors=true -p:AnalysisLevel=latest
+
+      # matrix の両 suite が同一キーへ保存を試みると片方が無駄な圧縮/アップロードを行うため、
+      # 保存は suite 1 のみに限定する（cache-hit 時は内容が変わらないため保存自体スキップ）。
+      - name: Save NuGet cache
+        if: matrix.suite == 1 && steps.nuget-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ~/.nuget/packages
+          key: ${{ steps.nuget-cache.outputs.cache-primary-key }}
 
       - name: Ensure Windows App SDK runtime
         shell: pwsh
@@ -153,14 +164,19 @@ jobs:
           $maxAttempts = 2
           $passed = $false
 
+          # Suite=1 は正フィルタ、Suite=2 は否定フィルタ（Suite!=1）にすることで、
+          # Trait("Suite", ...) の付け忘れがあった新規 [E2EFact] も必ず suite 2 側で
+          # 実行される（両方から漏れて CI が静かに何もテストしないことを構造的に防ぐ）。
+          $filter = if ("${{ matrix.suite }}" -eq "1") { "Suite=1" } else { "Suite!=1" }
+
           for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
             $resultFile = "e2e-results-suite${{ matrix.suite }}-attempt$attempt.trx"
-            Write-Host "Running E2E tests suite ${{ matrix.suite }} (attempt $attempt/$maxAttempts)..."
+            Write-Host "Running E2E tests suite ${{ matrix.suite }} (attempt $attempt/$maxAttempts, filter: $filter)..."
             $testArgs = @(
               "PhotoGeoExplorer.E2E/PhotoGeoExplorer.E2E.csproj",
               "-c", "Release",
               "--no-build",
-              "--filter", "Suite=${{ matrix.suite }}",
+              "--filter", $filter,
               "--logger", "trx;LogFileName=$resultFile",
               "--results-directory", "TestResults",
               "--blame-hang-timeout", "10m"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,11 @@ permissions:
 jobs:
   e2e:
     runs-on: windows-latest
+    name: e2e (suite ${{ matrix.suite }})
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [1, 2]
     env:
       SIXLABORS_LICENSE_KEY: ${{ secrets.SIXLABORS_LICENSE_KEY }}
 
@@ -23,6 +28,17 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
+
+      # packages.lock.json を導入せずに NuGet パッケージキャッシュのみ短縮する。
+      # setup-dotnet 標準の cache 入力はロックファイル前提のため、csproj/global.json の
+      # ハッシュをキーにした actions/cache を直接使う。
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~\.nuget\packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'global.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
 
       - name: Restore
         run: dotnet restore PhotoGeoExplorer.sln
@@ -138,12 +154,13 @@ jobs:
           $passed = $false
 
           for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
-            $resultFile = "e2e-results-attempt$attempt.trx"
-            Write-Host "Running E2E tests (attempt $attempt/$maxAttempts)..."
+            $resultFile = "e2e-results-suite${{ matrix.suite }}-attempt$attempt.trx"
+            Write-Host "Running E2E tests suite ${{ matrix.suite }} (attempt $attempt/$maxAttempts)..."
             $testArgs = @(
               "PhotoGeoExplorer.E2E/PhotoGeoExplorer.E2E.csproj",
               "-c", "Release",
               "--no-build",
+              "--filter", "Suite=${{ matrix.suite }}",
               "--logger", "trx;LogFileName=$resultFile",
               "--results-directory", "TestResults",
               "--blame-hang-timeout", "10m"
@@ -218,7 +235,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: e2e-artifacts-${{ github.run_id }}-${{ github.run_attempt }}
+          name: e2e-artifacts-${{ github.run_id }}-${{ github.run_attempt }}-suite${{ matrix.suite }}
           path: E2EArtifacts/
           if-no-files-found: warn
           retention-days: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@
   - `actions/cache/restore` + 条件付き `actions/cache/save`（v6、Node.js 24 対応）で NuGet パッケージキャッシュ（`~/.nuget/packages`、キーは csproj/global.json のハッシュ）を追加し restore を短縮。保存は suite 1 のみに限定し matrix 両ジョブの重複 save による無駄を排除（Copilot/thread-owl レビュー指摘対応）。`packages.lock.json` は導入せず（依存解決方式・Renovate 運用への影響を避けるため）
   - **根本原因の特定（thread-owl レビューで発覚）**: 分割前 4 run は毎回 `DeleteConfirmationDialogShowsForMultipleSelection` が attempt 1 で失敗していたが、これは「同じテストが壊れている」のではなく「そのプロセスで最初に実行されるテストである」ことが原因と判明（失敗前に完了したテストが 0 件であることをログで確認）。分割後は suite 2 の最初のテスト `ClipboardCopyPasteCopiesFileIntoSubfolder` も同様に attempt 1 で失敗するようになった（2 run とも再現）。つまり実態は「プロセス内で最初に実行される `[E2EFact]` は JIT ウォームアップ・AV スキャン・WinUI3 初回描画等のコールドスタートコストにより UIA タイムアウトしやすい」という既存の系統的 flaky であり、matrix 分割によって「最初の1本」の枠が単一プロセス1つから suite 数分（2つ）に増えたことで、flaky の発生機会が比例して増加していた
   - **対応**: `AppE2ETests` に `IClassFixture<WarmupFixture>` を導入し、各 matrix job（テストプロセス）で実テスト開始前に 1 回だけアプリを起動→終了するウォームアップを追加。これにより OS/AV/JIT/コンポジタのコールドスタートコストを実テスト計測から除外し、「最初の1本」問題を suite 分割の有無によらず解消する。ウォームアップ自体の失敗は best-effort（実テストの成否に影響させない）
-  - **flaky 率への影響**: 各 matrix job は独立した runner（VM）で実行されるため、issue #182 で明示的に非推奨とされた「同一マシン内 xUnit 並列によるフォーカス競合」は発生しない。ウォームアップ導入により「最初の1本」のコールドスタート flaky は理論上解消されるが、ウォームアップ導入後の CI 実測での再検証が必要（PR レビュー継続中に追記）
-  - wall clock は attempt を含む実測で比較する必要がある: 分割前（単一 job・retry込み）の job 全体は 8m51s（run `28786046897`）。分割後（2 job 並列・両 suite とも retry込み）は wall clock = max(suite1 job, suite2 job) = 6m35s（run `28788908674`）。retry を含めても約 25% の短縮を確認（ウォームアップ追加後の再計測は別途反映）
+  - **flaky 率への影響（ウォームアップ導入後に実測で確認）**: 各 matrix job は独立した runner（VM）で実行されるため、issue #182 で明示的に非推奨とされた「同一マシン内 xUnit 並列によるフォーカス競合」は発生しない。ウォームアップ導入後の CI 実行（run `28791361642`）では、suite 1（7本）・suite 2（6本）とも **attempt 1 で 0 失敗・retry 不要**を確認した。これは分割前後を通じて検証した全 run の中で唯一 retry なしで green に到達したケースであり、「最初の1本」のコールドスタート flaky が解消されたことを直接裏付ける
+  - wall clock はウォームアップ導入・retry 不要となった実測値で比較する: 分割前（単一 job・retry込み）の job 全体は 8m51s（run `28786046897`）。分割後＋ウォームアップ導入後（2 job 並列・retry なし）は wall clock = max(suite1, suite2) の `Run E2E tests` ステップで 1m37s / 1m1s、ジョブ全体は概ね 5〜6 分程度（固定コスト込み）。retry 常態化が解消されたことで、当初想定していた「テスト数按分」に近い安定した短縮効果が得られている
   - リトライ回数上限・`blame-hang-timeout` は変更なし
 
 ### テスト

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## [Unreleased]
 
+### CI
+- E2E ワークフローの総実行時間を短縮 (#182)
+  - 実測（直近 3 実行の GitHub Actions ステップタイミング）に基づき対応: 固定コスト（checkout/restore/build/ランタイム確認）が約 2.5〜3 分、テスト実行時間がテスト数に比例（1本あたり平均 27〜33 秒）して増加していることを確認。#181 で 3→13 本に増えテスト実行時間が支配的コストになったため、runner 分割が最も効果的と判断
+  - `AppE2ETests` の全 13 テストに `[Trait("Suite", "1"|"2")]` を付与し、実行時間が概ね均等になるよう 7本/6本に分割（ローカル実測: Suite1 1m28s / Suite2 1m36s）
+  - `e2e.yml` を `matrix: suite: [1, 2]`（`fail-fast: false`）でジョブ分割し、`dotnet test --filter "Suite=${{ matrix.suite }}"` で対応する Suite のみ実行。TRX ファイル名・アーティファクト名に suite を含め衝突を回避
+  - `actions/cache@v4` で NuGet パッケージキャッシュ（`~\.nuget\packages`、キーは csproj/global.json のハッシュ）を追加し restore を短縮。`packages.lock.json` は導入せず（依存解決方式・Renovate 運用への影響を避けるため）
+  - 各 matrix job は独立した runner（VM）で実行されるため、GUI/UIA の同一プロセス内並列で懸念されるフォーカス競合による flaky 増加は発生しない（issue #182 で非推奨とされたのは同一マシン内 xUnit 並列であり、本対応はそれとは異なる）
+  - リトライ回数・`blame-hang-timeout` は変更なし（flaky データが不足しているため据え置き。直近 3 実行はいずれもリトライなしで成功）
+
 ### テスト
 - E2E に FileBrowser 操作系の残りシナリオ（右クリック複数選択復元 / クリップボード / 移動・コピー競合キャンセル）と操作系 fixture を追加し、#181 の受け入れ条件を完了 (#181)
   - `RightClickOnSelectionPreservesMultipleSelection`: 複数選択中に選択項目を右クリックしてコンテキストメニューを開いても複数選択が維持されること（VM `ResolveRightTapSelection` による復元）を検証。復元は RightTapped ハンドラのロジックのため APPS キーではなくマウス右クリックで駆動し、ESC で非破壊に終了

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@
 
 ### CI
 - E2E ワークフローの総実行時間を短縮 (#182)
-  - 実測（直近 3 実行の GitHub Actions ステップタイミング）に基づき対応: 固定コスト（checkout/restore/build/ランタイム確認）が約 2.5〜3 分、テスト実行時間がテスト数に比例（1本あたり平均 27〜33 秒）して増加していることを確認。#181 で 3→13 本に増えテスト実行時間が支配的コストになったため、runner 分割が最も効果的と判断
-  - `AppE2ETests` の全 13 テストに `[Trait("Suite", "1"|"2")]` を付与し、実行時間が概ね均等になるよう 7本/6本に分割（ローカル実測: Suite1 1m28s / Suite2 1m36s）
+  - **実測（attempt 単位、GitHub Actions ログの実際の attempt 別 Passed/Failed 行に基づく再集計）**: 分割前後を問わず直近の main/PR 実行はいずれも 1 回目の試行で 1 本だけ flaky 失敗し 2 回目で成功する既存パターンが確認された（例: 分割前 main run `28786690007`＝13本中1本失敗→retry成功、`28333186948`／`28058515771`＝7本中1本失敗→retry成功）。これは本 PR が原因ではなく E2E スイートに元々存在する未解決の flaky（#180 が前提とする flaky 切り分けが必要な事象）であり、単一 attempt の実行時間を単純にテスト数へ按分した当初の分析は誤りだったため、以下は attempt 単位の実測に基づき訂正する
+  - 固定コスト（checkout/restore/build/ランタイム確認）は約 2.5〜3 分でほぼ一定。#181 で 3→13 本に増えテスト実行時間（1 attempt のクリーン実行で 13 本 ≈ 2m40s〜3m0s）が支配的コストになったため、runner 分割が最も効果的と判断
+  - `AppE2ETests` の全 13 テストに `[Trait("Suite", "1"|"2")]` を付与し、実行時間が概ね均等になるよう 7本/6本に分割（クリーン attempt 実測: suite1 ≈ 1m39s / suite2 ≈ 1m00s）
   - `e2e.yml` を `matrix: suite: [1, 2]`（`fail-fast: false`）でジョブ分割。suite 1 は正フィルタ（`Suite=1`）、suite 2 は否定フィルタ（`Suite!=1`）で実行し、`[Trait("Suite", ...)]` の付け忘れがあった新規テストも自動的に suite 2 側で実行されるようにして「両 suite から漏れて CI が静かに未実行になる」リスクを構造的に排除（thread-owl レビュー指摘対応）。TRX ファイル名・アーティファクト名に suite を含め衝突を回避
   - `actions/cache/restore` + 条件付き `actions/cache/save`（v6、Node.js 24 対応）で NuGet パッケージキャッシュ（`~/.nuget/packages`、キーは csproj/global.json のハッシュ）を追加し restore を短縮。保存は suite 1 のみに限定し matrix 両ジョブの重複 save による無駄を排除（Copilot/thread-owl レビュー指摘対応）。`packages.lock.json` は導入せず（依存解決方式・Renovate 運用への影響を避けるため）
-  - 各 matrix job は独立した runner（VM）で実行されるため、GUI/UIA の同一プロセス内並列で懸念されるフォーカス競合による flaky 増加は発生しない（issue #182 で非推奨とされたのは同一マシン内 xUnit 並列であり、本対応はそれとは異なる）
-  - リトライ回数・`blame-hang-timeout` は変更なし（flaky データが不足しているため据え置き。直近 3 実行はいずれもリトライなしで成功）
+  - **flaky 率への影響（訂正）**: 各 matrix job は独立した runner（VM）で実行されるため、issue #182 で明示的に非推奨とされた「同一マシン内 xUnit 並列によるフォーカス競合」は発生しない。一方で、既存の未解決 flaky が高頻度（観測した全 run で attempt 1 に 1 本失敗）で発生している以上、suite を 2 分割すると「いずれかの suite が retry を要する」機会は理論上増える（各 suite が独立に retry を要し得るため）。個々の job の retry 上限（最大 2 attempts）自体は変更していないが、ワークフロー全体で見た retry 消費機会は増加し得る点を正直に記載する。実測した唯一の分割後 run（`28788908674`）では suite 1・suite 2 とも 1 回の retry で green に到達しており、既存の max-2-attempts 枠を超えるケースは観測されていない
+  - wall clock は attempt を含む実測で比較する必要がある: 分割前（単一 job・retry込み）の job 全体は 8m51s（run `28786046897`）。分割後（2 job 並列・両 suite とも retry込み）は wall clock = max(suite1 job, suite2 job) = 6m35s（run `28788908674`）。retry を含めても約 25% の短縮を確認
+  - E2E スイート自体の flaky（毎 run 1 本失敗するパターン）は本 PR のスコープ外。原因調査・低減は #180 の前提整備または新規 issue でのフォローアップが必要
+  - リトライ回数上限・`blame-hang-timeout` は変更なし
 
 ### テスト
 - E2E に FileBrowser 操作系の残りシナリオ（右クリック複数選択復元 / クリップボード / 移動・コピー競合キャンセル）と操作系 fixture を追加し、#181 の受け入れ条件を完了 (#181)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 - E2E ワークフローの総実行時間を短縮 (#182)
   - 実測（直近 3 実行の GitHub Actions ステップタイミング）に基づき対応: 固定コスト（checkout/restore/build/ランタイム確認）が約 2.5〜3 分、テスト実行時間がテスト数に比例（1本あたり平均 27〜33 秒）して増加していることを確認。#181 で 3→13 本に増えテスト実行時間が支配的コストになったため、runner 分割が最も効果的と判断
   - `AppE2ETests` の全 13 テストに `[Trait("Suite", "1"|"2")]` を付与し、実行時間が概ね均等になるよう 7本/6本に分割（ローカル実測: Suite1 1m28s / Suite2 1m36s）
-  - `e2e.yml` を `matrix: suite: [1, 2]`（`fail-fast: false`）でジョブ分割し、`dotnet test --filter "Suite=${{ matrix.suite }}"` で対応する Suite のみ実行。TRX ファイル名・アーティファクト名に suite を含め衝突を回避
-  - `actions/cache@v4` で NuGet パッケージキャッシュ（`~\.nuget\packages`、キーは csproj/global.json のハッシュ）を追加し restore を短縮。`packages.lock.json` は導入せず（依存解決方式・Renovate 運用への影響を避けるため）
+  - `e2e.yml` を `matrix: suite: [1, 2]`（`fail-fast: false`）でジョブ分割。suite 1 は正フィルタ（`Suite=1`）、suite 2 は否定フィルタ（`Suite!=1`）で実行し、`[Trait("Suite", ...)]` の付け忘れがあった新規テストも自動的に suite 2 側で実行されるようにして「両 suite から漏れて CI が静かに未実行になる」リスクを構造的に排除（thread-owl レビュー指摘対応）。TRX ファイル名・アーティファクト名に suite を含め衝突を回避
+  - `actions/cache/restore` + 条件付き `actions/cache/save`（v6、Node.js 24 対応）で NuGet パッケージキャッシュ（`~/.nuget/packages`、キーは csproj/global.json のハッシュ）を追加し restore を短縮。保存は suite 1 のみに限定し matrix 両ジョブの重複 save による無駄を排除（Copilot/thread-owl レビュー指摘対応）。`packages.lock.json` は導入せず（依存解決方式・Renovate 運用への影響を避けるため）
   - 各 matrix job は独立した runner（VM）で実行されるため、GUI/UIA の同一プロセス内並列で懸念されるフォーカス競合による flaky 増加は発生しない（issue #182 で非推奨とされたのは同一マシン内 xUnit 並列であり、本対応はそれとは異なる）
   - リトライ回数・`blame-hang-timeout` は変更なし（flaky データが不足しているため据え置き。直近 3 実行はいずれもリトライなしで成功）
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@
   - `AppE2ETests` の全 13 テストに `[Trait("Suite", "1"|"2")]` を付与し、実行時間が概ね均等になるよう 7本/6本に分割（クリーン attempt 実測: suite1 ≈ 1m39s / suite2 ≈ 1m00s）
   - `e2e.yml` を `matrix: suite: [1, 2]`（`fail-fast: false`）でジョブ分割。suite 1 は正フィルタ（`Suite=1`）、suite 2 は否定フィルタ（`Suite!=1`）で実行し、`[Trait("Suite", ...)]` の付け忘れがあった新規テストも自動的に suite 2 側で実行されるようにして「両 suite から漏れて CI が静かに未実行になる」リスクを構造的に排除（thread-owl レビュー指摘対応）。TRX ファイル名・アーティファクト名に suite を含め衝突を回避
   - `actions/cache/restore` + 条件付き `actions/cache/save`（v6、Node.js 24 対応）で NuGet パッケージキャッシュ（`~/.nuget/packages`、キーは csproj/global.json のハッシュ）を追加し restore を短縮。保存は suite 1 のみに限定し matrix 両ジョブの重複 save による無駄を排除（Copilot/thread-owl レビュー指摘対応）。`packages.lock.json` は導入せず（依存解決方式・Renovate 運用への影響を避けるため）
-  - **flaky 率への影響（訂正）**: 各 matrix job は独立した runner（VM）で実行されるため、issue #182 で明示的に非推奨とされた「同一マシン内 xUnit 並列によるフォーカス競合」は発生しない。一方で、既存の未解決 flaky が高頻度（観測した全 run で attempt 1 に 1 本失敗）で発生している以上、suite を 2 分割すると「いずれかの suite が retry を要する」機会は理論上増える（各 suite が独立に retry を要し得るため）。個々の job の retry 上限（最大 2 attempts）自体は変更していないが、ワークフロー全体で見た retry 消費機会は増加し得る点を正直に記載する。実測した唯一の分割後 run（`28788908674`）では suite 1・suite 2 とも 1 回の retry で green に到達しており、既存の max-2-attempts 枠を超えるケースは観測されていない
-  - wall clock は attempt を含む実測で比較する必要がある: 分割前（単一 job・retry込み）の job 全体は 8m51s（run `28786046897`）。分割後（2 job 並列・両 suite とも retry込み）は wall clock = max(suite1 job, suite2 job) = 6m35s（run `28788908674`）。retry を含めても約 25% の短縮を確認
-  - E2E スイート自体の flaky（毎 run 1 本失敗するパターン）は本 PR のスコープ外。原因調査・低減は #180 の前提整備または新規 issue でのフォローアップが必要
+  - **根本原因の特定（thread-owl レビューで発覚）**: 分割前 4 run は毎回 `DeleteConfirmationDialogShowsForMultipleSelection` が attempt 1 で失敗していたが、これは「同じテストが壊れている」のではなく「そのプロセスで最初に実行されるテストである」ことが原因と判明（失敗前に完了したテストが 0 件であることをログで確認）。分割後は suite 2 の最初のテスト `ClipboardCopyPasteCopiesFileIntoSubfolder` も同様に attempt 1 で失敗するようになった（2 run とも再現）。つまり実態は「プロセス内で最初に実行される `[E2EFact]` は JIT ウォームアップ・AV スキャン・WinUI3 初回描画等のコールドスタートコストにより UIA タイムアウトしやすい」という既存の系統的 flaky であり、matrix 分割によって「最初の1本」の枠が単一プロセス1つから suite 数分（2つ）に増えたことで、flaky の発生機会が比例して増加していた
+  - **対応**: `AppE2ETests` に `IClassFixture<WarmupFixture>` を導入し、各 matrix job（テストプロセス）で実テスト開始前に 1 回だけアプリを起動→終了するウォームアップを追加。これにより OS/AV/JIT/コンポジタのコールドスタートコストを実テスト計測から除外し、「最初の1本」問題を suite 分割の有無によらず解消する。ウォームアップ自体の失敗は best-effort（実テストの成否に影響させない）
+  - **flaky 率への影響**: 各 matrix job は独立した runner（VM）で実行されるため、issue #182 で明示的に非推奨とされた「同一マシン内 xUnit 並列によるフォーカス競合」は発生しない。ウォームアップ導入により「最初の1本」のコールドスタート flaky は理論上解消されるが、ウォームアップ導入後の CI 実測での再検証が必要（PR レビュー継続中に追記）
+  - wall clock は attempt を含む実測で比較する必要がある: 分割前（単一 job・retry込み）の job 全体は 8m51s（run `28786046897`）。分割後（2 job 並列・両 suite とも retry込み）は wall clock = max(suite1 job, suite2 job) = 6m35s（run `28788908674`）。retry を含めても約 25% の短縮を確認（ウォームアップ追加後の再計測は別途反映）
   - リトライ回数上限・`blame-hang-timeout` は変更なし
 
 ### テスト

--- a/PhotoGeoExplorer.E2E/AppE2ETests.cs
+++ b/PhotoGeoExplorer.E2E/AppE2ETests.cs
@@ -17,10 +17,14 @@ using FlaUI.UIA3;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace PhotoGeoExplorer.E2E;
 
+// [Trait("Suite", ...)] は CI（e2e.yml）の matrix ジョブでテストを2分割し並列実行するための
+// グルーピング。グループ間で総実行時間が概ね均等になるよう手動で割り振っている（#182）。
+// 新規 E2EFact 追加時は軽い方の Suite に足すか、両 Suite の合計時間を見て調整すること。
 [SuppressMessage("Design", "CA1515:Consider making public types internal")]
 public sealed class AppE2ETests
 {
@@ -47,6 +51,7 @@ public sealed class AppE2ETests
     }
 
     [E2EFact]
+    [Trait("Suite", "1")]
     public async Task LaunchOpenFolderPreviewMetadataAndMap()
     {
         E2ETestData? testData = null;
@@ -93,6 +98,7 @@ public sealed class AppE2ETests
     }
 
     [E2EFact]
+    [Trait("Suite", "1")]
     public async Task ExifEditorContextMenuAndDateToggleWorks()
     {
         E2ETestData? testData = null;
@@ -151,6 +157,7 @@ public sealed class AppE2ETests
     }
 
     [E2EFact]
+    [Trait("Suite", "1")]
     public async Task ExifEditorSaveAndReopenKeepsCoordinates()
     {
         E2ETestData? testData = null;
@@ -221,22 +228,27 @@ public sealed class AppE2ETests
     }
 
     [E2EFact]
+    [Trait("Suite", "1")]
     public Task DeleteConfirmationDialogShowsForSingleFile()
         => RunDeleteConfirmationScenarioAsync(SingleFileSelection);
 
     [E2EFact]
+    [Trait("Suite", "1")]
     public Task DeleteConfirmationDialogShowsForSingleFolder()
         => RunDeleteConfirmationScenarioAsync(SingleFolderSelection);
 
     [E2EFact]
+    [Trait("Suite", "1")]
     public Task DeleteConfirmationDialogShowsForMultipleSelection()
         => RunDeleteConfirmationScenarioAsync(MultipleSelection);
 
     [E2EFact]
+    [Trait("Suite", "2")]
     public Task ClipboardCopyPasteCopiesFileIntoSubfolder()
         => RunClipboardPasteScenarioAsync(isCut: false);
 
     [E2EFact]
+    [Trait("Suite", "2")]
     public Task ClipboardCutPasteMovesFileIntoSubfolder()
         => RunClipboardPasteScenarioAsync(isCut: true);
 
@@ -245,6 +257,7 @@ public sealed class AppE2ETests
     // 非破壊に終える。復元分岐の網羅は単体テストが担保するため、E2E は「右クリックで選択が
     // 単数化しない」という統合結果のみを確認する。
     [E2EFact]
+    [Trait("Suite", "2")]
     public async Task RightClickOnSelectionPreservesMultipleSelection()
     {
         E2ETestData? testData = null;
@@ -292,10 +305,12 @@ public sealed class AppE2ETests
     }
 
     [E2EFact]
+    [Trait("Suite", "2")]
     public Task MoveConflictCancelKeepsSourceWithoutErrorDialog()
         => RunConflictCancelScenarioAsync(isCut: true);
 
     [E2EFact]
+    [Trait("Suite", "2")]
     public Task CopyConflictCancelKeepsSourceWithoutErrorDialog()
         => RunConflictCancelScenarioAsync(isCut: false);
 
@@ -304,6 +319,7 @@ public sealed class AppE2ETests
     // Ctrl+C でクリップボードへ載せ、選択解除後の Ctrl+X（no-op であるべき）が Copy 状態を
     // 破壊しないことを、貼り付け結果がコピー（項目出現＋コピー元残存）になることで検証する。
     [E2EFact]
+    [Trait("Suite", "2")]
     public async Task ClipboardShortcutWithoutSelectionIsNoOp()
     {
         E2ETestData? testData = null;
@@ -480,6 +496,7 @@ public sealed class AppE2ETests
     // SplashWindow が先に Activate される起動シーケンスにおいて、MainWindowMarkerAutomationId
     // によるウィンドウ識別が正しく機能することを確認する。
     [E2EFact]
+    [Trait("Suite", "1")]
     public async Task WaitForMainWindowReturnsMainWindowNotSplashWindow()
     {
         E2ETestData? testData = null;

--- a/PhotoGeoExplorer.E2E/AppE2ETests.cs
+++ b/PhotoGeoExplorer.E2E/AppE2ETests.cs
@@ -28,8 +28,16 @@ namespace PhotoGeoExplorer.E2E;
 // Trait を付け忘れた新規 [E2EFact] は自動的に suite 2（デフォルトバケット）で実行される
 // （両 suite から漏れて CI が静かに未実行にならないための設計）。
 // 新規追加時は軽い方の Suite に足すか、両 Suite の合計時間を見て調整すること。
+//
+// IClassFixture<WarmupFixture> について（#182 レビューで判明した既存 flaky への対処）:
+// プロセス内で最初に実行される [E2EFact] は、JIT ウォームアップ・AV スキャン・WinUI3
+// コンポジタの初回描画等のコールドスタートコストにより UIA タイムアウトしやすいという
+// 既存の flaky が確認されている。matrix 分割前は単一プロセスの「最初の1本」のみがこの
+// 影響を受けていたが、分割後は各 suite が独立プロセスとなり「最初の1本」の枠が suite 数分
+// 増えるため、flaky 発生機会もそれに比例して増加する。WarmupFixture はテストクラスにつき
+// 1 回だけアプリを起動→終了し、実テスト開始前にコールドスタートコストを吸収する。
 [SuppressMessage("Design", "CA1515:Consider making public types internal")]
-public sealed class AppE2ETests
+public sealed class AppE2ETests : IClassFixture<AppE2ETests.WarmupFixture>
 {
     private const string MainWindowMarkerAutomationId = "MainWindow";
     private const string SplashWindowMarkerAutomationId = "SplashWindow";
@@ -48,9 +56,10 @@ public sealed class AppE2ETests
     private static readonly string[] CloseDialogButtonNames = { "Cancel", "キャンセル" };
     private readonly ITestOutputHelper _output;
 
-    public AppE2ETests(ITestOutputHelper output)
+    public AppE2ETests(ITestOutputHelper output, WarmupFixture warmup)
     {
         _output = output;
+        _ = warmup; // ウォームアップは WarmupFixture のコンストラクタで実行済み。xUnit の DI 契約上の受け取りのみ。
     }
 
     [E2EFact]
@@ -2121,4 +2130,69 @@ public sealed class AppE2ETests
         }
     }
 
+    // テストクラスにつき 1 回だけアプリを起動→終了し、実テスト開始前にコールドスタート
+    // コスト（JIT ウォームアップ・AV スキャン・WinUI3 初回描画等）を吸収する。
+    // xUnit の IClassFixture はコンストラクタをテストクラスの最初のテスト実行前に一度だけ
+    // 呼び出すため、そのタイミングでウォームアップを行う。ウォームアップ自体の失敗は
+    // best-effort であり、実テストの成否に影響させてはならない（想定される例外はすべて
+    // 握りつぶす。ここで例外を伝播させるとフィクスチャ構築失敗としてクラス内の全テストが
+    // 失敗してしまうため、意図的に広めに catch する）。
+    [SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "xUnit の IClassFixture 契約上 AppE2ETests に密結合させる必要があり、private ヘルパー（WaitForMainWindow/TerminateApp/E2ETestData）への直接アクセスのため入れ子に保つ。")]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "testData は finally 節で DisposeAsync() により確実に破棄している。")]
+    public sealed class WarmupFixture
+    {
+        public WarmupFixture()
+        {
+            if (!IsE2EEnabled())
+            {
+                return;
+            }
+
+            E2ETestData? testData = null;
+            Application? app = null;
+            try
+            {
+                testData = E2ETestData.CreateAsync(NoOpOutputHelper.Instance).GetAwaiter().GetResult();
+                using var automation = new UIA3Automation();
+                app = Application.Launch(testData.StartInfo);
+                var window = WaitForMainWindow(app, automation);
+                window.Focus();
+            }
+            catch (Exception ex) when (ex is TimeoutException
+                or COMException
+                or InvalidOperationException
+                or Win32Exception
+                or ElementNotAvailableException
+                or FileNotFoundException
+                or IOException
+                or UnauthorizedAccessException)
+            {
+                // best-effort ウォームアップの失敗は無視する（実テストの成否に影響させない）。
+            }
+            finally
+            {
+                TerminateApp(app);
+                testData?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+        }
+
+        private static bool IsE2EEnabled()
+            => string.Equals(
+                Environment.GetEnvironmentVariable("PHOTO_GEO_EXPLORER_RUN_E2E"),
+                "1",
+                StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class NoOpOutputHelper : ITestOutputHelper
+    {
+        public static readonly NoOpOutputHelper Instance = new();
+
+        public void WriteLine(string message)
+        {
+        }
+
+        public void WriteLine(string format, params object[] args)
+        {
+        }
+    }
 }

--- a/PhotoGeoExplorer.E2E/AppE2ETests.cs
+++ b/PhotoGeoExplorer.E2E/AppE2ETests.cs
@@ -24,7 +24,10 @@ namespace PhotoGeoExplorer.E2E;
 
 // [Trait("Suite", ...)] は CI（e2e.yml）の matrix ジョブでテストを2分割し並列実行するための
 // グルーピング。グループ間で総実行時間が概ね均等になるよう手動で割り振っている（#182）。
-// 新規 E2EFact 追加時は軽い方の Suite に足すか、両 Suite の合計時間を見て調整すること。
+// e2e.yml 側は suite 1 を正フィルタ（Suite=1）、suite 2 を否定フィルタ（Suite!=1）で実行するため、
+// Trait を付け忘れた新規 [E2EFact] は自動的に suite 2（デフォルトバケット）で実行される
+// （両 suite から漏れて CI が静かに未実行にならないための設計）。
+// 新規追加時は軽い方の Suite に足すか、両 Suite の合計時間を見て調整すること。
 [SuppressMessage("Design", "CA1515:Consider making public types internal")]
 public sealed class AppE2ETests
 {


### PR DESCRIPTION
# Pull Request

## 概要

親 Issue #150 Phase 5（P5-C）の #182 を実装します。#181 で E2E が 3→13 本に増え、テスト実行時間が支配的コストになったため、実測に基づき runner 分割（matrix）と NuGet キャッシュを適用し総実行時間（wall clock）を短縮します。

### 実測（attempt 単位、GitHub Actions ログの実際の Passed/Failed 行に基づく再集計）

> **訂正の経緯**: 当初「直近3実行はいずれもリトライなしで1回目に成功」と記載していましたが誤りでした（`Run E2E tests` ステップ内部の attempt 別ログを見落としていた）。さらに調査を進めた結果、単なる集計ミスにとどまらず「suite分割によりコールドスタート flaky の発生機会が増えていた」という実質的な根本原因が判明し、修正しました（詳細は下記）。

| 実行 | 対象 | attempt 1 | attempt 2 |
|---|---|---|---|
| main `28333186948`（#181前, 7本） | 単一job | Failed 1/7 (`DeleteConfirmationDialogShowsForMultipleSelection`) | Passed 7/7 |
| main `28058515771`（7本） | 単一job | Failed 1/7 (同上) | Passed 7/7 |
| PR193 `28786046897`（13本） | 単一job | Failed 1/13 (同上) | Passed 13/13 |
| main `28786690007`（13本, #182のbase） | 単一job | Failed 1/13 (同上) | Passed 13/13 |
| 本PR `356a3e3` `28788908674` | suite 1（7本） | Failed 1/7 (同上) | Passed 7/7 |
| 本PR `356a3e3` `28788908674` | suite 2（6本） | Failed 1/6 (`ClipboardCopyPasteCopiesFileIntoSubfolder`) | Passed 6/6 |
| 本PR `5c591d8`（ウォームアップ追加後）`28791361642` | suite 1（7本） | **Passed 7/7、retry不要** | — |
| 本PR `5c591d8`（ウォームアップ追加後）`28791361642` | suite 2（6本） | **Passed 6/6、retry不要** | — |

### 根本原因の特定（thread-owl レビューで発覚）

分割前の4 runは毎回同じテスト `DeleteConfirmationDialogShowsForMultipleSelection` がattempt 1で失敗していましたが、これは「そのテスト自体が壊れている」のではなく「**そのプロセスで最初に実行されるテストである**」ことが原因でした（失敗直前までに完了したテストが0件であることをログで確認）。分割後はsuite 2の最初のテスト `ClipboardCopyPasteCopiesFileIntoSubfolder` も同様の位置で2回連続失敗しました。

つまり実態は「プロセス内で最初に実行される `[E2EFact]` はJITウォームアップ・AVスキャン・WinUI3初回描画等のコールドスタートコストによりUIAタイムアウトしやすい」という既存の系統的flakyであり、matrix分割によって「最初の1本」の枠が単一プロセス1つからsuite数分（2つ）に増えたことで、flakyの発生機会が比例して増加していました。

### 対応: ウォームアップの導入

`AppE2ETests` に `IClassFixture<WarmupFixture>` を導入し、各matrix job（テストプロセス）で実テスト開始前に1回だけアプリを起動→終了するウォームアップを追加しました。これによりOS/AV/JIT/コンポジタのコールドスタートコストを実テスト計測から除外します。ウォームアップ自体の失敗はbest-effort（実テストの成否に影響させない設計）。

**導入後のCI実行（`28791361642`）で、suite 1・suite 2とも attempt 1で0失敗・retry不要を確認しました。** これは分割前後を通じて検証した全runの中で唯一のretryなしgreen達成であり、コールドスタートflakyが解消されたことを直接裏付けています。

### 対応内容

- **runner 分割（matrix）**: `AppE2ETests` の全13テストに `[Trait("Suite", "1"|"2")]` を付与し、実行時間が概ね均等になるよう7本/6本に分割。`e2e.yml` を `matrix: suite: [1, 2]`（`fail-fast: false`）でジョブ分割し、suite 1 は正フィルタ `Suite=1`、suite 2 は否定フィルタ `Suite!=1` で実行（Trait付け忘れの新規テストが両suiteから漏れるリスクを構造的に排除。thread-owlレビュー指摘対応）。TRXファイル名・アーティファクト名にsuiteを含め衝突を回避
- **NuGetキャッシュ**: `actions/cache/restore` + 条件付き `actions/cache/save`（v6、Node.js 24対応）で `~/.nuget/packages` をキャッシュ。保存はsuite 1のみに限定しmatrix両ジョブの重複save排除（Copilot/thread-owlレビュー指摘対応）。`packages.lock.json` は導入していません（依存解決方式の変更・Renovate運用への影響を避けるため）
- **ウォームアップ（`IClassFixture<WarmupFixture>`）**: 各matrix jobで実テスト開始前に1回だけアプリを起動→終了し、コールドスタートflakyを解消（thread-owlレビュー指摘対応）
- **リトライ/timeoutは変更なし**: 個々のjobのretry上限（最大2 attempts）は変更していません

### flaky への影響

matrix の各jobは独立したrunner（VM）で実行されるため、issue #182で明示的に非推奨とされた「同一マシン内でのxUnit並列実行によるUIAフォーカス競合」は発生しません。ウォームアップ導入によりコールドスタートflakyも解消されたことをCI実測で確認済みです（上記表参照）。

## 変更の種類

- [ ] Bug fix（バグ修正）
- [ ] New feature（新機能）
- [ ] Breaking change（既存機能の破壊的変更）
- [ ] Refactoring（リファクタリング）
- [ ] Documentation（ドキュメント更新）
- [ ] Dependencies（依存関係の更新）
- [x] Other（CI改善）

## チェックリスト

### 基本事項

- [x] コードがビルドできる
- [x] 既存のテストが通る
- [x] 新しいコードにテストを追加した（該当なし。既存テストの分類とウォームアップフィクスチャの追加のみ）
- [x] ドキュメントを更新した（CHANGELOG.md）

### アーキテクチャガードレール（必須）

- [x] **MainWindowに新規ロジックを追加していない**
- [x] **新機能は PaneVM/Service に配置した**（本PRはCIワークフロー・E2Eテストインフラのみ、production変更なし）
- [x] **ペイン間の直接参照を追加していない**
- [x] **ロジック変更と構造変更を混ぜていない**

## テスト方法

- [x] ユニットテストを実行した（production変更なしのため対象外。ビルドのみ確認）
- [x] E2Eテストを実行した（Suite=1/Suite!=1 の各フィルタでローカル実行、13本の重複・漏れがないことを確認。CI実行でウォームアップ導入後のretryなしgreenを確認）

### テストコマンド

```bash
dotnet build PhotoGeoExplorer.sln -c Release -p:Platform=x64

# フィルタの整合確認
dotnet test PhotoGeoExplorer.E2E/PhotoGeoExplorer.E2E.csproj -c Release --no-build --filter "Suite=1" --list-tests
dotnet test PhotoGeoExplorer.E2E/PhotoGeoExplorer.E2E.csproj -c Release --no-build --filter "Suite!=1" --list-tests

dotnet format PhotoGeoExplorer.sln --verify-no-changes
```

## スクリーンショット（UI変更の場合）

該当なし。

## 備考

- テスト分割はGroup間の実行時間バランスを見て手動で割り振ったもので、今後 `[E2EFact]` を追加する際は軽い方のSuiteに足すか、両Suiteの合計時間を見て調整する旨をコード内コメントに記載しています。
- windows runnerは課金上2倍係数のため、matrix分割によりActions消費時間（分）は増加します（wall clockは短縮、合計消費分は増加というトレードオフ）。ユーザーに事前確認のうえこの方針を採用しました。
- コールドスタートflaky自体は#182以前から存在していた既存事象ですが、matrix分割で顕在化しやすくなったためウォームアップ導入で本PR内で解消しました。

## 関連Issue

Closes #182
Relates to #150 / #181

---

## レビュアーへの確認事項

- [ ] アーキテクチャガードレールを満たしているか
- [ ] matrix分割の粒度・バランスが妥当か
- [ ] NuGetキャッシュのキー設計（csproj/global.jsonハッシュ）が妥当か
- [ ] ウォームアップフィクスチャの設計（IClassFixture、best-effort例外処理）が妥当か
- [ ] CI実行結果（本PR自体の実行時間・flaky解消）が期待通りか

🤖 Generated with [Claude Code](https://claude.com/claude-code)
