### PR TITLE
refactor(map): MapPaneViewControl の EXIF/GPS 位置ピッカー責務を MapExifLocationPicker へ分離 (#176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@
 - FileBrowser ゴッドクラス解体 Phase 1（#150 / 子 issue #152〜#159）の成果を `docs/Architecture/FileBrowserDecomposition-Phase1-Summary.md` にモジュール行数で集計（View `1,941→908`・ViewModel `2,089→1,263`、責務別モジュール 9 件を新設）(#159)
 
 ### リファクタリング
+- `MapPaneViewControl` から EXIF/GPS 位置ピッカー責務を `MapExifLocationPicker` へ分離（#150 Phase 2）(#176)
+  - `IExifLocationPicker` 実装（`PickExifLocationAsync` の TaskCompletionSource 管理）、ピック中のポインタ状態機械（右クリックキャンセル・しきい値内クリック判定・キャプチャ喪失）、ステータス表示の退避/復元追跡を専用ハンドラ（`Panes/Map/MapExifLocationPicker.cs`）へ移動し、View を 694 行 → 515 行に縮退
+  - EXIF ピックと矩形選択で共有していたポインタハンドラ（Pressed/Released/CaptureLost）をモード別ルーターに整理。ピック中はハンドラへ委譲し戻り値で `e.Handled` を決定、矩形選択・マーカー flyout の分岐は不変（さらなる分離は Phase 4 候補としてスコープ外）
+  - UI 依存（マップ有無判定・ステータスオーバーレイの退避/復元）はコールバック注入とし、状態遷移（キャンセル・ドラッグ超過の無視・ワールド座標未解決時の継続・キャプチャ喪失後の再試行等）をパラメータ化単体テストで固定（`MapExifLocationPickerTests`、計 15 ケース）
+  - `MainWindow` は `MapPaneControl.ExifLocationPicker` を `ExifEditorService` へ渡す形へ変更し、View 自身は `IExifLocationPicker` を実装しない（挙動は不変）
 - `SettingsPaneViewModel` からペインレイアウト責務を `SettingsPaneLayoutSectionViewModel` へ抽出（#150 Phase 2）(#175)
   - レイアウトプリセット・リージョン1〜3の表示ビュー選択・重複スワップ・リージョンラベル・インデックス変換（約 200 行）を専用の子 ViewModel（`Panes/Settings/SettingsPaneLayoutSectionViewModel.cs`、`BindableBase` 派生）へ移動し、`SettingsPaneViewModel` は `PaneLayout` プロパティで公開する調停役に縮退（671 行 → 387 行）
   - 変更の即時適用は子 VM が `ISettingsCoordinator.ChangePaneLayout` を直接呼び、ダーティ追跡は `notifyChanged` コールバックで親へ通知。リフレッシュ（`RefreshFromCoordinator`）・リセット（`ResetToDefaults`）は子 VM 内部の抑制フラグで変更追跡を発火させない（既存挙動を維持）

--- a/PhotoGeoExplorer.Tests/MapExifLocationPickerTests.cs
+++ b/PhotoGeoExplorer.Tests/MapExifLocationPickerTests.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Threading.Tasks;
+using Mapsui;
+using Mapsui.Projections;
+using PhotoGeoExplorer.Panes.Map;
+using Windows.Foundation;
+using Xunit;
+
+namespace PhotoGeoExplorer.Tests;
+
+public sealed class MapExifLocationPickerTests
+{
+    [Theory]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, true)]
+    public void ConstructorThrowsWhenCallbackIsNull(bool canPickIsNull, bool hideIsNull, bool restoreIsNull)
+    {
+        Assert.Throws<ArgumentNullException>(() => new MapExifLocationPicker(
+            canPickIsNull ? null! : () => true,
+            hideIsNull ? null! : () => false,
+            restoreIsNull ? null! : () => { }));
+    }
+
+    [Fact]
+    public async Task PickExifLocationAsyncReturnsNullWhenCannotPick()
+    {
+        var harness = new PickerHarness(canPick: false);
+
+        var result = await harness.Picker.PickExifLocationAsync().ConfigureAwait(true);
+
+        Assert.Null(result);
+        Assert.False(harness.Picker.IsPicking);
+        Assert.Equal(0, harness.HideCallCount);
+    }
+
+    [Fact]
+    public void PickExifLocationAsyncReturnsSameTaskWhilePicking()
+    {
+        var harness = new PickerHarness();
+
+        var first = harness.Picker.PickExifLocationAsync();
+        var second = harness.Picker.PickExifLocationAsync();
+
+        Assert.Same(first, second);
+        Assert.True(harness.Picker.IsPicking);
+        Assert.Equal(1, harness.HideCallCount);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void PickExifLocationAsyncTracksStatusRestoreOnlyWhenStatusWasHidden(bool statusWasHidden)
+    {
+        var harness = new PickerHarness(hideResult: statusWasHidden);
+
+        _ = harness.Picker.PickExifLocationAsync();
+
+        Assert.Equal(statusWasHidden, harness.Picker.IsStatusRestorePending);
+    }
+
+    [Fact]
+    public async Task HandlePointerPressedWithRightButtonCancelsPick()
+    {
+        var harness = new PickerHarness();
+        var pickTask = harness.Picker.PickExifLocationAsync();
+
+        var handled = harness.Picker.HandlePointerPressed(
+            isLeftButtonPressed: false,
+            isRightButtonPressed: true,
+            position: new Point(10, 10));
+
+        Assert.True(handled);
+        Assert.False(harness.Picker.IsPicking);
+        Assert.False(harness.Picker.IsStatusRestorePending);
+        Assert.Equal(1, harness.RestoreCallCount);
+        Assert.Null(await pickTask.ConfigureAwait(true));
+    }
+
+    [Fact]
+    public void HandlePointerPressedWithLeftButtonIsNotHandled()
+    {
+        var harness = new PickerHarness();
+        _ = harness.Picker.PickExifLocationAsync();
+
+        var handled = harness.Picker.HandlePointerPressed(
+            isLeftButtonPressed: true,
+            isRightButtonPressed: false,
+            position: new Point(10, 10));
+
+        Assert.False(handled);
+        Assert.True(harness.Picker.IsPicking);
+    }
+
+    [Fact]
+    public async Task HandlePointerReleasedCompletesPickWithLonLat()
+    {
+        var harness = new PickerHarness();
+        var pickTask = harness.Picker.PickExifLocationAsync();
+        var worldPosition = new MPoint(15557238.0, 4257415.0);
+        var expected = SphericalMercator.ToLonLat(worldPosition);
+
+        harness.Picker.HandlePointerPressed(true, false, new Point(100, 100));
+        var handled = harness.Picker.HandlePointerReleased(new Point(103, 98), () => worldPosition);
+
+        Assert.True(handled);
+        Assert.False(harness.Picker.IsPicking);
+        Assert.Equal(1, harness.RestoreCallCount);
+        var result = await pickTask.ConfigureAwait(true);
+        Assert.NotNull(result);
+        Assert.Equal(expected.Y, result.Value.Latitude);
+        Assert.Equal(expected.X, result.Value.Longitude);
+    }
+
+    [Theory]
+    [InlineData(7, 0)]
+    [InlineData(0, 7)]
+    [InlineData(-7, -7)]
+    public void HandlePointerReleasedIgnoresDragBeyondThreshold(double deltaX, double deltaY)
+    {
+        var harness = new PickerHarness();
+        _ = harness.Picker.PickExifLocationAsync();
+
+        harness.Picker.HandlePointerPressed(true, false, new Point(100, 100));
+        var handled = harness.Picker.HandlePointerReleased(
+            new Point(100 + deltaX, 100 + deltaY),
+            () => new MPoint(0, 0));
+
+        Assert.False(handled);
+        Assert.True(harness.Picker.IsPicking);
+        Assert.Equal(0, harness.RestoreCallCount);
+    }
+
+    [Fact]
+    public void HandlePointerReleasedWithoutActivePointerIsIgnored()
+    {
+        var harness = new PickerHarness();
+        _ = harness.Picker.PickExifLocationAsync();
+
+        var handled = harness.Picker.HandlePointerReleased(new Point(0, 0), () => new MPoint(0, 0));
+
+        Assert.False(handled);
+        Assert.True(harness.Picker.IsPicking);
+    }
+
+    [Fact]
+    public void HandlePointerReleasedKeepsPickingWhenWorldPositionIsUnavailable()
+    {
+        var harness = new PickerHarness();
+        _ = harness.Picker.PickExifLocationAsync();
+
+        harness.Picker.HandlePointerPressed(true, false, new Point(100, 100));
+        var handled = harness.Picker.HandlePointerReleased(new Point(100, 100), () => null);
+
+        Assert.False(handled);
+        Assert.True(harness.Picker.IsPicking);
+    }
+
+    [Fact]
+    public void HandlePointerReleasedThrowsWhenWorldPositionResolverIsNull()
+    {
+        var harness = new PickerHarness();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            harness.Picker.HandlePointerReleased(new Point(0, 0), null!));
+    }
+
+    [Fact]
+    public void CancelWithoutPendingPickDoesNotRestoreStatus()
+    {
+        var harness = new PickerHarness();
+
+        harness.Picker.Cancel();
+
+        Assert.Equal(0, harness.RestoreCallCount);
+        Assert.False(harness.Picker.IsPicking);
+    }
+
+    [Fact]
+    public async Task HandlePointerCaptureLostKeepsPickingAndAllowsRetry()
+    {
+        var harness = new PickerHarness();
+        var pickTask = harness.Picker.PickExifLocationAsync();
+
+        harness.Picker.HandlePointerPressed(true, false, new Point(100, 100));
+        harness.Picker.HandlePointerCaptureLost();
+        var handledAfterLost = harness.Picker.HandlePointerReleased(new Point(100, 100), () => new MPoint(0, 0));
+
+        Assert.False(handledAfterLost);
+        Assert.True(harness.Picker.IsPicking);
+
+        harness.Picker.HandlePointerPressed(true, false, new Point(50, 50));
+        var handledRetry = harness.Picker.HandlePointerReleased(new Point(50, 50), () => new MPoint(0, 0));
+
+        Assert.True(handledRetry);
+        Assert.NotNull(await pickTask.ConfigureAwait(true));
+    }
+
+    private sealed class PickerHarness
+    {
+        public PickerHarness(bool canPick = true, bool hideResult = true)
+        {
+            Picker = new MapExifLocationPicker(
+                () => canPick,
+                () =>
+                {
+                    HideCallCount++;
+                    return hideResult;
+                },
+                () => RestoreCallCount++);
+        }
+
+        public MapExifLocationPicker Picker { get; }
+
+        public int HideCallCount { get; private set; }
+
+        public int RestoreCallCount { get; private set; }
+    }
+}

