### PR TITLE
refactor(exif): ExifService の読み取り責務を ExifReader へ分離 (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@
 - FileBrowser ゴッドクラス解体 Phase 1（#150 / 子 issue #152〜#159）の成果を `docs/Architecture/FileBrowserDecomposition-Phase1-Summary.md` にモジュール行数で集計（View `1,941→908`・ViewModel `2,089→1,263`、責務別モジュール 9 件を新設）(#159)
 
 ### リファクタリング
+- `ExifService` の読み取り責務を `ExifReader` へ分離（#150 Phase 3 / #178 P3-A）(#199)
+  - `GetMetadataAsync` / `GetMetadata` / `ReadMetadata`（MetadataExtractor による GPS / カメラ情報 / 撮影日時の読み取りと例外ハンドリング）を `PhotoGeoExplorer.Core/Services/ExifReader.cs`（internal static）へ移動し、MetadataExtractor 依存を `ExifReader` に局所化（`ExifService` は 558 行 → 380 行の書き込み専用クラスに縮退）
+  - 呼び出し側 5 箇所（`PreviewPaneService` / `ExifMetadataService` / `MapPaneService` / `FileBrowserStatusViewModel` / `ThumbnailGenerationCoordinator`）を `ExifReader.GetMetadataAsync` へ振り向け（挙動は不変）
+  - 読み取り系テストを `ExifReaderTests` へ再編（既存の ExifSubIfd 日時欠落ケースを移動し、非画像ファイル / 非存在ファイルの null 返却ケースを追加）。`ExifServiceTests` の書き込み検証用読み取りは `ExifReader` 経由へ更新
 - `SettingsCoordinator` の純粋正規化関数を `SettingsNormalization` へ抽出（#150 Phase 2）(#177)
   - `NormalizeLanguageSetting` / `NormalizeMapZoomLevel` / `NormalizeExternalContentBaseUrl` / `NormalizePaneLayoutPreset` / `NormalizePaneRegionViews` / `FindValidAncestorPath` を `Services/SettingsNormalization.cs`（internal static）へ移動し、`SettingsCoordinator` をオーケストレーション責務に縮退（621 行 → 417 行）
   - `SettingsPaneViewModel` 側の重複正規化ロジックを抽出先へ集約。言語正規化は完全版（`ja` → `ja-JP` 等のタグ変換込み）へ委譲し、`SaveAsync` の言語変更判定が正規化後の値同士の比較になるよう改善。ズームレベルはスライダー入力向けの「最寄り値へスナップ」の意図を `SnapMapZoomLevelToNearest` として設定読み込み時の `NormalizeMapZoomLevel`（無効値→既定値）と区別して集約

--- a/PhotoGeoExplorer.Core/Services/ExifReader.cs
+++ b/PhotoGeoExplorer.Core/Services/ExifReader.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MetadataExtractor;
+using MetadataExtractor.Formats.Exif;
+using MetadataExtractor.Formats.FileSystem;
+using PhotoGeoExplorer.Models;
+
+namespace PhotoGeoExplorer.Services;
+
+/// <summary>
+/// EXIF メタデータの読み取り責務を担う（MetadataExtractor 依存はこのクラスに局所化する）
+/// </summary>
+internal static class ExifReader
+{
+    public static Task<PhotoMetadata?> GetMetadataAsync(string filePath, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+        return Task.Run(() => ReadMetadata(filePath, cancellationToken), cancellationToken);
+    }
+
+    public static PhotoMetadata? GetMetadata(string filePath)
+    {
+        ArgumentNullException.ThrowIfNull(filePath);
+        return ReadMetadata(filePath, CancellationToken.None);
+    }
+
+    private static PhotoMetadata? ReadMetadata(string filePath, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        IReadOnlyList<MetadataExtractor.Directory> directories;
+        try
+        {
+            directories = ImageMetadataReader.ReadMetadata(filePath);
+        }
+        catch (MetadataExtractor.ImageProcessingException ex)
+        {
+            AppLog.Error($"Failed to read metadata: {filePath}", ex);
+            return null;
+        }
+        catch (IOException ex)
+        {
+            AppLog.Error($"Failed to read metadata: {filePath}", ex);
+            return null;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            AppLog.Error($"Failed to read metadata: {filePath}", ex);
+            return null;
+        }
+        catch (NotSupportedException ex)
+        {
+            AppLog.Error($"Failed to read metadata: {filePath}", ex);
+            return null;
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex)
+        {
+            // Catch any other unexpected exceptions from MetadataExtractor library
+            // (e.g., IndexOutOfRangeException when processing certain MP3 files)
+            // to prevent app crashes. These are logged and treated as metadata read failures.
+            AppLog.Error($"Unexpected exception reading metadata: {filePath}", ex);
+            return null;
+        }
+#pragma warning restore CA1031 // Do not catch general exception types
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            var gpsDirectory = directories.OfType<GpsDirectory>().FirstOrDefault();
+            GeoLocation? location = null;
+            if (gpsDirectory is not null && gpsDirectory.TryGetGeoLocation(out var geoLocation))
+            {
+                location = geoLocation;
+            }
+
+            double? latitude = location?.Latitude;
+            double? longitude = location?.Longitude;
+
+            var exifIfd0 = directories.OfType<ExifIfd0Directory>().FirstOrDefault();
+            var cameraMake = exifIfd0?.GetString(ExifDirectoryBase.TagMake);
+            var cameraModel = exifIfd0?.GetString(ExifDirectoryBase.TagModel);
+
+            var subIfd = directories.OfType<ExifSubIfdDirectory>().FirstOrDefault();
+            DateTime? dateTime = null;
+            if (subIfd is not null)
+            {
+                if (subIfd.TryGetDateTime(ExifDirectoryBase.TagDateTimeOriginal, out var dt))
+                    dateTime = dt;
+                else if (subIfd.TryGetDateTime(ExifDirectoryBase.TagDateTimeDigitized, out dt))
+                    dateTime = dt;
+            }
+
+            if (dateTime is null)
+            {
+                var fileMeta = directories.OfType<FileMetadataDirectory>().FirstOrDefault();
+                if (fileMeta is not null && fileMeta.TryGetDateTime(FileMetadataDirectory.TagFileModifiedDate, out var dt))
+                    dateTime = dt;
+            }
+
+            DateTimeOffset? takenAt = null;
+            if (dateTime.HasValue)
+            {
+                var localTime = DateTime.SpecifyKind(dateTime.Value, DateTimeKind.Local);
+                takenAt = new DateTimeOffset(localTime);
+            }
+
+            return new PhotoMetadata(
+                takenAt,
+                cameraMake,
+                cameraModel,
+                latitude,
+                longitude,
+                hasGpsData: gpsDirectory is not null);
+        }
+        catch (MetadataExtractor.MetadataException ex)
+        {
+            AppLog.Error($"Partial metadata read failure: {filePath}", ex);
+            return null;
+        }
+    }
+}