--- a/PhotoGeoExplorer/MainWindow.xaml.cs
+++ b/PhotoGeoExplorer/MainWindow.xaml.cs
@@ -52,7 +52,7 @@ public sealed partial class MainWindow : Window, IDisposable
         var exifEditorService = new ExifEditorService(
             dialogService,
             new ExifMetadataService(),
-            MapPaneControl,
+            MapPaneControl.ExifLocationPicker,
             (message, severity) => _viewModel.ShowNotificationMessage(message, severity));
         // MainWindow のコンストラクタは UI スレッドで実行されるため、
         // ここで生成した UiDispatcher が UI スレッドの DispatcherQueue を捕捉する

--- a/PhotoGeoExplorer/Panes/Map/MapExifLocationPicker.cs
+++ b/PhotoGeoExplorer/Panes/Map/MapExifLocationPicker.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Threading.Tasks;
+using Mapsui;
+using Mapsui.Projections;
+using PhotoGeoExplorer.Services;
+using Windows.Foundation;
+
+namespace PhotoGeoExplorer.Panes.Map;
+
+/// <summary>
+/// EXIF/GPS 位置ピックの状態機械と取得フローを担当するハンドラ。
+/// マップ有無の判定・ステータス表示の退避/復元は UI 依存のためコールバックで注入する。
+/// </summary>
+internal sealed class MapExifLocationPicker : IExifLocationPicker
+{
+    private readonly Func<bool> _canPick;
+    private readonly Func<bool> _hideMapStatus;
+    private readonly Action _restoreMapStatus;
+
+    private TaskCompletionSource<(double Latitude, double Longitude)?>? _pendingPick;
+    private bool _isPointerActive;
+    private Point? _pointerStart;
+    private bool _restoreStatusAfterPick;
+
+    public MapExifLocationPicker(Func<bool> canPick, Func<bool> hideMapStatus, Action restoreMapStatus)
+    {
+        _canPick = canPick ?? throw new ArgumentNullException(nameof(canPick));
+        _hideMapStatus = hideMapStatus ?? throw new ArgumentNullException(nameof(hideMapStatus));
+        _restoreMapStatus = restoreMapStatus ?? throw new ArgumentNullException(nameof(restoreMapStatus));
+    }
+
+    public bool CanPickExifLocation => _canPick();
+
+    public bool IsPicking { get; private set; }
+
+    /// <summary>ピックのためにステータス表示を退避中で、完了/キャンセル時に復元が必要な状態。</summary>
+    public bool IsStatusRestorePending => _restoreStatusAfterPick;
+
+    public Task<(double Latitude, double Longitude)?> PickExifLocationAsync()
+    {
+        if (!CanPickExifLocation)
+        {
+            return Task.FromResult<(double Latitude, double Longitude)?>(null);
+        }
+
+        if (_pendingPick is not null)
+        {
+            return _pendingPick.Task;
+        }
+
+        IsPicking = true;
+        _restoreStatusAfterPick = _hideMapStatus();
+        _pendingPick = new TaskCompletionSource<(double Latitude, double Longitude)?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        return _pendingPick.Task;
+    }
+
+    /// <summary>ピック中のポインタ押下を処理する。戻り値はイベントを Handled にすべきかどうか。</summary>
+    public bool HandlePointerPressed(bool isLeftButtonPressed, bool isRightButtonPressed, Point position)
+    {
+        if (isRightButtonPressed)
+        {
+            Cancel();
+            return true;
+        }
+
+        if (!isLeftButtonPressed)
+        {
+            return false;
+        }
+
+        _isPointerActive = true;
+        _pointerStart = position;
+        return false;
+    }
+
+    /// <summary>
+    /// ピック中のポインタ解放を処理する。押下位置からの移動がしきい値内（クリック扱い）であれば
+    /// ワールド座標を経緯度へ変換してピックを完了する。戻り値はイベントを Handled にすべきかどうか。
+    /// </summary>
+    public bool HandlePointerReleased(Point currentPosition, Func<MPoint?> getWorldPosition)
+    {
+        ArgumentNullException.ThrowIfNull(getWorldPosition);
+
+        if (!_isPointerActive)
+        {
+            return false;
+        }
+
+        _isPointerActive = false;
+        var startPoint = _pointerStart;
+        _pointerStart = null;
+        if (startPoint is null)
+        {
+            return false;
+        }
+
+        if (!MapPaneSelectionHelper.IsPointerMovementWithinThreshold(startPoint.Value, currentPosition))
+        {
+            return false;
+        }
+
+        var worldPosition = getWorldPosition();
+        if (worldPosition is null)
+        {
+            return false;
+        }
+
+        var lonLat = SphericalMercator.ToLonLat(worldPosition);
+        Complete(lonLat.Y, lonLat.X);
+        return true;
+    }
+
+    /// <summary>ポインタキャプチャ喪失時の処理。ドラッグ追跡のみ破棄し、ピック自体は継続する。</summary>
+    public void HandlePointerCaptureLost()
+    {
+        _isPointerActive = false;
+        _pointerStart = null;
+    }
+
+    public void Cancel()
+    {
+        CompleteCore(null);
+    }
+
+    private void Complete(double latitude, double longitude)
+    {
+        CompleteCore((latitude, longitude));
+    }
+
+    private void CompleteCore((double Latitude, double Longitude)? result)
+    {
+        if (!IsPicking)
+        {
+            return;
+        }
+
+        IsPicking = false;
+        _isPointerActive = false;
+        _pointerStart = null;
+        RestoreMapStatus();
+        var pendingPick = _pendingPick;
+        _pendingPick = null;
+        pendingPick?.TrySetResult(result);
+    }
+
+    private void RestoreMapStatus()
+    {
+        if (!_restoreStatusAfterPick)
+        {
+            return;
+        }
+
+        _restoreStatusAfterPick = false;
+        _restoreMapStatus();
+    }
+}

--- a/PhotoGeoExplorer/Panes/Map/MapPaneViewControl.xaml.cs
+++ b/PhotoGeoExplorer/Panes/Map/MapPaneViewControl.xaml.cs
@@ -1,14 +1,11 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
-using System.Threading.Tasks;
 using Mapsui;
 using Mapsui.Extensions;
 using Mapsui.Layers;
 using Mapsui.Nts;
-using Mapsui.Projections;
 using Mapsui.Styles;
 using Mapsui.UI.WinUI;
 using Microsoft.UI;
@@ -23,13 +20,14 @@ using Windows.UI.Core;
 
 namespace PhotoGeoExplorer.Panes.Map;
 
-internal sealed partial class MapPaneViewControl : UserControl, IDisposable, IExifLocationPicker
+internal sealed partial class MapPaneViewControl : UserControl, IDisposable
 {
     private const string PhotoItemKey = "PhotoItem";
     private const string PhotoMetadataKey = "PhotoMetadata";
     private static readonly Color SelectionFillColor = Color.FromArgb(64, 0, 120, 215);
     private static readonly Color SelectionOutlineColor = Color.FromArgb(255, 0, 120, 215);
 
+    private readonly MapExifLocationPicker _exifLocationPicker;
     private MapPaneViewModel? _viewModel;
     private Mapsui.Map? _map;
     private PhotoMetadata? _flyoutMetadata;
@@ -38,38 +36,18 @@ internal sealed partial class MapPaneViewControl : UserControl, IDisposable, IEx
     private MemoryLayer? _rectangleSelectionLayer;
     private bool _mapPanLockBeforeSelection;
     private bool _mapPanLockActive;
-    private TaskCompletionSource<(double Latitude, double Longitude)?>? _exifLocationPicker;
-    private bool _isPickingExifLocation;
-    private bool _isExifPickPointerActive;
-    private Windows.Foundation.Point? _exifPickPointerStart;
-    private bool _restoreMapStatusAfterExifPick;
     private bool _isViewLoaded;
 
     public MapPaneViewControl()
     {
         InitializeComponent();
+        _exifLocationPicker = new MapExifLocationPicker(
+            canPick: () => _map is not null,
+            hideMapStatus: HideMapStatusForExifPick,
+            restoreMapStatus: UpdateMapStatusFromViewModel);
     }
 
-    public bool CanPickExifLocation => _map is not null;
-
-    public Task<(double Latitude, double Longitude)?> PickExifLocationAsync()
-    {
-        if (!CanPickExifLocation)
-        {
-            return Task.FromResult<(double Latitude, double Longitude)?>(null);
-        }
-
-        if (_exifLocationPicker is not null)
-        {
-            return _exifLocationPicker.Task;
-        }
-
-        _isPickingExifLocation = true;
-        HideMapStatusForExifPick();
-        _exifLocationPicker = new TaskCompletionSource<(double Latitude, double Longitude)?>(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        return _exifLocationPicker.Task;
-    }
+    internal IExifLocationPicker ExifLocationPicker => _exifLocationPicker;
 
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
@@ -88,7 +66,7 @@ internal sealed partial class MapPaneViewControl : UserControl, IDisposable, IEx
     private void OnUnloaded(object sender, RoutedEventArgs e)
     {
         _isViewLoaded = false;
-        CancelExifLocationPick();
+        _exifLocationPicker.Cancel();
         DetachViewModel();
         ClearRectangleSelectionLayer();
         _map = null;
@@ -150,14 +128,14 @@ internal sealed partial class MapPaneViewControl : UserControl, IDisposable, IEx
         if (propertyName == nameof(MapPaneViewModel.Map))
         {
             ApplyMapFromViewModel();
-            if (!_restoreMapStatusAfterExifPick)
+            if (!_exifLocationPicker.IsStatusRestorePending)
             {
                 UpdateMapStatusFromViewModel();
             }
             return;
         }
 
-        if (_restoreMapStatusAfterExifPick)
+        if (_exifLocationPicker.IsStatusRestorePending)
         {
             return;
         }
@@ -237,64 +215,21 @@ internal sealed partial class MapPaneViewControl : UserControl, IDisposable, IEx
         return DispatcherQueue?.HasThreadAccess ?? false;
     }
 
-    private void HideMapStatusForExifPick()
+    private bool HideMapStatusForExifPick()
     {
         if (MapStatusOverlay is null || MapStatusPanel is null)
         {
-            return;
+            return false;
         }
 
         if (MapStatusOverlay.Visibility == Visibility.Collapsed && MapStatusPanel.Visibility == Visibility.Collapsed)
         {
-            return;
+            return false;
         }
 
-        _restoreMapStatusAfterExifPick = true;
         MapStatusOverlay.Visibility = Visibility.Collapsed;
         MapStatusPanel.Visibility = Visibility.Collapsed;
-    }
-
-    private void RestoreMapStatusAfterExifPick()
-    {
-        if (!_restoreMapStatusAfterExifPick)
-        {
-            return;
-        }
-
-        _restoreMapStatusAfterExifPick = false;
-        UpdateMapStatusFromViewModel();
-    }
-
-    private void CompleteExifLocationPick(double latitude, double longitude)
-    {
-        if (!_isPickingExifLocation)
-        {
-            return;
-        }
-
-        _isPickingExifLocation = false;
-        _isExifPickPointerActive = false;
-        _exifPickPointerStart = null;
-        RestoreMapStatusAfterExifPick();
-        var picker = _exifLocationPicker;
-        _exifLocationPicker = null;
-        picker?.TrySetResult((latitude, longitude));
-    }
-
-    private void CancelExifLocationPick()
-    {
-        if (!_isPickingExifLocation)
-        {
-            return;
-        }
-
-        _isPickingExifLocation = false;
-        _isExifPickPointerActive = false;
-        _exifPickPointerStart = null;
-        RestoreMapStatusAfterExifPick();
-        var picker = _exifLocationPicker;
-        _exifLocationPicker = null;
-        picker?.TrySetResult(null);
+        return true;
     }
 
     private MemoryLayer? GetMarkerLayer()
@@ -414,22 +349,15 @@ internal sealed partial class MapPaneViewControl : UserControl, IDisposable, IEx
         }
 
         var point = e.GetCurrentPoint(MapControl);
-        if (_isPickingExifLocation)
+        if (_exifLocationPicker.IsPicking)
         {
-            if (point.Properties.IsRightButtonPressed)
+            if (_exifLocationPicker.HandlePointerPressed(
+                point.Properties.IsLeftButtonPressed,
+                point.Properties.IsRightButtonPressed,
+                point.Position))
             {
-                CancelExifLocationPick();
                 e.Handled = true;
-                return;
             }
-
-            if (!point.Properties.IsLeftButtonPressed)
-            {
-                return;
-            }
-
-            _isExifPickPointerActive = true;
-            _exifPickPointerStart = point.Position;
             return;
         }
 
@@ -483,36 +411,14 @@ internal sealed partial class MapPaneViewControl : UserControl, IDisposable, IEx
             return;
         }
 