--- a/PhotoGeoExplorer.Core/Services/ExifService.cs
+++ b/PhotoGeoExplorer.Core/Services/ExifService.cs
@@ -1,35 +1,20 @@
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using MetadataExtractor;
-using MetadataExtractor.Formats.Exif;
-using MetadataExtractor.Formats.FileSystem;
-using PhotoGeoExplorer.Models;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using ImageSharpRational = SixLabors.ImageSharp.Rational;
 
 namespace PhotoGeoExplorer.Services;
 
+/// <summary>
+/// EXIF メタデータの書き込み責務を担う（読み取りは <see cref="ExifReader"/> を参照）
+/// </summary>
 internal static class ExifService
 {
     private static readonly byte[] ExifHeader = { 0x45, 0x78, 0x69, 0x66, 0x00, 0x00 };
-
-    public static Task<PhotoMetadata?> GetMetadataAsync(string filePath, CancellationToken cancellationToken)
-    {
-        ArgumentNullException.ThrowIfNull(filePath);
-        return Task.Run(() => ReadMetadata(filePath, cancellationToken), cancellationToken);
-    }
-
-    public static PhotoMetadata? GetMetadata(string filePath)
-    {
-        ArgumentNullException.ThrowIfNull(filePath);
-        return ReadMetadata(filePath, CancellationToken.None);
-    }
 
     public static Task<bool> UpdateMetadataAsync(
         string filePath,
@@ -41,103 +26,6 @@ internal static class ExifService
     {
         ArgumentNullException.ThrowIfNull(filePath);
         return Task.Run(() => WriteMetadata(filePath, takenAt, latitude, longitude, updateFileModifiedDate, cancellationToken), cancellationToken);
-    }
-
-    private static PhotoMetadata? ReadMetadata(string filePath, CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        IReadOnlyList<MetadataExtractor.Directory> directories;
-        try
-        {
-            directories = ImageMetadataReader.ReadMetadata(filePath);
-        }
-        catch (MetadataExtractor.ImageProcessingException ex)
-        {
-            AppLog.Error($"Failed to read metadata: {filePath}", ex);
-            return null;
-        }
-        catch (IOException ex)
-        {
-            AppLog.Error($"Failed to read metadata: {filePath}", ex);
-            return null;
-        }
-        catch (UnauthorizedAccessException ex)
-        {
-            AppLog.Error($"Failed to read metadata: {filePath}", ex);
-            return null;
-        }
-        catch (NotSupportedException ex)
-        {
-            AppLog.Error($"Failed to read metadata: {filePath}", ex);
-            return null;
-        }
-#pragma warning disable CA1031 // Do not catch general exception types
-        catch (Exception ex)
-        {
-            // Catch any other unexpected exceptions from MetadataExtractor library
-            // (e.g., IndexOutOfRangeException when processing certain MP3 files)
-            // to prevent app crashes. These are logged and treated as metadata read failures.
-            AppLog.Error($"Unexpected exception reading metadata: {filePath}", ex);
-            return null;
-        }
-#pragma warning restore CA1031 // Do not catch general exception types
-
-        cancellationToken.ThrowIfCancellationRequested();
-
-        try
-        {
-            var gpsDirectory = directories.OfType<GpsDirectory>().FirstOrDefault();
-            GeoLocation? location = null;
-            if (gpsDirectory is not null && gpsDirectory.TryGetGeoLocation(out var geoLocation))
-            {
-                location = geoLocation;
-            }
-
-            double? latitude = location?.Latitude;
-            double? longitude = location?.Longitude;
-
-            var exifIfd0 = directories.OfType<ExifIfd0Directory>().FirstOrDefault();
-            var cameraMake = exifIfd0?.GetString(ExifDirectoryBase.TagMake);
-            var cameraModel = exifIfd0?.GetString(ExifDirectoryBase.TagModel);
-
-            var subIfd = directories.OfType<ExifSubIfdDirectory>().FirstOrDefault();
-            DateTime? dateTime = null;
-            if (subIfd is not null)
-            {
-                if (subIfd.TryGetDateTime(ExifDirectoryBase.TagDateTimeOriginal, out var dt))
-                    dateTime = dt;
-                else if (subIfd.TryGetDateTime(ExifDirectoryBase.TagDateTimeDigitized, out dt))
-                    dateTime = dt;
-            }
-
-            if (dateTime is null)
-            {
-                var fileMeta = directories.OfType<FileMetadataDirectory>().FirstOrDefault();
-                if (fileMeta is not null && fileMeta.TryGetDateTime(FileMetadataDirectory.TagFileModifiedDate, out var dt))
-                    dateTime = dt;
-            }
-
-            DateTimeOffset? takenAt = null;
-            if (dateTime.HasValue)
-            {
-                var localTime = DateTime.SpecifyKind(dateTime.Value, DateTimeKind.Local);
-                takenAt = new DateTimeOffset(localTime);
-            }
-
-            return new PhotoMetadata(
-                takenAt,
-                cameraMake,
-                cameraModel,
-                latitude,
-                longitude,
-                hasGpsData: gpsDirectory is not null);
-        }
-        catch (MetadataExtractor.MetadataException ex)
-        {
-            AppLog.Error($"Partial metadata read failure: {filePath}", ex);
-            return null;
-        }
     }
 
     private static bool WriteMetadata(

--- a/PhotoGeoExplorer.Tests/ExifReaderTests.cs
+++ b/PhotoGeoExplorer.Tests/ExifReaderTests.cs
@@ -30,6 +30,7 @@ public sealed class ExifReaderTests
             var metadata = await ExifReader.GetMetadataAsync(jpgPath, CancellationToken.None).ConfigureAwait(true);
 
             Assert.NotNull(metadata);
+            Assert.NotNull(metadata.TakenAt);
         }
         finally
         {
@@ -59,11 +60,42 @@ public sealed class ExifReaderTests
     [Fact]
     public async Task GetMetadataAsyncNonExistentFileReturnsNull()
     {
-        var nonExistentPath = Path.Combine(Path.GetTempPath(), "nonexistent.jpg");
+        var nonExistentPath = Path.Combine(Path.GetTempPath(), $"nonexistent_{Guid.NewGuid():N}.jpg");
+        Assert.False(File.Exists(nonExistentPath));
 
         var metadata = await ExifReader.GetMetadataAsync(nonExistentPath, CancellationToken.None).ConfigureAwait(true);
 
         Assert.Null(metadata);
+    }
+
+    [Fact]
+    public async Task GetMetadataSyncReadsSameMetadataAsAsync()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var jpgPath = Path.Combine(root, "sync.jpg");
+
+            using (var image = new Image<Rgba32>(100, 100))
+            {
+                var exifProfile = new ExifProfile();
+                exifProfile.SetValue(ExifTag.DateTimeOriginal, "2024:01:15 12:30:00");
+                image.Metadata.ExifProfile = exifProfile;
+                await image.SaveAsync(jpgPath, new JpegEncoder()).ConfigureAwait(true);
+            }
+
+            var metadata = ExifReader.GetMetadata(jpgPath);
+
+            Assert.NotNull(metadata);
+            Assert.NotNull(metadata.TakenAt);
+            Assert.Equal(2024, metadata.TakenAt.Value.Year);
+            Assert.Equal(1, metadata.TakenAt.Value.Month);
+            Assert.Equal(15, metadata.TakenAt.Value.Day);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
     }
 
     private static string CreateTempDirectory()

--- a/PhotoGeoExplorer.Tests/ExifReaderTests.cs
+++ b/PhotoGeoExplorer.Tests/ExifReaderTests.cs
@@ -1,0 +1,92 @@
+using PhotoGeoExplorer.Services;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Metadata.Profiles.Exif;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace PhotoGeoExplorer.Tests;
+
+public sealed class ExifReaderTests
+{
+    [Fact]
+    public async Task GetMetadataAsyncJpegWithExifSubIfdButNoDateTimeTagsDoesNotThrow()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var jpgPath = Path.Combine(root, "no_datetime.jpg");
+
+            using (var image = new Image<Rgba32>(100, 100))
+            {
+                var exifProfile = new ExifProfile();
+                // ExifVersion を設定して ExifSubIfdDirectory を生成させる（Date/Time Original は意図的に設定しない）
+                exifProfile.SetValue(ExifTag.ExifVersion, new byte[] { 0x30, 0x32, 0x32, 0x30 });
+                image.Metadata.ExifProfile = exifProfile;
+                await image.SaveAsync(jpgPath, new JpegEncoder()).ConfigureAwait(true);
+            }
+
+            // MetadataException をスローせずに正常完了することを確認する
+            // Date/Time Original 不在時はファイル更新日時にフォールバックするため TakenAt は非 null になる
+            var metadata = await ExifReader.GetMetadataAsync(jpgPath, CancellationToken.None).ConfigureAwait(true);
+
+            Assert.NotNull(metadata);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public async Task GetMetadataAsyncNonImageFileReturnsNull()
+    {
+        var root = CreateTempDirectory();
+        try
+        {
+            var txtPath = Path.Combine(root, "test.txt");
+            await File.WriteAllTextAsync(txtPath, "test content").ConfigureAwait(true);
+
+            var metadata = await ExifReader.GetMetadataAsync(txtPath, CancellationToken.None).ConfigureAwait(true);
+
+            Assert.Null(metadata);
+        }
+        finally
+        {
+            TryDeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public async Task GetMetadataAsyncNonExistentFileReturnsNull()
+    {
+        var nonExistentPath = Path.Combine(Path.GetTempPath(), "nonexistent.jpg");
+
+        var metadata = await ExifReader.GetMetadataAsync(nonExistentPath, CancellationToken.None).ConfigureAwait(true);
+
+        Assert.Null(metadata);
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "PhotoGeoExplorerTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/PhotoGeoExplorer.Tests/ExifServiceTests.cs
+++ b/PhotoGeoExplorer.Tests/ExifServiceTests.cs
@@ -1,7 +1,6 @@
 using PhotoGeoExplorer.Services;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Jpeg;
-using SixLabors.ImageSharp.Metadata.Profiles.Exif;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace PhotoGeoExplorer.Tests;
@@ -59,7 +58,7 @@ public sealed class ExifServiceTests
             Assert.True(result);
 
             // Verify the metadata was written
-            var metadata = await ExifService.GetMetadataAsync(jpgPath, CancellationToken.None).ConfigureAwait(true);
+            var metadata = await ExifReader.GetMetadataAsync(jpgPath, CancellationToken.None).ConfigureAwait(true);
             Assert.NotNull(metadata);
             Assert.NotNull(metadata.TakenAt);
             Assert.Equal(takenAt.DateTime.Year, metadata.TakenAt.Value.DateTime.Year);
@@ -134,7 +133,7 @@ public sealed class ExifServiceTests
                 updateFileModifiedDate: false,
                 CancellationToken.None).ConfigureAwait(true);
 
-            var metadataWithGps = await ExifService.GetMetadataAsync(jpgPath, CancellationToken.None).ConfigureAwait(true);
+            var metadataWithGps = await ExifReader.GetMetadataAsync(jpgPath, CancellationToken.None).ConfigureAwait(true);
             Assert.NotNull(metadataWithGps);
             Assert.NotNull(metadataWithGps.Latitude);
             Assert.NotNull(metadataWithGps.Longitude);
@@ -151,7 +150,7 @@ public sealed class ExifServiceTests
             Assert.True(result);
 
             // Verify GPS data is removed
-            var metadataWithoutGps = await ExifService.GetMetadataAsync(jpgPath, CancellationToken.None).ConfigureAwait(true);
+            var metadataWithoutGps = await ExifReader.GetMetadataAsync(jpgPath, CancellationToken.None).ConfigureAwait(true);
             Assert.NotNull(metadataWithoutGps);
             Assert.Null(metadataWithoutGps.Latitude);
             Assert.Null(metadataWithoutGps.Longitude);
@@ -196,7 +195,7 @@ public sealed class ExifServiceTests
                 CancellationToken.None).ConfigureAwait(true);
 
             // Verify date is preserved
-            var metadata = await ExifService.GetMetadataAsync(jpgPath, CancellationToken.None).ConfigureAwait(true);
+            var metadata = await ExifReader.GetMetadataAsync(jpgPath, CancellationToken.None).ConfigureAwait(true);
             Assert.NotNull(metadata);
             Assert.NotNull(metadata.TakenAt);
             Assert.Equal(initialDate.Year, metadata.TakenAt.Value.Year);
@@ -204,35 +203,6 @@ public sealed class ExifServiceTests
             Assert.Equal(initialDate.Day, metadata.TakenAt.Value.Day);
             Assert.NotNull(metadata.Latitude);
             Assert.NotNull(metadata.Longitude);
-        }
-        finally
-        {
-            TryDeleteDirectory(root);
-        }
-    }
-
-    [Fact]
-    public async Task GetMetadataAsyncJpegWithExifSubIfdButNoDateTimeTagsDoesNotThrow()
-    {
-        var root = CreateTempDirectory();
-        try
-        {
-            var jpgPath = Path.Combine(root, "no_datetime.jpg");
-
-            using (var image = new Image<Rgba32>(100, 100))
-            {
-                var exifProfile = new ExifProfile();
-                // ExifVersion を設定して ExifSubIfdDirectory を生成させる（Date/Time Original は意図的に設定しない）
-                exifProfile.SetValue(ExifTag.ExifVersion, new byte[] { 0x30, 0x32, 0x32, 0x30 });
-                image.Metadata.ExifProfile = exifProfile;
-                await image.SaveAsync(jpgPath, new JpegEncoder()).ConfigureAwait(true);
-            }
-
-            // MetadataException をスローせずに正常完了することを確認する
-            // Date/Time Original 不在時はファイル更新日時にフォールバックするため TakenAt は非 null になる
-            var metadata = await ExifService.GetMetadataAsync(jpgPath, CancellationToken.None).ConfigureAwait(true);
-
-            Assert.NotNull(metadata);
         }
         finally
         {

--- a/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserStatusViewModel.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/FileBrowserStatusViewModel.cs
@@ -43,7 +43,7 @@ internal sealed class FileBrowserStatusViewModel : BindableBase, IDisposable
     private PhotoListItem? _selectedItem;
 
     /// <param name="uiDispatcher">メタデータロード完了時の UI 更新に使うディスパッチャ。</param>
-    /// <param name="getMetadataAsync">EXIF メタデータ取得処理。null の場合は <see cref="ExifService.GetMetadataAsync"/>（テスト用シーム）。</param>
+    /// <param name="getMetadataAsync">EXIF メタデータ取得処理。null の場合は <see cref="ExifReader.GetMetadataAsync"/>（テスト用シーム）。</param>
     public FileBrowserStatusViewModel(
         IUiDispatcher uiDispatcher,
         Func<string, CancellationToken, Task<PhotoMetadata?>>? getMetadataAsync = null)
@@ -51,7 +51,7 @@ internal sealed class FileBrowserStatusViewModel : BindableBase, IDisposable
         ArgumentNullException.ThrowIfNull(uiDispatcher);
 
         _uiDispatcher = uiDispatcher;
-        _getMetadataAsync = getMetadataAsync ?? ExifService.GetMetadataAsync;
+        _getMetadataAsync = getMetadataAsync ?? ExifReader.GetMetadataAsync;
     }
 
     public string? StatusMessage

--- a/PhotoGeoExplorer/Panes/FileBrowser/ThumbnailGenerationCoordinator.cs
+++ b/PhotoGeoExplorer/Panes/FileBrowser/ThumbnailGenerationCoordinator.cs
@@ -44,7 +44,7 @@ internal sealed class ThumbnailGenerationCoordinator : IDisposable
     /// <param name="uiDispatcher">バッチ更新タイマーの構成に使う UI スレッドディスパッチャ。</param>
     /// <param name="isJpegFile">EXIF メタデータ取得対象（JPEG）かどうかの判定。</param>
     /// <param name="generateThumbnail">サムネイル生成処理。null の場合は <see cref="ThumbnailService.GenerateThumbnail"/>（テスト用シーム）。</param>
-    /// <param name="getMetadataAsync">EXIF メタデータ取得処理。null の場合は <see cref="ExifService.GetMetadataAsync"/>（テスト用シーム）。</param>
+    /// <param name="getMetadataAsync">EXIF メタデータ取得処理。null の場合は <see cref="ExifReader.GetMetadataAsync"/>（テスト用シーム）。</param>
     /// <param name="createThumbnailImage">サムネイル画像の生成処理。null の場合は BitmapImage を生成する既定実装（テスト用シーム）。</param>
     public ThumbnailGenerationCoordinator(
         IUiDispatcher uiDispatcher,
@@ -59,7 +59,7 @@ internal sealed class ThumbnailGenerationCoordinator : IDisposable
         _uiDispatcher = uiDispatcher;
         _isJpegFile = isJpegFile;
         _generateThumbnail = generateThumbnail ?? ThumbnailService.GenerateThumbnail;
-        _getMetadataAsync = getMetadataAsync ?? ExifService.GetMetadataAsync;
+        _getMetadataAsync = getMetadataAsync ?? ExifReader.GetMetadataAsync;
         _createThumbnailImage = createThumbnailImage ?? CreateThumbnailImage;
     }
 

--- a/PhotoGeoExplorer/Panes/Map/MapPaneService.cs
+++ b/PhotoGeoExplorer/Panes/Map/MapPaneService.cs
@@ -173,7 +173,7 @@ internal sealed class MapPaneService : IMapPaneService
                 return (item, null);
             }
 
-            var metadata = await ExifService.GetMetadataAsync(item.Item.FilePath, cancellationToken).ConfigureAwait(false);
+            var metadata = await ExifReader.GetMetadataAsync(item.Item.FilePath, cancellationToken).ConfigureAwait(false);
             return (item, metadata);
         }
         catch (OperationCanceledException)

--- a/PhotoGeoExplorer/Panes/Preview/PreviewPaneService.cs
+++ b/PhotoGeoExplorer/Panes/Preview/PreviewPaneService.cs
@@ -49,7 +49,7 @@ internal sealed class PreviewPaneService : IPreviewPaneService
     /// 指定ファイルの EXIF メタデータを非同期で読み込む
     /// </summary>
     public Task<PhotoMetadata?> GetMetadataAsync(string filePath, CancellationToken cancellationToken)
-        => ExifService.GetMetadataAsync(filePath, cancellationToken);
+        => ExifReader.GetMetadataAsync(filePath, cancellationToken);
 
     /// <summary>
     /// ビューポートに画像をフィットさせるズームファクターを計算

--- a/PhotoGeoExplorer/Services/ExifMetadataService.cs
+++ b/PhotoGeoExplorer/Services/ExifMetadataService.cs
@@ -9,7 +9,7 @@ internal sealed class ExifMetadataService : IExifMetadataService
 {
     public Task<PhotoMetadata?> GetMetadataAsync(string filePath, CancellationToken cancellationToken)
     {
-        return ExifService.GetMetadataAsync(filePath, cancellationToken);
+        return ExifReader.GetMetadataAsync(filePath, cancellationToken);
     }
 
     public Task<bool> UpdateMetadataAsync(


### PR DESCRIPTION
## 要約

#150 Phase 3（#178 P3-A）。`ExifService.cs`（558 行）から読み取り責務を `ExifReader`（internal static、114 行）へ分離し、MetadataExtractor 依存を新クラスに局所化した。`ExifService` は書き込み専用クラス（380 行）に縮退。

## 変更内容

- **`PhotoGeoExplorer.Core/Services/ExifReader.cs`（新規）**: `GetMetadataAsync` / `GetMetadata`（公開 API）と `ReadMetadata`（MetadataExtractor による GPS / カメラ情報 / 撮影日時の読み取り、例外ハンドリング）を移動。ロジックは無変更
- **`ExifService.cs`**: 読み取りコードと MetadataExtractor 系 using を除去し、不要になった `System.Collections.Generic` / `System.Linq` / `PhotoGeoExplorer.Models` も削除。書き込み責務（`UpdateMetadataAsync` / `WriteMetadata` / JPEG セグメント処理）は変更なし
- **呼び出し側 5 箇所を `ExifReader.GetMetadataAsync` へ振り向け**（挙動不変）:
  - `PreviewPaneService` / `ExifMetadataService` / `MapPaneService`（直接呼び出し）
  - `FileBrowserStatusViewModel` / `ThumbnailGenerationCoordinator`（テスト用シームの既定値。doc コメントの cref も更新）
- **テスト再編**: 読み取り系テスト（ExifSubIfd 日時欠落ケース）を `ExifReaderTests`（新規）へ移動し、非画像ファイル / 非存在ファイルの null 返却ケースを追加。`ExifServiceTests` の書き込み検証用読み取りは `ExifReader` 経由へ更新
- CHANGELOG.md 更新

## 理由

読み取り（MetadataExtractor）と書き込み（ImageSharp）は依存ライブラリも責務も別であり、単一 static クラスへの同居が #150 で 🟠 要注意と分類されていた。P3-B（#200）/ P3-C（#201）の書き込み側分離に先行して、独立着手可能な読み取り側を切り出す。

## 検証

- `dotnet build PhotoGeoExplorer.sln -c Release -p:Platform=x64` → 成功（0 警告 / 0 エラー）
- `dotnet test PhotoGeoExplorer.sln -c Release -p:Platform=x64` → **704/704 合格**（E2E 13 件は `PHOTO_GEO_EXPLORER_RUN_E2E` 未指定のため想定どおりスキップ）
- pre-commit（agent-docs / build / format）・pre-push（test）フックすべてグリーン

## 受け入れ条件（#199）

- [x] 読み取り責務が `ExifReader` に分離され、`ExifService` から読み取りコードが除去されている
- [x] MetadataExtractor への依存が `ExifReader` に局所化されている
- [x] 既存 `ExifServiceTests` の読み取り系テストが新構成でグリーン（`ExifReaderTests` へ再編）
- [x] `dotnet build` / `dotnet test` グリーン

Closes #199
Refs #150, #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)