-        if (_isPickingExifLocation)
+        if (_exifLocationPicker.IsPicking)
         {
-            if (!_isExifPickPointerActive)
+            if (_exifLocationPicker.HandlePointerReleased(
+                e.GetCurrentPoint(MapControl).Position,
+                () => GetWorldPosition(e)))
             {
-                return;
+                e.Handled = true;
             }
-
-            _isExifPickPointerActive = false;
-            var startPoint = _exifPickPointerStart;
-            _exifPickPointerStart = null;
-            if (startPoint is null)
-            {
-                return;
-            }
-
-            var currentPoint = e.GetCurrentPoint(MapControl).Position;
-            if (!MapPaneSelectionHelper.IsPointerMovementWithinThreshold(startPoint.Value, currentPoint))
-            {
-                return;
-            }
-
-            var worldPosition = GetWorldPosition(e);
-            if (worldPosition is null)
-            {
-                return;
-            }
-
-            var lonLat = SphericalMercator.ToLonLat(worldPosition);
-            CompleteExifLocationPick(lonLat.Y, lonLat.X);
-            e.Handled = true;
             return;
         }
 
@@ -550,8 +456,7 @@ internal sealed partial class MapPaneViewControl : UserControl, IDisposable, IEx
     {
         _mapRectangleSelecting = false;
         _mapRectangleStart = null;
-        _isExifPickPointerActive = false;
-        _exifPickPointerStart = null;
+        _exifLocationPicker.HandlePointerCaptureLost();
         ClearRectangleSelectionLayer();
         RestoreMapPanLock();
     }


### PR DESCRIPTION
# Pull Request

## 概要

親 Issue #150 の Phase 2（🟠 App 層）。`MapPaneViewControl.xaml.cs`（694 行）に同居していた EXIF/GPS 位置ピッカー責務を専用ハンドラ `Panes/Map/MapExifLocationPicker.cs` へ分離しました。

- **状態機械の移動**: `IExifLocationPicker` 実装（`PickExifLocationAsync` の `TaskCompletionSource` 管理）、ピック中のポインタ状態（`_isExifPickPointerActive` / `_exifPickPointerStart`）、ステータス表示の退避/復元追跡（`_restoreMapStatusAfterExifPick`）をハンドラへ移動。View は 694 行 → **515 行**（−179 行）
- **ポインタのモード別ルーター化**: EXIF ピックと矩形選択で分岐が絡み合っていた `OnMapPointerPressed` / `OnMapPointerReleased` / `OnMapPointerCaptureLost` を「ピック中はハンドラへ委譲（戻り値で `e.Handled` を決定）、それ以外は矩形選択」のルーターに整理。矩形選択・マーカー flyout のロジックは不変（さらなる分離は Issue 記載どおり Phase 4 候補でスコープ外）
- **テスト可能な設計**: UI 依存（マップ有無判定・ステータスオーバーレイの退避/復元）はコールバック注入。ハンドラは `Mapsui` / `Windows.Foundation.Point` のみに依存し、WinUI 型に依存しない
- **配線変更**: `MainWindow` は `MapPaneControl.ExifLocationPicker` を `ExifEditorService` へ渡す形へ変更（View 自身は `IExifLocationPicker` を実装しない）。挙動は不変

## 変更の種類

- [x] Refactoring（リファクタリング）

## チェックリスト

### 基本事項

- [x] コードがビルドできる
- [x] 既存のテストが通る
- [x] 新しいコードにテストを追加した（`MapExifLocationPickerTests`、計 15 ケース）
- [x] ドキュメントを更新した（CHANGELOG.md）

### アーキテクチャガードレール（必須）

- [x] **MainWindowに新規ロジックを追加していない**（`ExifEditorService` へ渡す参照を `MapPaneControl` → `MapPaneControl.ExifLocationPicker` に変更した 1 行のみ）
- [x] **新機能は PaneVM/Service に配置した**（新機能なし。ピッカー状態機械は `Panes/Map` 配下の専用ハンドラへ配置）
- [x] **ペイン間の直接参照を追加していない**
- [x] **ロジック変更と構造変更を混ぜていない**（構造変更のみ。状態遷移・分岐は元コードを忠実に移設）

## テスト方法

- [x] ユニットテストを実行した（674/674 pass、新規 15 ケース含む）
- [ ] 手動テストを実行した（位置ピック・矩形選択の回帰確認は手元環境での確認を推奨）
- [ ] E2Eテストを実行した（既存 E2E `ExifEditorSaveAndReopenKeepsCoordinates` が地図クリックによる位置ピック経路をカバー。CI で実行）

### テストコマンド

```bash
# ビルド
dotnet build PhotoGeoExplorer.sln -c Release -p:Platform=x64   # 0 警告 0 エラー

# テスト実行
dotnet test PhotoGeoExplorer.sln -c Release -p:Platform=x64    # 674/674 pass

# フォーマット検証
dotnet format --verify-no-changes PhotoGeoExplorer.sln         # 差分なし
```

## 備考

- 単体テストで固定した状態遷移: 右クリックキャンセル、しきい値超過ドラッグの無視、ワールド座標未解決時のピック継続、ポインタキャプチャ喪失後の再試行、ステータス退避が発生しなかった場合の復元スキップ、`CanPickExifLocation=false` 時の即時 null 返却、二重呼び出し時の同一 Task 返却
- `HideMapStatusForExifPick` は「実際に隠したか」を `bool` で返す形に変更し、退避要否の判定（UI の Visibility 参照）は View 責務のまま維持

## 関連Issue

Closes #176
Relates to #150

---

## レビュアーへの確認事項

- [x] アーキテクチャガードレールを満たしているか
- [x] コードの品質と可読性
- [x] テストの網羅性
- [x] ドキュメントの更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)